### PR TITLE
docs: troubleshoot ascii codec error under GUI-launched MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,32 @@ If `docker` is avaliable, you can try use docker image, but you may need to conf
 }
 ```
 
+### Troubleshooting: `'ascii' codec can't encode characters` under GUI-launched MCP clients
+
+If every call to `send_email` (or other outgoing-mail tools) fails with an error like:
+
+```
+'ascii' codec can't encode characters in position 1-3: ordinal not in range(128)
+```
+
+Fix it by forcing a UTF-8 locale for the server process in your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US.UTF-8",
+        "PYTHONIOENCODING": "UTF-8"
+      }
+    }
+  }
+}
+```
+
 ### Installing via Smithery
 
 To install Email Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@ai-zerolab/mcp-email-server):


### PR DESCRIPTION
## Summary

Adds a troubleshooting section to the README for a `UnicodeEncodeError` (`'ascii' codec can't encode characters in position 1-3: ordinal not in range(128)`) that surfaces when `mcp-email-server` is launched by a GUI MCP client (Claude Desktop, Cowork, etc.) rather than from an interactive shell.

## Context

Hit this while using `send_email` via Claude Desktop / Cowork:

- Every `send_email` call failed with `'ascii' codec can't encode characters in position 1-3: ordinal not in range(128)`.
- Reproduced identically on both `0.13.1` and `0.14.1` — ruling out a version regression.
- Reproduced with a trivial, all-ASCII subject/body — ruling out a content-encoding issue.
- The Gmail account, SMTP/IMAP settings, and computer hostname were all plain ASCII too.

The GUI app spawns the `uvx mcp-email-server stdio` process directly, without going through the user's login shell, so it doesn't inherit `LANG`/`LC_ALL`. The child process then runs under the `C`/`POSIX` locale, which defaults to ASCII text encoding — and any non-ASCII byte encountered internally (e.g. in `uv`'s own installer/progress output, which runs before the actual tool logic) raises the error above, independent of what the user actually asked to send.

Setting `LANG` / `LC_ALL` / `PYTHONIOENCODING` to a UTF-8 locale in the server's `env` block resolved it immediately, with no other changes.

## Change

- Adds a new `### Troubleshooting: 'ascii' codec can't encode characters under GUI-launched MCP clients` section to `README.md`, placed after the existing "Self-Signed Certificates and IMAP STARTTLS" troubleshooting section, following the same style (symptom description + fixed JSON config snippet).

## Checklist

- [x] Docs-only change, no code/behavior modified.
- [ ] N/A — no tests needed for a README addition.
