### PR TITLE
feat: add archive_emails tool

### DIFF
--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -423,9 +423,7 @@ async def archive_emails(
         list[str],
         Field(description="List of email_id to archive (obtained from list_emails_metadata)."),
     ],
-    mailbox: Annotated[
-        str, Field(default="INBOX", description="The source mailbox containing the emails.")
-    ] = "INBOX",
+    mailbox: Annotated[str, Field(default="INBOX", description="The source mailbox containing the emails.")] = "INBOX",
 ) -> str:
     handler = dispatch_handler(account_name)
     archived_ids, failed_ids = await handler.archive_emails(email_ids, mailbox)

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -413,6 +413,30 @@ async def move_emails(
 
 
 @mcp.tool(
+    description="Archive one or more emails by moving them to the account's Archive folder, "
+    "auto-detected via the RFC 6154 \\Archive flag (falling back to common names like Archive or "
+    "[Gmail]/All Mail). Use list_emails_metadata first to get the email_id."
+)
+async def archive_emails(
+    account_name: Annotated[str, Field(description="The name of the email account.")],
+    email_ids: Annotated[
+        list[str],
+        Field(description="List of email_id to archive (obtained from list_emails_metadata)."),
+    ],
+    mailbox: Annotated[
+        str, Field(default="INBOX", description="The source mailbox containing the emails.")
+    ] = "INBOX",
+) -> str:
+    handler = dispatch_handler(account_name)
+    archived_ids, failed_ids = await handler.archive_emails(email_ids, mailbox)
+
+    result = f"Successfully archived {len(archived_ids)} email(s)"
+    if failed_ids:
+        result += f", failed to archive {len(failed_ids)} email(s): {', '.join(failed_ids)}"
+    return result
+
+
+@mcp.tool(
     description="List available mailboxes/folders for an email account. Returns folder names, hierarchy delimiters, and flags. Useful for discovering folder names before moving emails."
 )
 async def list_mailboxes(

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -426,9 +426,9 @@ async def archive_emails(
     mailbox: Annotated[str, Field(default="INBOX", description="The source mailbox containing the emails.")] = "INBOX",
 ) -> str:
     handler = dispatch_handler(account_name)
-    archived_ids, failed_ids = await handler.archive_emails(email_ids, mailbox)
+    archived_ids, failed_ids, archive_folder = await handler.archive_emails(email_ids, mailbox)
 
-    result = f"Successfully archived {len(archived_ids)} email(s)"
+    result = f"Successfully archived {len(archived_ids)} email(s) to {archive_folder}"
     if failed_ids:
         result += f", failed to archive {len(failed_ids)} email(s): {', '.join(failed_ids)}"
     return result

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -127,9 +127,9 @@ class EmailHandler(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def archive_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
+    async def archive_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str], str]:
         """
-        Move emails to the account's Archive folder (auto-detected). Returns (moved_ids, failed_ids).
+        Move emails to the account's Archive folder (auto-detected). Returns (moved_ids, failed_ids, archive_folder).
 
         Args:
             email_ids: List of email UIDs to archive.

--- a/mcp_email_server/emails/__init__.py
+++ b/mcp_email_server/emails/__init__.py
@@ -127,6 +127,16 @@ class EmailHandler(abc.ABC):
         """
 
     @abc.abstractmethod
+    async def archive_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
+        """
+        Move emails to the account's Archive folder (auto-detected). Returns (moved_ids, failed_ids).
+
+        Args:
+            email_ids: List of email UIDs to archive.
+            mailbox: The source mailbox (default: "INBOX").
+        """
+
+    @abc.abstractmethod
     async def list_mailboxes(self, pattern: str = "*", reference: str = "") -> list["MailboxInfo"]:
         """
         List available mailboxes/folders in the account.

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -36,6 +36,9 @@ from mcp_email_server.log import logger
 # Maximum body length before truncation (characters)
 MAX_BODY_LENGTH = 20000
 
+# Common Archive folder names, used as a fallback when no RFC 6154 \Archive flag is found.
+_ARCHIVE_FOLDER_CANDIDATES = ("Archive", "Archives", "[Gmail]/All Mail")
+
 
 # RFC 3501 system flags (except \Recent which is read-only) + custom keyword atoms
 _VALID_IMAP_FLAG = re.compile(r"^\\[A-Za-z]+$|^[A-Za-z][A-Za-z0-9_-]*$")
@@ -1723,6 +1726,28 @@ class ClassicEmailHandler(EmailHandler):
     ) -> tuple[list[str], list[str]]:
         """Move emails between mailboxes. Returns (moved_ids, failed_ids)."""
         return await self.incoming_client.move_emails(email_ids, source_mailbox, destination_mailbox)
+
+    async def _find_archive_folder(self) -> str | None:
+        """Locate the Archive folder via the RFC 6154 ``\\Archive`` flag, then common names."""
+        mailboxes = await self.incoming_client.list_mailboxes()
+        for mailbox in mailboxes:
+            if any(flag.lstrip("\\").lower() == "archive" for flag in mailbox.flags):
+                return mailbox.name
+        names = {mailbox.name for mailbox in mailboxes}
+        for candidate in _ARCHIVE_FOLDER_CANDIDATES:
+            if candidate in names:
+                return candidate
+        return None
+
+    async def archive_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
+        """Move emails to the auto-detected Archive folder. Returns (moved_ids, failed_ids)."""
+        archive_folder = await self._find_archive_folder()
+        if archive_folder is None:
+            raise ValueError(
+                "No Archive folder found (looked for the RFC 6154 \\Archive flag and common names: "
+                f"{', '.join(_ARCHIVE_FOLDER_CANDIDATES)}). Use move_emails with an explicit folder instead."
+            )
+        return await self.incoming_client.move_emails(email_ids, mailbox, archive_folder)
 
     async def list_mailboxes(self, pattern: str = "*", reference: str = "") -> list[MailboxInfo]:
         """List available mailboxes with flags and delimiter."""

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -1730,24 +1730,27 @@ class ClassicEmailHandler(EmailHandler):
     async def _find_archive_folder(self) -> str | None:
         """Locate the Archive folder via the RFC 6154 ``\\Archive`` flag, then common names."""
         mailboxes = await self.incoming_client.list_mailboxes()
-        for mailbox in mailboxes:
-            if any(flag.lstrip("\\").lower() == "archive" for flag in mailbox.flags):
-                return mailbox.name
-        names = {mailbox.name for mailbox in mailboxes}
+        for mailbox_info in mailboxes:
+            if any(flag.lstrip("\\").lower() == "archive" for flag in mailbox_info.flags):
+                return mailbox_info.name
+
+        names_by_lowercase = {mailbox_info.name.lower(): mailbox_info.name for mailbox_info in mailboxes}
         for candidate in _ARCHIVE_FOLDER_CANDIDATES:
-            if candidate in names:
-                return candidate
+            archive_folder = names_by_lowercase.get(candidate.lower())
+            if archive_folder is not None:
+                return archive_folder
         return None
 
-    async def archive_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str]]:
-        """Move emails to the auto-detected Archive folder. Returns (moved_ids, failed_ids)."""
+    async def archive_emails(self, email_ids: list[str], mailbox: str = "INBOX") -> tuple[list[str], list[str], str]:
+        """Move emails to the auto-detected Archive folder. Returns (moved_ids, failed_ids, archive_folder)."""
         archive_folder = await self._find_archive_folder()
         if archive_folder is None:
             raise ValueError(
                 "No Archive folder found (looked for the RFC 6154 \\Archive flag and common names: "
                 f"{', '.join(_ARCHIVE_FOLDER_CANDIDATES)}). Use move_emails with an explicit folder instead."
             )
-        return await self.incoming_client.move_emails(email_ids, mailbox, archive_folder)
+        moved_ids, failed_ids = await self.incoming_client.move_emails(email_ids, mailbox, archive_folder)
+        return moved_ids, failed_ids, archive_folder
 
     async def list_mailboxes(self, pattern: str = "*", reference: str = "") -> list[MailboxInfo]:
         """List available mailboxes with flags and delimiter."""

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -6,6 +6,7 @@ import pytest
 from mcp_email_server import app as app_module
 from mcp_email_server.app import (
     add_email_account,
+    archive_emails,
     delete_emails,
     download_attachment,
     get_emails_content,
@@ -709,6 +710,32 @@ class TestMcpTools:
 
             assert result == "Successfully moved 2 email(s) to Archive"
             mock_handler.move_emails.assert_called_once_with(["12345", "12346"], "INBOX", "Archive")
+
+    @pytest.mark.asyncio
+    async def test_archive_emails(self):
+        """Test archive_emails MCP tool."""
+        mock_handler = AsyncMock()
+        mock_handler.archive_emails.return_value = (["12345", "12346"], [])
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await archive_emails(
+                account_name="test_account",
+                email_ids=["12345", "12346"],
+            )
+
+            assert result == "Successfully archived 2 email(s)"
+            mock_handler.archive_emails.assert_called_once_with(["12345", "12346"], "INBOX")
+
+    @pytest.mark.asyncio
+    async def test_archive_emails_with_failures(self):
+        """Test archive_emails MCP tool reports failures."""
+        mock_handler = AsyncMock()
+        mock_handler.archive_emails.return_value = (["12345"], ["12346"])
+
+        with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
+            result = await archive_emails(account_name="test_account", email_ids=["12345", "12346"])
+
+            assert result == "Successfully archived 1 email(s), failed to archive 1 email(s): 12346"
 
     @pytest.mark.asyncio
     async def test_move_emails_with_source_mailbox(self):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -715,7 +715,7 @@ class TestMcpTools:
     async def test_archive_emails(self):
         """Test archive_emails MCP tool."""
         mock_handler = AsyncMock()
-        mock_handler.archive_emails.return_value = (["12345", "12346"], [])
+        mock_handler.archive_emails.return_value = (["12345", "12346"], [], "Archive")
 
         with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
             result = await archive_emails(
@@ -723,19 +723,19 @@ class TestMcpTools:
                 email_ids=["12345", "12346"],
             )
 
-            assert result == "Successfully archived 2 email(s)"
+            assert result == "Successfully archived 2 email(s) to Archive"
             mock_handler.archive_emails.assert_called_once_with(["12345", "12346"], "INBOX")
 
     @pytest.mark.asyncio
     async def test_archive_emails_with_failures(self):
         """Test archive_emails MCP tool reports failures."""
         mock_handler = AsyncMock()
-        mock_handler.archive_emails.return_value = (["12345"], ["12346"])
+        mock_handler.archive_emails.return_value = (["12345"], ["12346"], "[Gmail]/All Mail")
 
         with patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler):
             result = await archive_emails(account_name="test_account", email_ids=["12345", "12346"])
 
-            assert result == "Successfully archived 1 email(s), failed to archive 1 email(s): 12346"
+            assert result == "Successfully archived 1 email(s) to [Gmail]/All Mail, failed to archive 1 email(s): 12346"
 
     @pytest.mark.asyncio
     async def test_move_emails_with_source_mailbox(self):

--- a/tests/test_move_and_list_mailboxes.py
+++ b/tests/test_move_and_list_mailboxes.py
@@ -652,6 +652,58 @@ class TestClassicHandlerMoveEmails:
         mock_move.assert_called_once_with(["300"], "Trash", "INBOX")
 
 
+class TestClassicHandlerArchiveEmails:
+    """Tests for ClassicEmailHandler.archive_emails (Archive-folder detection + move)."""
+
+    @pytest.mark.asyncio
+    async def test_archive_uses_rfc6154_flag(self, classic_handler):
+        """The Archive folder is detected via the RFC 6154 \\Archive flag."""
+        mailboxes = [
+            MailboxInfo(name="INBOX", delimiter="/", flags=["\\HasNoChildren"]),
+            MailboxInfo(name="All Mail", delimiter="/", flags=["\\Archive", "\\HasNoChildren"]),
+        ]
+        mock_list = AsyncMock(return_value=mailboxes)
+        mock_move = AsyncMock(return_value=(["100"], []))
+
+        with patch.object(classic_handler.incoming_client, "list_mailboxes", mock_list):
+            with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
+                moved, failed = await classic_handler.archive_emails(["100"], "INBOX")
+
+        assert moved == ["100"]
+        assert failed == []
+        mock_move.assert_called_once_with(["100"], "INBOX", "All Mail")
+
+    @pytest.mark.asyncio
+    async def test_archive_falls_back_to_common_name(self, classic_handler):
+        """Without an \\Archive flag, fall back to a common folder name."""
+        mailboxes = [
+            MailboxInfo(name="INBOX", delimiter="/", flags=[]),
+            MailboxInfo(name="Archive", delimiter="/", flags=["\\HasNoChildren"]),
+        ]
+        mock_list = AsyncMock(return_value=mailboxes)
+        mock_move = AsyncMock(return_value=(["100", "200"], []))
+
+        with patch.object(classic_handler.incoming_client, "list_mailboxes", mock_list):
+            with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
+                moved, _failed = await classic_handler.archive_emails(["100", "200"])
+
+        assert moved == ["100", "200"]
+        mock_move.assert_called_once_with(["100", "200"], "INBOX", "Archive")
+
+    @pytest.mark.asyncio
+    async def test_archive_raises_when_no_archive_folder(self, classic_handler):
+        """A ValueError is raised when no Archive folder can be found."""
+        mock_list = AsyncMock(return_value=[MailboxInfo(name="INBOX", delimiter="/", flags=[])])
+        mock_move = AsyncMock()
+
+        with patch.object(classic_handler.incoming_client, "list_mailboxes", mock_list):
+            with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
+                with pytest.raises(ValueError, match="No Archive folder found"):
+                    await classic_handler.archive_emails(["100"])
+
+        mock_move.assert_not_called()
+
+
 class TestClassicHandlerListMailboxes:
     """Tests for ClassicEmailHandler.list_mailboxes delegation."""
 

--- a/tests/test_move_and_list_mailboxes.py
+++ b/tests/test_move_and_list_mailboxes.py
@@ -667,10 +667,11 @@ class TestClassicHandlerArchiveEmails:
 
         with patch.object(classic_handler.incoming_client, "list_mailboxes", mock_list):
             with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
-                moved, failed = await classic_handler.archive_emails(["100"], "INBOX")
+                moved, failed, archive_folder = await classic_handler.archive_emails(["100"], "INBOX")
 
         assert moved == ["100"]
         assert failed == []
+        assert archive_folder == "All Mail"
         mock_move.assert_called_once_with(["100"], "INBOX", "All Mail")
 
     @pytest.mark.asyncio
@@ -685,10 +686,30 @@ class TestClassicHandlerArchiveEmails:
 
         with patch.object(classic_handler.incoming_client, "list_mailboxes", mock_list):
             with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
-                moved, _failed = await classic_handler.archive_emails(["100", "200"])
+                moved, _failed, archive_folder = await classic_handler.archive_emails(["100", "200"])
 
         assert moved == ["100", "200"]
+        assert archive_folder == "Archive"
         mock_move.assert_called_once_with(["100", "200"], "INBOX", "Archive")
+
+    @pytest.mark.asyncio
+    async def test_archive_fallback_preserves_server_mailbox_case(self, classic_handler):
+        """Common folder-name fallback is case-insensitive but preserves the server's actual mailbox name."""
+        mailboxes = [
+            MailboxInfo(name="INBOX", delimiter="/", flags=[]),
+            MailboxInfo(name="archive", delimiter="/", flags=[]),
+        ]
+        mock_list = AsyncMock(return_value=mailboxes)
+        mock_move = AsyncMock(return_value=(["100"], []))
+
+        with patch.object(classic_handler.incoming_client, "list_mailboxes", mock_list):
+            with patch.object(classic_handler.incoming_client, "move_emails", mock_move):
+                moved, failed, archive_folder = await classic_handler.archive_emails(["100"])
+
+        assert moved == ["100"]
+        assert failed == []
+        assert archive_folder == "archive"
+        mock_move.assert_called_once_with(["100"], "INBOX", "archive")
 
     @pytest.mark.asyncio
     async def test_archive_raises_when_no_archive_folder(self, classic_handler):


### PR DESCRIPTION
## Summary

Adds an `archive_emails` tool — a common one-step action ("archive this") that today requires the user to first `list_mailboxes`, figure out which folder is the archive, then `move_emails`.

It auto-detects the Archive folder via the **RFC 6154 `\Archive` flag**, falling back to common names (`Archive`, `Archives`, `[Gmail]/All Mail`), then moves the emails there.

## Details

- Thin convenience wrapper over the existing `move_emails` machinery — no new IMAP code paths. `ClassicEmailHandler.archive_emails` detects the folder via `list_mailboxes` and delegates to `move_emails`.
- Mirrors the `move_emails` tool conventions exactly: returns a summary string, same arg shape.
- Raises a clear `ValueError` (listing what it looked for) when no Archive folder can be found, so the user knows to use `move_emails` with an explicit folder.

## Tests

- Archive detection via the `\Archive` flag, fallback to a common name, and the no-Archive-folder error.
- Tool-level summary output (success + partial failure).
- Full suite passes (`uv run pytest`), `ruff check` clean.