### PR TITLE
feat: add body / text / has_attachment filters to list_emails_metadata

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -145,6 +145,22 @@ async def list_emails_metadata(
         bool | None,
         Field(default=None, description="Filter by replied status: True=replied, False=not replied, None=all."),
     ] = None,
+    body: Annotated[
+        str | None,
+        Field(default=None, description="Search for text in the email body (IMAP BODY)."),
+    ] = None,
+    text: Annotated[
+        str | None,
+        Field(default=None, description="Search for text in the entire message — headers and body (IMAP TEXT)."),
+    ] = None,
+    has_attachment: Annotated[
+        bool | None,
+        Field(
+            default=None,
+            description="Filter by attachment presence: True=has attachment, False=none, None=all "
+            "(multipart/mixed heuristic; may miss inline images or yield false positives).",
+        ),
+    ] = None,
 ) -> EmailMetadataPageResponse:
     handler = dispatch_handler(account_name)
 
@@ -161,6 +177,9 @@ async def list_emails_metadata(
         seen=seen,
         flagged=flagged,
         answered=answered,
+        body=body,
+        text=text,
+        has_attachment=has_attachment,
     )
 
 

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -27,6 +27,9 @@ class EmailHandler(abc.ABC):
         seen: bool | None = None,
         flagged: bool | None = None,
         answered: bool | None = None,
+        body: str | None = None,
+        text: str | None = None,
+        has_attachment: bool | None = None,
     ) -> "EmailMetadataPageResponse":
         """
         Get email metadata only (without body content) for better performance.
@@ -44,6 +47,10 @@ class EmailHandler(abc.ABC):
             seen: Filter by read status (True=read, False=unread, None=all).
             flagged: Filter by flagged/starred status (True=flagged, False=unflagged, None=all).
             answered: Filter by replied status (True=replied, False=not replied, None=all).
+            body: Search for text in the email body (IMAP BODY).
+            text: Search for text in the entire message, headers + body (IMAP TEXT).
+            has_attachment: Filter by attachment presence (True/False/None) via a
+                multipart/mixed Content-Type heuristic.
         """
 
     @abc.abstractmethod

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -617,22 +617,32 @@ class EmailClient:
         seen: bool | None = None,
         flagged: bool | None = None,
         answered: bool | None = None,
+        has_attachment: bool | None = None,
     ) -> list[str]:
         search_criteria = []
         if before:
             search_criteria.extend(["BEFORE", before.strftime("%d-%b-%Y").upper()])
         if since:
             search_criteria.extend(["SINCE", since.strftime("%d-%b-%Y").upper()])
-        if subject:
-            search_criteria.extend(["SUBJECT", EmailClient._sanitize_imap_value(subject)])
-        if body:
-            search_criteria.extend(["BODY", EmailClient._sanitize_imap_value(body)])
-        if text:
-            search_criteria.extend(["TEXT", EmailClient._sanitize_imap_value(text)])
-        if from_address:
-            search_criteria.extend(["FROM", EmailClient._sanitize_imap_value(from_address)])
-        if to_address:
-            search_criteria.extend(["TO", EmailClient._sanitize_imap_value(to_address)])
+
+        # Substring-match fields (IMAP keyword, value)
+        text_criteria = [
+            ("SUBJECT", subject),
+            ("BODY", body),
+            ("TEXT", text),
+            ("FROM", from_address),
+            ("TO", to_address),
+        ]
+        for keyword, value in text_criteria:
+            if value:
+                search_criteria.extend([keyword, EmailClient._sanitize_imap_value(value)])
+
+        # Attachment heuristic: most attachments are carried in multipart/mixed.
+        # May miss some types (e.g. inline images) or yield false positives.
+        if has_attachment is True:
+            search_criteria.extend(["HEADER", "Content-Type", "multipart/mixed"])
+        elif has_attachment is False:
+            search_criteria.extend(["NOT", "HEADER", "Content-Type", "multipart/mixed"])
 
         # Flag-based criteria using mapping to reduce complexity
         flag_criteria = [
@@ -794,6 +804,9 @@ class EmailClient:
         seen: bool | None = None,
         flagged: bool | None = None,
         answered: bool | None = None,
+        body: str | None = None,
+        text: str | None = None,
+        has_attachment: bool | None = None,
     ) -> tuple[int, list[dict[str, Any]]]:
         imap = await self._connect_imap()
         try:
@@ -807,11 +820,14 @@ class EmailClient:
                 before,
                 since,
                 subject,
+                body=body,
+                text=text,
                 from_address=from_address,
                 to_address=to_address,
                 seen=seen,
                 flagged=flagged,
                 answered=answered,
+                has_attachment=has_attachment,
             )
             logger.info(f"Get metadata: Search criteria: {search_criteria}")
 
@@ -1559,6 +1575,9 @@ class ClassicEmailHandler(EmailHandler):
         seen: bool | None = None,
         flagged: bool | None = None,
         answered: bool | None = None,
+        body: str | None = None,
+        text: str | None = None,
+        has_attachment: bool | None = None,
     ) -> EmailMetadataPageResponse:
         total, email_dicts = await self.incoming_client.get_emails_metadata(
             page,
@@ -1573,6 +1592,9 @@ class ClassicEmailHandler(EmailHandler):
             seen,
             flagged,
             answered,
+            body,
+            text,
+            has_attachment,
         )
         emails = [EmailMetadata.from_email(d) for d in email_dicts]
         return EmailMetadataPageResponse(

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -124,7 +124,7 @@ class TestClassicEmailHandler:
 
             # Verify the client method was called correctly
             mock_get_metadata.assert_called_once_with(
-                1, 10, now, None, "Test", "sender@example.com", None, "desc", "INBOX", None, None, None
+                1, 10, now, None, "Test", "sender@example.com", None, "desc", "INBOX", None, None, None, None, None, None
             )
 
     @pytest.mark.asyncio
@@ -154,7 +154,7 @@ class TestClassicEmailHandler:
 
             # Verify mailbox parameter was passed correctly
             mock_get_metadata.assert_called_once_with(
-                1, 10, None, None, None, None, None, "desc", "Sent", None, None, None
+                1, 10, None, None, None, None, None, "desc", "Sent", None, None, None, None, None, None
             )
 
     @pytest.mark.asyncio

--- a/tests/test_classic_handler.py
+++ b/tests/test_classic_handler.py
@@ -124,7 +124,21 @@ class TestClassicEmailHandler:
 
             # Verify the client method was called correctly
             mock_get_metadata.assert_called_once_with(
-                1, 10, now, None, "Test", "sender@example.com", None, "desc", "INBOX", None, None, None, None, None, None
+                1,
+                10,
+                now,
+                None,
+                "Test",
+                "sender@example.com",
+                None,
+                "desc",
+                "INBOX",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
             )
 
     @pytest.mark.asyncio

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -273,6 +273,18 @@ class TestEmailClient:
         assert "FLAGGED" in criteria
         assert "ANSWERED" in criteria
 
+        # Test has_attachment=True (multipart/mixed heuristic)
+        criteria = EmailClient._build_search_criteria(has_attachment=True)
+        assert criteria == ["HEADER", "Content-Type", "multipart/mixed"]
+
+        # Test has_attachment=False (negated heuristic)
+        criteria = EmailClient._build_search_criteria(has_attachment=False)
+        assert criteria == ["NOT", "HEADER", "Content-Type", "multipart/mixed"]
+
+        # Test has_attachment=None (no criteria added)
+        criteria = EmailClient._build_search_criteria(has_attachment=None)
+        assert criteria == ["ALL"]
+
         # Test compound criteria: unread, flagged, from specific sender, with subject
         criteria = EmailClient._build_search_criteria(
             seen=False, flagged=True, from_address="test@example.com", subject="Important"

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -179,6 +179,9 @@ class TestMcpTools:
                 seen=None,
                 flagged=None,
                 answered=None,
+                body=None,
+                text=None,
+                has_attachment=None,
             )
 
     @pytest.mark.asyncio
@@ -227,6 +230,9 @@ class TestMcpTools:
                 seen=None,
                 flagged=None,
                 answered=None,
+                body=None,
+                text=None,
+                has_attachment=None,
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Extends the IMAP search filters on `list_emails_metadata` with three commonly-useful options. Today the tool supports date range, subject, from/to, and the `seen`/`flagged`/`answered` flags (#101); this adds:

- **`body`** — full-text search of the message body (IMAP `BODY`)
- **`text`** — search of the entire message, headers + body (IMAP `TEXT`)
- **`has_attachment`** — filter by attachment presence (True / False / None) using a `multipart/mixed` Content-Type heuristic

## Details

- `_build_search_criteria` already accepted `body`/`text` internally — they just weren't reachable from the tool. This wires them through `get_emails_metadata` (client + `ClassicEmailHandler`), the `EmailHandler` interface, and the MCP tool, and adds `has_attachment`.
- The repetitive substring-field branches in `_build_search_criteria` are collapsed into a small loop, which keeps cyclomatic complexity within the configured `mccabe` limit (no `# noqa` needed) and reads a bit cleaner.
- `has_attachment` is documented as a heuristic in the tool description — it may miss inline images or yield occasional false positives, since it keys off `Content-Type: multipart/mixed`.

## Tests

- New `_build_search_criteria` cases for `has_attachment` True/False/None.
- Updated the handler/tool call-through assertions for the new params.
- Full suite passes (`uv run pytest`), `ruff check` clean.