### PR TITLE
feat: capability-scope permission model + install-docs restructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ tests/config.toml
 local/
 config.toml
 .worktrees/
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ IMAP and SMTP via MCP Server
 
 ## Installation
 
-### Manual Installation
+We recommend [uv](https://github.com/astral-sh/uv) to manage your environment.
 
-We recommend using [uv](https://github.com/astral-sh/uv) to manage your environment.
+Run the configuration UI once to set up your account, then point your MCP client at the server:
 
-Try `uvx mcp-email-server@latest ui` to config, and use following configuration for mcp client:
+```bash
+uvx mcp-email-server@latest ui
+```
 
 ```json
 {
@@ -31,396 +33,29 @@ Try `uvx mcp-email-server@latest ui` to config, and use following configuration 
 }
 ```
 
-This package is available on PyPI, so you can install it using `pip install mcp-email-server`
+The package is also on PyPI (`pip install mcp-email-server`), as a Docker image (`ghcr.io/ai-zerolab/mcp-email-server`), and on [Smithery](https://smithery.ai/server/@ai-zerolab/mcp-email-server).
 
-After that, configure your email server using the ui: `mcp-email-server ui`
+**See the full [Installation & Configuration guide](https://ai-zerolab.github.io/mcp-email-server/installation/)** ([docs/installation.md](docs/installation.md)) for environment-variable configuration, credential storage (OS keyring), HTTP transport security, attachment downloads, allowlists, and self-signed certificate setups.
 
-### Credential Storage
+## Permissions
 
-Accounts added via the UI or the `add_email_account` tool are persisted to a TOML
-file at `~/.config/zerolib/mcp_email_server/config.toml`. Where the actual
-passwords/API keys live depends on `credential_storage` (also settable via
-`MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`), one of:
+The server is **read-only by default**. Every tool is gated behind a capability scope, granted via `permissions` in the config file or `MCP_EMAIL_SERVER_PERMISSIONS` (comma-separated):
 
-- **`auto`** (default): store credentials in the OS keyring — macOS Keychain,
-  Linux Secret Service (GNOME Keyring / KWallet) — when a usable backend is
-  detected; otherwise fall back to the plaintext TOML file (`0o600`
-  permissions, owner-only). Falls back automatically on headless Linux,
-  Docker, or any environment without a D-Bus session.
-- **`keyring`**: require the OS keyring; fail loudly instead of silently
-  falling back if no backend is usable.
-- **`plaintext`**: never touch the keyring. Useful for containers, CI, or if
-  you simply prefer a portable config file.
-
-When credentials are keyring-backed, the TOML file stores only a placeholder
-(`__KEYRING__`) and non-secret metadata — the real secret lives in the OS
-keyring under service `mcp-email-server`, one entry per
-`<account_name>:<incoming|outgoing|api_key>` (viewable in Keychain Access on
-macOS, or Seahorse on Linux).
-
-**Migrating an existing config** between storage modes:
-
-```sh
-mcp-email-server migrate-credentials --to keyring    # move plaintext secrets into the OS keyring
-mcp-email-server migrate-credentials --to plaintext  # move keyring secrets back into the TOML file
-```
-
-Migration also happens implicitly: any time you add/edit an account while
-`credential_storage` is `auto` or `keyring` with a usable backend, that
-account's secrets move into the keyring on the next save. If
-`MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` is active during a save, its effective
-mode is persisted too, keeping the mode marker consistent with the credential
-representation written to the same file.
-
-#### Failure modes & troubleshooting
-
-- **Server won't start / UI won't load accounts, keychain-related error**: the
-  OS keyring is locked or unreachable. This is expected if credentials are
-  keyring-backed — the secret simply isn't in the config file. Unlock your
-  keychain, or run `mcp-email-server migrate-credentials --to plaintext` if
-  you'd rather not depend on it.
-- **`credential_storage` is 'plaintext' but the config references
-  keyring-stored credentials**: run `migrate-credentials --to plaintext`, or
-  unset `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` / the `credential_storage`
-  setting so the config can resolve them from the keyring instead.
-- **macOS Keychain access prompt, or the server can't read a secret it wrote
-  earlier**: Keychain ACLs are per-application. If the server is spawned via
-  `uvx` (as in the Claude Desktop config above), a fresh `uvx` resolution can
-  present a different binary path than the one that stored the secret,
-  triggering a "Keychain wants to use a password" prompt. Choose "Always
-  Allow" the first time this happens.
-- **A migration seems to have had no effect**: if
-  `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` is set in your environment, it takes
-  precedence over whatever `migrate-credentials --to ...` just wrote to the
-  file on every subsequent run. Unset it, or keep it in sync with your
-  intended mode.
-
-#### Known limitations
-
-- **Non-POSIX (Windows) file permissions**: the `0o600` owner-only guarantee on
-  the plaintext TOML is enforced only on POSIX systems. On Windows the file is
-  written without an owner-restricted ACL, so prefer `keyring` mode (Windows
-  Credential Locker) there when secrets must not be readable by other accounts.
-- **`auto`/`keyring` trusts whatever `keyring` backend is active**: usability is
-  decided by a live set/get round-trip, not by the backend's storage guarantees.
-  A third-party `keyring` plugin that persists secrets in plaintext would pass
-  that probe. If you install custom `keyring` backends, verify the active one
-  (`keyring --list-backends`) stores secrets securely.
-- **Keyring and TOML writes are not transactional**: a save pushes secrets to
-  the keyring and then rewrites the TOML. The TOML rewrite is atomic on its own
-  (temp file + `os.replace`), but a crash _between_ the two steps can leave a
-  keyring entry with no matching config reference (an orphaned secret), or a
-  config reference whose keyring write partly failed. A plaintext migration
-  reports keyring entries it could not remove so you can clean them up manually.
-
-### Environment Variable Configuration
-
-You can also configure the email server using environment variables, which is particularly useful for CI/CD environments like Jenkins. zerolib-email supports both UI configuration (via TOML file) and environment variables, with environment variables taking precedence.
-
-```json
-{
-  "mcpServers": {
-    "zerolib-email": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_ACCOUNT_NAME": "work",
-        "MCP_EMAIL_SERVER_FULL_NAME": "John Doe",
-        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
-        "MCP_EMAIL_SERVER_USER_NAME": "john@example.com",
-        "MCP_EMAIL_SERVER_PASSWORD": "your_password",
-        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.gmail.com",
-        "MCP_EMAIL_SERVER_IMAP_PORT": "993",
-        "MCP_EMAIL_SERVER_SMTP_HOST": "smtp.gmail.com",
-        "MCP_EMAIL_SERVER_SMTP_PORT": "465"
-      }
-    }
-  }
-}
-```
-
-#### Available Environment Variables
-
-| Variable                                      | Description                                                  | Default       | Required |
-| --------------------------------------------- | ------------------------------------------------------------ | ------------- | -------- |
-| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                           | `"default"`   | No       |
-| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                                 | Email prefix  | No       |
-| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                                | -             | Yes      |
-| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                               | Same as email | No       |
-| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                               | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                             | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                             | `993`         | No       |
-| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                              | `true`        | No       |
-| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                         | `false`       | No       |
-| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)       | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for IMAP-only mode (no sending)       | -             | No       |
-| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                             | `465`         | No       |
-| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                              | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                              | `false`       | No       |
-| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)            | `true`        | No       |
-| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                   | `false`       | No       |
-| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                         | `true`        | No       |
-| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)             | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all           | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all        | -             | No       |
-| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op) | `false`       | No       |
-| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | Credential storage mode: `auto`, `keyring`, or `plaintext`   | `auto`        | No       |
-
-### IMAP-only mode (no SMTP)
-
-SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, the account runs in IMAP-only mode: `send_email` is hidden (when every configured email account lacks SMTP) and no mail can leave the server. Note that IMAP-only is not strictly read-only — IMAP-backed write tools such as `save_to_mailbox` (which composes a message and stores it in a folder via IMAP APPEND), `delete_emails`, `move_emails`, and `archive_emails` remain available.
-
-```json
-{
-  "mcpServers": {
-    "zerolib-email": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
-        "MCP_EMAIL_SERVER_PASSWORD": "your_password",
-        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.gmail.com"
-      }
-    }
-  }
-}
-```
-
-### HTTP Transport Security
-
-HTTP transports (`sse` and `streamable-http`) validate request `Host` and `Origin` headers to protect against DNS rebinding attacks. Localhost is allowed by default. For Docker networks or reverse proxies, configure the expected service names explicitly.
-
-| Variable                              | Description                                                      | Default           |
-| ------------------------------------- | ---------------------------------------------------------------- | ----------------- |
-| `MCP_HOST`                            | HTTP bind host for `streamable-http`                             | `localhost`       |
-| `MCP_PORT`                            | HTTP bind port for `streamable-http`                             | `9557`            |
-| `MCP_ALLOWED_HOSTS`                   | Comma-separated allowed `Host` values. Supports `host:*` ports   | Localhost hosts   |
-| `MCP_ALLOWED_ORIGINS`                 | Comma-separated allowed `Origin` values. Supports `host:*` ports | Localhost origins |
-| `MCP_ENABLE_DNS_REBINDING_PROTECTION` | Enable DNS rebinding protection                                  | `true`            |
-
-Docker Compose example:
-
-```yaml
-services:
-  mcp-email-server:
-    image: ghcr.io/ai-zerolab/mcp-email-server:latest
-    command: ["streamable-http"]
-    environment:
-      MCP_HOST: 0.0.0.0
-      MCP_PORT: 9557
-      MCP_ALLOWED_HOSTS: mcp-email-server:*,localhost:*,127.0.0.1:*
-      MCP_ALLOWED_ORIGINS: http://mcp-email-server:*,http://localhost:*,http://127.0.0.1:*
-```
-
-Bare host entries such as `MCP_ALLOWED_HOSTS=mcp-email-server` also allow any port on that host. `MCP_ENABLE_DNS_REBINDING_PROTECTION=false`, `MCP_ALLOWED_HOSTS=*`, or `MCP_ALLOWED_ORIGINS=*` disables Host and Origin validation entirely. Use those options only in isolated local development environments.
-
-IPv6 literals in allowlists should use bracketed notation, such as `[::1]:*` and `http://[::1]:*`.
-
-### Enabling Attachment Downloads
-
-By default, downloading email attachments is disabled for security reasons. To enable this feature, you can either:
-
-**Option 1: Environment Variable**
-
-```json
-{
-  "mcpServers": {
-    "zerolib-email": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD": "true"
-      }
-    }
-  }
-}
-```
-
-**Option 2: TOML Configuration**
-
-Add `enable_attachment_download = true` to your TOML configuration file (`~/.config/zerolib/mcp_email_server/config.toml`):
+| Scope      | Grants                                                                          |
+| ---------- | ------------------------------------------------------------------------------- |
+| `read`     | Always granted: list/read mail, mailboxes, attachments                          |
+| `draft`    | `save_to_mailbox` (drafts-type folders only, unless `organize` is also granted) |
+| `organize` | `move_emails`, `archive_emails`, `mark_emails_as_read`                          |
+| `delete`   | `delete_emails`                                                                  |
+| `send`     | `send_email`                                                                     |
+| `manage`   | `add_email_account`                                                              |
+| `full`     | Everything above                                                                 |
 
 ```toml
-enable_attachment_download = true
-
-[[emails]]
-# ... your email configuration
+permissions = ["read", "draft", "send"]  # reads, drafts, and sends — can never delete or move mail
 ```
 
-Once enabled, you can use the `download_attachment` tool to save email attachments to a specified path.
-
-### Saving Sent Emails to IMAP Sent Folder
-
-By default, sent emails are automatically saved to your IMAP Sent folder. This ensures that emails sent via the MCP server appear in your email client (Thunderbird, webmail, etc.).
-
-The server auto-detects common Sent folder names: `Sent`, `INBOX.Sent`, `Sent Items`, `Sent Mail`, `[Gmail]/Sent Mail`.
-
-**To specify a custom Sent folder name** (useful for providers with non-standard folder names):
-
-**Option 1: Environment Variable**
-
-```json
-{
-  "mcpServers": {
-    "zerolib-email": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_SENT_FOLDER_NAME": "INBOX.Sent"
-      }
-    }
-  }
-}
-```
-
-**Option 2: TOML Configuration**
-
-```toml
-[[emails]]
-account_name = "work"
-save_to_sent = true
-sent_folder_name = "INBOX.Sent"
-# ... rest of your email configuration
-```
-
-**To disable saving to Sent folder**, set `MCP_EMAIL_SERVER_SAVE_TO_SENT=false` or `save_to_sent = false` in your TOML config.
-
-### Restricting Recipients (Allowlist)
-
-By default the server can send to any address. Set `allowed_recipients` to restrict **both**
-`send_email` and `save_to_mailbox` to a trusted set. Leave it empty (the default) to allow all.
-
-```toml
-allowed_recipients = ["alice@example.com", "bob@example.com"]
-```
-
-Or via environment variable (comma-separated):
-
-```
-MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS="alice@example.com,bob@example.com"
-```
-
-When configured, any To/CC/BCC address not on the list is rejected with a clear error. Matching is
-case-insensitive and understands the `Name <addr@example.com>` form. The `list_allowed_recipients`
-tool appears only when an allowlist is configured, so default installs keep a minimal tool surface.
-
-### Filtering Incoming Mail (Sender Allowlist)
-
-By default all senders are visible. Set `allowed_senders` to show mail only from trusted senders.
-Patterns support globs (e.g. `*@company.com`) and exact addresses, matched case-insensitively. Leave
-it empty (the default) to show everything.
-
-```toml
-allowed_senders = ["*@company.com", "alice@example.com"]
-```
-
-Or via environment variable (comma-separated):
-
-```
-MCP_EMAIL_SERVER_ALLOWED_SENDERS="*@company.com,alice@example.com"
-```
-
-When configured, filtering is applied to inbound read and mutation paths: `list_emails_metadata` excludes
-non-allowed senders **before** pagination, so `total` and page sizes reflect only allowed mail;
-`get_emails_content` and `download_attachment` check the sender before reading a message, so a non-allowed
-message's body and attachments are never fetched or marked read, and it is reported as inaccessible —
-indistinguishable from a missing message. Mutation tools first check the sender and never delete, flag, or
-move blocked mail. The `list_allowed_senders` tool appears only when an allowlist is configured.
-
-**Scope:** the allowlist protects every inbound path — read (`list_emails_metadata`, `get_emails_content`,
-`download_attachment`) and mutation (`delete_emails`, `mark_emails_as_read`, `move_emails`,
-`archive_emails`). A blocked sender's mail is never read, deleted, flagged, or moved.
-
-**Blocked mutations (`report_blocked_mutations`, default `false`):** when a mutation targets a blocked
-sender's message, it is never performed. By default the result is reported as a successful no-op —
-indistinguishable from acting on a non-existent message, so the allowlist does not reveal that a hidden
-message exists. Set `report_blocked_mutations = true` (or `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS=true`)
-to instead report blocked UIDs as failures (explicit, but reveals a blocked-but-real message differs from
-a missing one).
-
-**Note:** matching is against the message's `From` header — local filtering only, not sender
-authentication. A spoofed `From` will pass the allowlist, so this is not a substitute for provider-side
-SPF / DKIM / DMARC enforcement.
-
-### Self-Signed Certificates and IMAP STARTTLS (e.g., ProtonMail Bridge)
-
-Local mail bridges such as ProtonMail Bridge commonly use STARTTLS with self-signed certificates. Configure IMAP with plaintext connect plus STARTTLS upgrade, and disable certificate verification for the local bridge certificate:
-
-```json
-{
-  "mcpServers": {
-    "zerolib-email": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_IMAP_HOST": "127.0.0.1",
-        "MCP_EMAIL_SERVER_IMAP_PORT": "1143",
-        "MCP_EMAIL_SERVER_IMAP_SSL": "false",
-        "MCP_EMAIL_SERVER_IMAP_START_SSL": "true",
-        "MCP_EMAIL_SERVER_IMAP_VERIFY_SSL": "false",
-        "MCP_EMAIL_SERVER_SMTP_VERIFY_SSL": "false"
-      }
-    }
-  }
-}
-```
-
-Or in TOML configuration:
-
-```toml
-[[emails]]
-account_name = "protonmail"
-# ... other settings ...
-
-[emails.incoming]
-host = "127.0.0.1"
-port = 1143
-use_ssl = false
-start_ssl = true
-verify_ssl = false
-
-[emails.outgoing]
-verify_ssl = false
-```
-
-For separate IMAP/SMTP credentials, you can also use:
-
-- `MCP_EMAIL_SERVER_IMAP_USER_NAME` / `MCP_EMAIL_SERVER_IMAP_PASSWORD`
-- `MCP_EMAIL_SERVER_SMTP_USER_NAME` / `MCP_EMAIL_SERVER_SMTP_PASSWORD`
-
-Then you can try it in [Claude Desktop](https://claude.ai/download). If you want to intergrate it with other mcp client, run `$which mcp-email-server` for the path and configure it in your client like:
-
-```json
-{
-  "mcpServers": {
-    "zerolib-email": {
-      "command": "{{ ENTRYPOINT }}",
-      "args": ["stdio"]
-    }
-  }
-}
-```
-
-If `docker` is avaliable, you can try use docker image, but you may need to config it in your client using `tools` via `MCP`. The default config path is `~/.config/zerolib/mcp_email_server/config.toml`
-
-```json
-{
-  "mcpServers": {
-    "zerolib-email": {
-      "command": "docker",
-      "args": ["run", "-it", "ghcr.io/ai-zerolab/mcp-email-server:latest"]
-    }
-  }
-}
-```
-
-### Installing via Smithery
-
-To install Email Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@ai-zerolab/mcp-email-server):
-
-```bash
-npx -y @smithery/cli install @ai-zerolab/mcp-email-server --client claude
-```
+Tools outside the granted scopes are hidden from the tool list and rejected if called anyway. Upgrading from a version without scopes? Set `permissions = ["full"]` to restore the old behavior. Details in the [Installation & Configuration guide](docs/installation.md#permission-scopes).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ The server is **read-only by default**. Every tool is gated behind a capability 
 | `read`     | Always granted: list/read mail, mailboxes, attachments                          |
 | `draft`    | `save_to_mailbox` (drafts-type folders only, unless `organize` is also granted) |
 | `organize` | `move_emails`, `archive_emails`, `mark_emails_as_read`                          |
-| `delete`   | `delete_emails`                                                                  |
-| `send`     | `send_email`                                                                     |
-| `manage`   | `add_email_account`                                                              |
-| `full`     | Everything above                                                                 |
+| `delete`   | `delete_emails`                                                                 |
+| `send`     | `send_email`                                                                    |
+| `manage`   | `add_email_account`                                                             |
+| `full`     | Everything above                                                                |
 
 ```toml
 permissions = ["read", "draft", "send"]  # reads, drafts, and sends — can never delete or move mail

--- a/README.md
+++ b/README.md
@@ -33,9 +33,15 @@ uvx mcp-email-server@latest ui
 }
 ```
 
+For the [Claude Code](https://claude.com/claude-code) CLI, register it in one command (after `uv tool install mcp-email-server`):
+
+```bash
+claude mcp add zerolib-email --scope user -- mcp-email-server stdio
+```
+
 The package is also on PyPI (`pip install mcp-email-server`), as a Docker image (`ghcr.io/ai-zerolab/mcp-email-server`), and on [Smithery](https://smithery.ai/server/@ai-zerolab/mcp-email-server).
 
-**See the full [Installation & Configuration guide](https://ai-zerolab.github.io/mcp-email-server/installation/)** ([docs/installation.md](docs/installation.md)) for environment-variable configuration, credential storage (OS keyring), HTTP transport security, attachment downloads, allowlists, and self-signed certificate setups.
+**See the full [Installation & Configuration guide](https://ai-zerolab.github.io/mcp-email-server/installation/)** ([docs/installation.md](docs/installation.md)) for uv/pip/Docker/Claude Code install, updating, environment-variable configuration, credential storage (OS keyring), HTTP transport security, attachment downloads, allowlists, and self-signed certificate setups.
 
 ## Permissions
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,9 +29,46 @@ Then point your MCP client at the server:
 
 ## Installation methods
 
+### uv (recommended)
+
+Install as a persistent tool so `mcp-email-server` is on your `PATH`:
+
+```bash
+uv tool install mcp-email-server
+mcp-email-server ui   # configure your account
+```
+
+Alternatively, the Quick start above uses `uvx mcp-email-server@latest stdio`, which runs the server without installing it — uv fetches and caches it on first use. Use `uv tool install` when you want a stable command (e.g. for the Claude Code CLI example below); use `uvx` for a zero-install setup.
+
+### Claude Code (CLI)
+
+If you use the [Claude Code](https://claude.com/claude-code) CLI, register the server with `claude mcp add` instead of hand-editing JSON. With uv tool install (above) putting `mcp-email-server` on your `PATH`:
+
+```bash
+claude mcp add zerolib-email --scope user -- mcp-email-server stdio
+```
+
+`--scope user` makes it available across all your projects (drop it for the current project only). To run without installing first, use `uvx` as the command:
+
+```bash
+claude mcp add zerolib-email --scope user -- uvx mcp-email-server@latest stdio
+```
+
+Pass configuration with `-e KEY=value` before the `--`:
+
+```bash
+claude mcp add zerolib-email --scope user \
+  -e MCP_EMAIL_SERVER_EMAIL_ADDRESS=you@example.com \
+  -e MCP_EMAIL_SERVER_PASSWORD=your_password \
+  -e MCP_EMAIL_SERVER_IMAP_HOST=imap.gmail.com \
+  -- mcp-email-server stdio
+```
+
+Verify with `claude mcp list` (or `/mcp` inside Claude Code); remove with `claude mcp remove zerolib-email`.
+
 ### pip
 
-The package is on PyPI:
+If you prefer pip:
 
 ```bash
 pip install mcp-email-server
@@ -73,6 +110,19 @@ To install for Claude Desktop automatically via [Smithery](https://smithery.ai/s
 ```bash
 npx -y @smithery/cli install @ai-zerolab/mcp-email-server --client claude
 ```
+
+## Updating
+
+How you update depends on how you installed. Restart your MCP client (Claude Desktop, Claude Code, etc.) afterward so it picks up the new version.
+
+| Installed with    | Update command                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| `uv tool install` | `uv tool upgrade mcp-email-server`                                                          |
+| `uvx ...@latest`  | Re-resolves on each run; force a refresh with `uvx --refresh mcp-email-server@latest stdio` |
+| `pip`             | `pip install --upgrade mcp-email-server`                                                    |
+| Docker            | `docker pull ghcr.io/ai-zerolab/mcp-email-server:latest`                                    |
+
+For the Claude Code CLI: if you registered the `uvx ...@latest` form it updates automatically on the next launch; if you registered the installed `mcp-email-server` command, run `uv tool upgrade mcp-email-server` first.
 
 ## Configuration overview
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -157,31 +157,31 @@ Example environment-variable account configuration:
 
 ### Available environment variables
 
-| Variable                                      | Description                                                                              | Default       | Required |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------- | -------- |
-| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                                                       | `"default"`   | No       |
-| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                                                             | Email prefix  | No       |
-| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                                                            | -             | Yes      |
-| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                                                           | Same as email | No       |
-| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                                                           | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                                                         | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                                                         | `993`         | No       |
-| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                                                          | `true`        | No       |
-| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                                                     | `false`       | No       |
-| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)                                   | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for read-only mode                                                | -             | No       |
-| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                                                         | `465`         | No       |
-| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                                                          | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                                                          | `false`       | No       |
-| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)                                        | `true`        | No       |
+| Variable                                      | Description                                                                                          | Default       | Required |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------- | -------- |
+| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                                                                   | `"default"`   | No       |
+| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                                                                         | Email prefix  | No       |
+| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                                                                        | -             | Yes      |
+| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                                                                       | Same as email | No       |
+| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                                                                       | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                                                                     | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                                                                     | `993`         | No       |
+| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                                                                      | `true`        | No       |
+| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                                                                 | `false`       | No       |
+| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)                                               | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for read-only mode                                                            | -             | No       |
+| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                                                                     | `465`         | No       |
+| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                                                                      | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                                                                      | `false`       | No       |
+| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)                                                    | `true`        | No       |
 | `MCP_EMAIL_SERVER_PERMISSIONS`                | Permission scopes (comma-separated): `read`, `draft`, `organize`, `delete`, `send`, `manage`, `full` | `read`        | No       |
-| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                                               | `false`       | No       |
-| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                                                     | `true`        | No       |
-| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)                                         | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all                                       | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all                                    | -             | No       |
-| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op)                             | `false`       | No       |
-| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | Credential storage mode: `auto`, `keyring`, or `plaintext`                               | `auto`        | No       |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                                                           | `false`       | No       |
+| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                                                                 | `true`        | No       |
+| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)                                                     | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all                                                   | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all                                                | -             | No       |
+| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op)                                         | `false`       | No       |
+| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | Credential storage mode: `auto`, `keyring`, or `plaintext`                                           | `auto`        | No       |
 
 For separate IMAP/SMTP credentials, you can also use:
 
@@ -190,17 +190,17 @@ For separate IMAP/SMTP credentials, you can also use:
 
 ## Permission scopes
 
-Every MCP tool is gated behind a capability scope. **The default is `read`: a fresh install is read-only** — the server can list and read mail but cannot modify, delete, or send anything until you grant more scopes. Tools outside the granted scopes are hidden from the client's tool list *and* rejected at call time.
+Every MCP tool is gated behind a capability scope. **The default is `read`: a fresh install is read-only** — the server can list and read mail but cannot modify, delete, or send anything until you grant more scopes. Tools outside the granted scopes are hidden from the client's tool list _and_ rejected at call time.
 
-| Scope      | Grants                                                                                                                                       |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scope      | Grants                                                                                                                                                                              |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `read`     | Always granted. `list_available_accounts`, `list_emails_metadata`, `get_emails_content`, `list_mailboxes`, `download_attachment` (which also requires `enable_attachment_download`) |
-| `draft`    | `save_to_mailbox`, restricted to drafts-type folders (`Drafts`, `INBOX.Drafts`, `[Gmail]/Drafts`, …). Combine with `organize` to save to arbitrary folders. |
-| `organize` | `move_emails`, `archive_emails`, `mark_emails_as_read` — and the `mark_as_read` parameter of `get_emails_content`                              |
-| `delete`   | `delete_emails`                                                                                                                                |
-| `send`     | `send_email` (the tool also requires at least one SMTP-configured account)                                                                     |
-| `manage`   | `add_email_account` — writes credentials to disk/keyring, so treat it as server administration                                                 |
-| `full`     | Everything above, including `manage`                                                                                                           |
+| `draft`    | `save_to_mailbox`, restricted to drafts-type folders (`Drafts`, `INBOX.Drafts`, `[Gmail]/Drafts`, …). Combine with `organize` to save to arbitrary folders.                         |
+| `organize` | `move_emails`, `archive_emails`, `mark_emails_as_read` — and the `mark_as_read` parameter of `get_emails_content`                                                                   |
+| `delete`   | `delete_emails`                                                                                                                                                                     |
+| `send`     | `send_email` (the tool also requires at least one SMTP-configured account)                                                                                                          |
+| `manage`   | `add_email_account` — writes credentials to disk/keyring, so treat it as server administration                                                                                      |
+| `full`     | Everything above, including `manage`                                                                                                                                                |
 
 Scopes are independent — grant any combination. For example, an assistant that reads mail, drafts replies, and sends them, but can never delete or move anything, is `["read", "draft", "send"]`.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -202,19 +202,61 @@ Every MCP tool is gated behind a capability scope. **The default is `read`: a fr
 | `manage`   | `add_email_account` — writes credentials to disk/keyring, so treat it as server administration                                                 |
 | `full`     | Everything above, including `manage`                                                                                                           |
 
-Scopes are independent — grant any combination. For example, an assistant that reads mail, drafts replies, and sends them, but can never delete or move anything:
+Scopes are independent — grant any combination. For example, an assistant that reads mail, drafts replies, and sends them, but can never delete or move anything, is `["read", "draft", "send"]`.
+
+### Setting and changing scopes
+
+Scopes come from one of two places. If both are set, the **environment variable wins**.
+
+**1. Config file — persistent (recommended).** Edit the `permissions` line in your config TOML (`~/.config/zerolib/mcp_email_server/config.toml`, or wherever `MCP_EMAIL_SERVER_CONFIG_PATH` points):
 
 ```toml
 permissions = ["read", "draft", "send"]
 ```
 
-Or via environment variable (comma-separated, overrides the TOML at runtime and is **never** persisted back to the file):
+Save the file, then **restart your MCP client** — scopes are read when the server starts. To change them later, edit this same line and restart again. (If you configured the account entirely through environment variables and have no TOML file, use method 2 instead.)
 
-```
-MCP_EMAIL_SERVER_PERMISSIONS="read,draft,send"
-```
+**2. `MCP_EMAIL_SERVER_PERMISSIONS` environment variable — overrides the file.** Comma-separated (e.g. `read,draft,send`). It overrides whatever the TOML says and is **never written back** to the file, so it's the right choice for per-client or throwaway setups. Set it wherever your client defines the server's environment:
 
-Setting the environment variable to an empty string resets to the read-only default. Unknown scope names are rejected at startup.
+- **Claude Code CLI** — pass `-e` when adding the server:
+
+  ```bash
+  claude mcp add zerolib-email --scope user \
+    -e MCP_EMAIL_SERVER_PERMISSIONS=read,draft,send \
+    -- mcp-email-server stdio
+  ```
+
+  To change it later, remove and re-add with the new value (or edit the entry in your Claude config), then reconnect:
+
+  ```bash
+  claude mcp remove zerolib-email
+  claude mcp add zerolib-email --scope user \
+    -e MCP_EMAIL_SERVER_PERMISSIONS=read,organize \
+    -- mcp-email-server stdio
+  ```
+
+- **JSON `mcpServers` config** (Claude Desktop and similar) — add or edit it in the server's `env` block, then restart the app:
+
+  ```json
+  {
+    "mcpServers": {
+      "zerolib-email": {
+        "command": "uvx",
+        "args": ["mcp-email-server@latest", "stdio"],
+        "env": { "MCP_EMAIL_SERVER_PERMISSIONS": "read,draft,send" }
+      }
+    }
+  }
+  ```
+
+- **Docker** — add it under `environment:` (Compose) or `-e MCP_EMAIL_SERVER_PERMISSIONS=...` (`docker run`).
+
+Setting the variable to an empty string resets to the read-only default. Unknown scope names are rejected at startup.
+
+### After you change scopes
+
+- **Restart / reconnect the MCP client.** The server reads scopes once at startup, so a change only takes effect on the next launch.
+- **Verify what's active by the tools your client shows.** A scope you didn't grant hides its tools — e.g. without `delete`, `delete_emails` won't appear in the tool list — and calling a hidden tool anyway is rejected server-side, so visibility and enforcement always agree.
 
 > **Upgrade note:** versions without permission scopes exposed every tool unconditionally. To restore that behavior, set `permissions = ["full"]` (or `MCP_EMAIL_SERVER_PERMISSIONS=full`).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,399 @@
+# Installation & Configuration
+
+Complete guide for installing mcp-email-server and configuring accounts, permissions, and security options.
+
+## Quick start
+
+We recommend [uv](https://github.com/astral-sh/uv) to manage your environment.
+
+Run the configuration UI once to set up your account:
+
+```bash
+uvx mcp-email-server@latest ui
+```
+
+Then point your MCP client at the server:
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"]
+    }
+  }
+}
+```
+
+> **Note:** the server starts **read-only** by default. To let it organize, delete, or send mail, grant [permission scopes](#permission-scopes).
+
+## Installation methods
+
+### pip
+
+The package is on PyPI:
+
+```bash
+pip install mcp-email-server
+mcp-email-server ui   # configure your account
+```
+
+For clients that need an absolute path, find the entrypoint with `which mcp-email-server` and configure:
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "{{ ENTRYPOINT }}",
+      "args": ["stdio"]
+    }
+  }
+}
+```
+
+### Docker
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "docker",
+      "args": ["run", "-it", "ghcr.io/ai-zerolab/mcp-email-server:latest"]
+    }
+  }
+}
+```
+
+The default config path inside the container is `~/.config/zerolib/mcp_email_server/config.toml`.
+
+### Smithery
+
+To install for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@ai-zerolab/mcp-email-server):
+
+```bash
+npx -y @smithery/cli install @ai-zerolab/mcp-email-server --client claude
+```
+
+## Configuration overview
+
+Configuration lives in a TOML file at `~/.config/zerolib/mcp_email_server/config.toml` (override the path with `MCP_EMAIL_SERVER_CONFIG_PATH`). Two ways to manage it:
+
+- **UI**: `mcp-email-server ui` walks you through account setup.
+- **Environment variables**: useful for CI/CD and containerized setups; they take precedence over the TOML file.
+
+Example environment-variable account configuration:
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_ACCOUNT_NAME": "work",
+        "MCP_EMAIL_SERVER_FULL_NAME": "John Doe",
+        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
+        "MCP_EMAIL_SERVER_USER_NAME": "john@example.com",
+        "MCP_EMAIL_SERVER_PASSWORD": "your_password",
+        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.gmail.com",
+        "MCP_EMAIL_SERVER_IMAP_PORT": "993",
+        "MCP_EMAIL_SERVER_SMTP_HOST": "smtp.gmail.com",
+        "MCP_EMAIL_SERVER_SMTP_PORT": "465"
+      }
+    }
+  }
+}
+```
+
+### Available environment variables
+
+| Variable                                      | Description                                                                              | Default       | Required |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------- | -------- |
+| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                                                       | `"default"`   | No       |
+| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                                                             | Email prefix  | No       |
+| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                                                            | -             | Yes      |
+| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                                                           | Same as email | No       |
+| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                                                           | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                                                         | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                                                         | `993`         | No       |
+| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                                                          | `true`        | No       |
+| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                                                     | `false`       | No       |
+| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)                                   | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for read-only mode                                                | -             | No       |
+| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                                                         | `465`         | No       |
+| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                                                          | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                                                          | `false`       | No       |
+| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)                                        | `true`        | No       |
+| `MCP_EMAIL_SERVER_PERMISSIONS`                | Permission scopes (comma-separated): `read`, `draft`, `organize`, `delete`, `send`, `manage`, `full` | `read`        | No       |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                                               | `false`       | No       |
+| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                                                     | `true`        | No       |
+| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)                                         | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all                                       | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all                                    | -             | No       |
+| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op)                             | `false`       | No       |
+| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | Credential storage mode: `auto`, `keyring`, or `plaintext`                               | `auto`        | No       |
+
+For separate IMAP/SMTP credentials, you can also use:
+
+- `MCP_EMAIL_SERVER_IMAP_USER_NAME` / `MCP_EMAIL_SERVER_IMAP_PASSWORD`
+- `MCP_EMAIL_SERVER_SMTP_USER_NAME` / `MCP_EMAIL_SERVER_SMTP_PASSWORD`
+
+## Permission scopes
+
+Every MCP tool is gated behind a capability scope. **The default is `read`: a fresh install is read-only** — the server can list and read mail but cannot modify, delete, or send anything until you grant more scopes. Tools outside the granted scopes are hidden from the client's tool list *and* rejected at call time.
+
+| Scope      | Grants                                                                                                                                       |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `read`     | Always granted. `list_available_accounts`, `list_emails_metadata`, `get_emails_content`, `list_mailboxes`, `download_attachment` (which also requires `enable_attachment_download`) |
+| `draft`    | `save_to_mailbox`, restricted to drafts-type folders (`Drafts`, `INBOX.Drafts`, `[Gmail]/Drafts`, …). Combine with `organize` to save to arbitrary folders. |
+| `organize` | `move_emails`, `archive_emails`, `mark_emails_as_read` — and the `mark_as_read` parameter of `get_emails_content`                              |
+| `delete`   | `delete_emails`                                                                                                                                |
+| `send`     | `send_email` (the tool also requires at least one SMTP-configured account)                                                                     |
+| `manage`   | `add_email_account` — writes credentials to disk/keyring, so treat it as server administration                                                 |
+| `full`     | Everything above, including `manage`                                                                                                           |
+
+Scopes are independent — grant any combination. For example, an assistant that reads mail, drafts replies, and sends them, but can never delete or move anything:
+
+```toml
+permissions = ["read", "draft", "send"]
+```
+
+Or via environment variable (comma-separated, overrides the TOML at runtime and is **never** persisted back to the file):
+
+```
+MCP_EMAIL_SERVER_PERMISSIONS="read,draft,send"
+```
+
+Setting the environment variable to an empty string resets to the read-only default. Unknown scope names are rejected at startup.
+
+> **Upgrade note:** versions without permission scopes exposed every tool unconditionally. To restore that behavior, set `permissions = ["full"]` (or `MCP_EMAIL_SERVER_PERMISSIONS=full`).
+
+## Credential storage
+
+Accounts added via the UI or the `add_email_account` tool are persisted to the TOML config file. Where the actual passwords/API keys live depends on `credential_storage` (also settable via `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`), one of:
+
+- **`auto`** (default): store credentials in the OS keyring — macOS Keychain, Linux Secret Service (GNOME Keyring / KWallet) — when a usable backend is detected; otherwise fall back to the plaintext TOML file (`0o600` permissions, owner-only). Falls back automatically on headless Linux, Docker, or any environment without a D-Bus session.
+- **`keyring`**: require the OS keyring; fail loudly instead of silently falling back if no backend is usable.
+- **`plaintext`**: never touch the keyring. Useful for containers, CI, or if you simply prefer a portable config file.
+
+When credentials are keyring-backed, the TOML file stores only a placeholder (`__KEYRING__`) and non-secret metadata — the real secret lives in the OS keyring under service `mcp-email-server`, one entry per `<account_name>:<incoming|outgoing|api_key>` (viewable in Keychain Access on macOS, or Seahorse on Linux).
+
+**Migrating an existing config** between storage modes:
+
+```sh
+mcp-email-server migrate-credentials --to keyring    # move plaintext secrets into the OS keyring
+mcp-email-server migrate-credentials --to plaintext  # move keyring secrets back into the TOML file
+```
+
+Migration also happens implicitly: any time you add/edit an account while `credential_storage` is `auto` or `keyring` with a usable backend, that account's secrets move into the keyring on the next save. If `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` is active during a save, its effective mode is persisted too, keeping the mode marker consistent with the credential representation written to the same file.
+
+### Failure modes & troubleshooting
+
+- **Server won't start / UI won't load accounts, keychain-related error**: the OS keyring is locked or unreachable. This is expected if credentials are keyring-backed — the secret simply isn't in the config file. Unlock your keychain, or run `mcp-email-server migrate-credentials --to plaintext` if you'd rather not depend on it.
+- **`credential_storage` is 'plaintext' but the config references keyring-stored credentials**: run `migrate-credentials --to plaintext`, or unset `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` / the `credential_storage` setting so the config can resolve them from the keyring instead.
+- **macOS Keychain access prompt, or the server can't read a secret it wrote earlier**: Keychain ACLs are per-application. If the server is spawned via `uvx`, a fresh `uvx` resolution can present a different binary path than the one that stored the secret, triggering a "Keychain wants to use a password" prompt. Choose "Always Allow" the first time this happens.
+- **A migration seems to have had no effect**: if `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` is set in your environment, it takes precedence over whatever `migrate-credentials --to ...` just wrote to the file on every subsequent run. Unset it, or keep it in sync with your intended mode.
+
+### Known limitations
+
+- **Non-POSIX (Windows) file permissions**: the `0o600` owner-only guarantee on the plaintext TOML is enforced only on POSIX systems. On Windows the file is written without an owner-restricted ACL, so prefer `keyring` mode (Windows Credential Locker) there when secrets must not be readable by other accounts.
+- **`auto`/`keyring` trusts whatever `keyring` backend is active**: usability is decided by a live set/get round-trip, not by the backend's storage guarantees. A third-party `keyring` plugin that persists secrets in plaintext would pass that probe. If you install custom `keyring` backends, verify the active one (`keyring --list-backends`) stores secrets securely.
+- **Keyring and TOML writes are not transactional**: a save pushes secrets to the keyring and then rewrites the TOML. The TOML rewrite is atomic on its own (temp file + `os.replace`), but a crash _between_ the two steps can leave a keyring entry with no matching config reference (an orphaned secret), or a config reference whose keyring write partly failed. A plaintext migration reports keyring entries it could not remove so you can clean them up manually.
+
+## Read-only IMAP mode
+
+SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, no account can send: `send_email` is hidden when every configured email account lacks SMTP — independently of the [permission scopes](#permission-scopes) above (both gates must pass). This does not disable IMAP-backed write tools: `save_to_mailbox` (a pure IMAP APPEND) stays available whenever the `draft` scope is granted, as do `delete_emails`, `move_emails`, and `archive_emails` under their `delete`/`organize` scopes.
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
+        "MCP_EMAIL_SERVER_PASSWORD": "your_password",
+        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.gmail.com"
+      }
+    }
+  }
+}
+```
+
+## HTTP transport security
+
+HTTP transports (`sse` and `streamable-http`) validate request `Host` and `Origin` headers to protect against DNS rebinding attacks. Localhost is allowed by default. For Docker networks or reverse proxies, configure the expected service names explicitly.
+
+| Variable                              | Description                                                      | Default           |
+| ------------------------------------- | ---------------------------------------------------------------- | ----------------- |
+| `MCP_HOST`                            | HTTP bind host for `streamable-http`                             | `localhost`       |
+| `MCP_PORT`                            | HTTP bind port for `streamable-http`                             | `9557`            |
+| `MCP_ALLOWED_HOSTS`                   | Comma-separated allowed `Host` values. Supports `host:*` ports   | Localhost hosts   |
+| `MCP_ALLOWED_ORIGINS`                 | Comma-separated allowed `Origin` values. Supports `host:*` ports | Localhost origins |
+| `MCP_ENABLE_DNS_REBINDING_PROTECTION` | Enable DNS rebinding protection                                  | `true`            |
+
+Docker Compose example:
+
+```yaml
+services:
+  mcp-email-server:
+    image: ghcr.io/ai-zerolab/mcp-email-server:latest
+    command: ["streamable-http"]
+    environment:
+      MCP_HOST: 0.0.0.0
+      MCP_PORT: 9557
+      MCP_ALLOWED_HOSTS: mcp-email-server:*,localhost:*,127.0.0.1:*
+      MCP_ALLOWED_ORIGINS: http://mcp-email-server:*,http://localhost:*,http://127.0.0.1:*
+```
+
+Bare host entries such as `MCP_ALLOWED_HOSTS=mcp-email-server` also allow any port on that host. `MCP_ENABLE_DNS_REBINDING_PROTECTION=false`, `MCP_ALLOWED_HOSTS=*`, or `MCP_ALLOWED_ORIGINS=*` disables Host and Origin validation entirely. Use those options only in isolated local development environments.
+
+IPv6 literals in allowlists should use bracketed notation, such as `[::1]:*` and `http://[::1]:*`.
+
+## Enabling attachment downloads
+
+By default, downloading email attachments is disabled for security reasons. To enable this feature, you can either:
+
+**Option 1: Environment Variable**
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD": "true"
+      }
+    }
+  }
+}
+```
+
+**Option 2: TOML Configuration**
+
+Add `enable_attachment_download = true` to your TOML configuration file:
+
+```toml
+enable_attachment_download = true
+
+[[emails]]
+# ... your email configuration
+```
+
+Once enabled, you can use the `download_attachment` tool to save email attachments to a specified path.
+
+## Saving sent emails to the IMAP Sent folder
+
+By default, sent emails are automatically saved to your IMAP Sent folder. This ensures that emails sent via the MCP server appear in your email client (Thunderbird, webmail, etc.).
+
+The server auto-detects common Sent folder names: `Sent`, `INBOX.Sent`, `Sent Items`, `Sent Mail`, `[Gmail]/Sent Mail`.
+
+**To specify a custom Sent folder name** (useful for providers with non-standard folder names):
+
+**Option 1: Environment Variable**
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_SENT_FOLDER_NAME": "INBOX.Sent"
+      }
+    }
+  }
+}
+```
+
+**Option 2: TOML Configuration**
+
+```toml
+[[emails]]
+account_name = "work"
+save_to_sent = true
+sent_folder_name = "INBOX.Sent"
+# ... rest of your email configuration
+```
+
+**To disable saving to Sent folder**, set `MCP_EMAIL_SERVER_SAVE_TO_SENT=false` or `save_to_sent = false` in your TOML config.
+
+## Restricting recipients (allowlist)
+
+By default the server can send to any address. Set `allowed_recipients` to restrict **both** `send_email` and `save_to_mailbox` to a trusted set. Leave it empty (the default) to allow all.
+
+```toml
+allowed_recipients = ["alice@example.com", "bob@example.com"]
+```
+
+Or via environment variable (comma-separated):
+
+```
+MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS="alice@example.com,bob@example.com"
+```
+
+When configured, any To/CC/BCC address not on the list is rejected with a clear error. Matching is case-insensitive and understands the `Name <addr@example.com>` form. The `list_allowed_recipients` tool appears only when an allowlist is configured, so default installs keep a minimal tool surface.
+
+## Filtering incoming mail (sender allowlist)
+
+By default all senders are visible. Set `allowed_senders` to show mail only from trusted senders. Patterns support globs (e.g. `*@company.com`) and exact addresses, matched case-insensitively. Leave it empty (the default) to show everything.
+
+```toml
+allowed_senders = ["*@company.com", "alice@example.com"]
+```
+
+Or via environment variable (comma-separated):
+
+```
+MCP_EMAIL_SERVER_ALLOWED_SENDERS="*@company.com,alice@example.com"
+```
+
+When configured, filtering is applied to inbound read and mutation paths: `list_emails_metadata` excludes non-allowed senders **before** pagination, so `total` and page sizes reflect only allowed mail; `get_emails_content` and `download_attachment` check the sender before reading a message, so a non-allowed message's body and attachments are never fetched or marked read, and it is reported as inaccessible — indistinguishable from a missing message. Mutation tools first check the sender and never delete, flag, or move blocked mail. The `list_allowed_senders` tool appears only when an allowlist is configured.
+
+**Scope:** the allowlist protects every inbound path — read (`list_emails_metadata`, `get_emails_content`, `download_attachment`) and mutation (`delete_emails`, `mark_emails_as_read`, `move_emails`, `archive_emails`). A blocked sender's mail is never read, deleted, flagged, or moved.
+
+**Blocked mutations (`report_blocked_mutations`, default `false`):** when a mutation targets a blocked sender's message, it is never performed. By default the result is reported as a successful no-op — indistinguishable from acting on a non-existent message, so the allowlist does not reveal that a hidden message exists. Set `report_blocked_mutations = true` (or `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS=true`) to instead report blocked UIDs as failures (explicit, but reveals a blocked-but-real message differs from a missing one).
+
+**Note:** matching is against the message's `From` header — local filtering only, not sender authentication. A spoofed `From` will pass the allowlist, so this is not a substitute for provider-side SPF / DKIM / DMARC enforcement.
+
+## Self-signed certificates and IMAP STARTTLS (e.g., ProtonMail Bridge)
+
+Local mail bridges such as ProtonMail Bridge commonly use STARTTLS with self-signed certificates. Configure IMAP with plaintext connect plus STARTTLS upgrade, and disable certificate verification for the local bridge certificate:
+
+```json
+{
+  "mcpServers": {
+    "zerolib-email": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_IMAP_HOST": "127.0.0.1",
+        "MCP_EMAIL_SERVER_IMAP_PORT": "1143",
+        "MCP_EMAIL_SERVER_IMAP_SSL": "false",
+        "MCP_EMAIL_SERVER_IMAP_START_SSL": "true",
+        "MCP_EMAIL_SERVER_IMAP_VERIFY_SSL": "false",
+        "MCP_EMAIL_SERVER_SMTP_VERIFY_SSL": "false"
+      }
+    }
+  }
+}
+```
+
+Or in TOML configuration:
+
+```toml
+[[emails]]
+account_name = "protonmail"
+# ... other settings ...
+
+[emails.incoming]
+host = "127.0.0.1"
+port = 1143
+use_ssl = false
+start_ssl = true
+verify_ssl = false
+
+[emails.outgoing]
+verify_ssl = false
+```

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable
 from datetime import datetime
 from email.utils import getaddresses
@@ -36,6 +37,34 @@ def _has_allowed_recipients() -> bool:
 
 def _has_allowed_senders() -> bool:
     return bool(get_settings().allowed_senders)
+
+
+def _scope_granted(scope: str) -> bool:
+    return get_settings().has_scope(scope)
+
+
+def _scope_visible(scope: str) -> ToolVisibilityPredicate:
+    return lambda: _scope_granted(scope)
+
+
+def _require_scope(scope: str) -> None:
+    """Call-time enforcement backing the visibility predicates.
+
+    Hiding a tool from list_tools() is cosmetic — a client can still invoke it by
+    name — so every scoped tool re-checks its scope here.
+    """
+    if not _scope_granted(scope):
+        raise PermissionError(
+            f"Permission scope '{scope}' is not granted. Add '{scope}' (or 'full') to the "
+            "'permissions' list in the config file or the MCP_EMAIL_SERVER_PERMISSIONS "
+            "environment variable."
+        )
+
+
+def _is_drafts_mailbox(mailbox: str) -> bool:
+    """True if the mailbox's leaf name is a drafts folder (e.g. Drafts, INBOX.Drafts, [Gmail]/Drafts)."""
+    leaf = re.split(r"[./]", mailbox)[-1].strip().strip('"').lower()
+    return leaf in ("draft", "drafts")
 
 
 def _enforce_recipient_allowlist(
@@ -101,8 +130,12 @@ async def list_available_accounts() -> list[AccountAttributes]:
     return [account.masked() for account in settings.get_accounts()]
 
 
-@mcp.tool(description="Add a new email account configuration to the settings.")
+@mcp.tool(
+    description="Add a new email account configuration to the settings. Requires the 'manage' permission scope.",
+    visible_if=_scope_visible("manage"),
+)
 async def add_email_account(email: EmailSettings) -> str:
+    _require_scope("manage")
     settings = get_settings()
     try:
         settings.add_email(email)
@@ -239,6 +272,10 @@ async def get_emails_content(
         ),
     ] = 20000,
 ) -> EmailContentBatchResponse:
+    # mark_as_read is a flag mutation smuggled into a read tool; hold it to the
+    # same scope as mark_emails_as_read.
+    if mark_as_read:
+        _require_scope("organize")
     handler = dispatch_handler(account_name)
     return await handler.get_emails_content(email_ids, mailbox, mark_as_read, body_offset, max_body_length)
 
@@ -270,7 +307,7 @@ async def list_allowed_senders() -> list[str]:
 
 @mcp.tool(
     description="Send an email using the specified account. Supports replying to emails with proper threading when in_reply_to is provided.",
-    visible_if=_has_send_capable_account,
+    visible_if=lambda: _scope_granted("send") and _has_send_capable_account(),
 )
 async def send_email(
     account_name: Annotated[str, Field(description="The name of the email account to send from.")],
@@ -318,6 +355,7 @@ async def send_email(
         ),
     ] = None,
 ) -> str:
+    _require_scope("send")
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
     await handler.send_email(
@@ -341,7 +379,10 @@ async def send_email(
     description="Compose an email and save it to an IMAP folder (e.g., Drafts). "
     "Same parameters as send_email, but saves instead of sending. "
     "Default folder is Drafts with \\Draft and \\Seen flags. "
-    "Pure IMAP operation — works without SMTP configuration.",
+    "Pure IMAP operation — works without SMTP configuration. "
+    "With only the 'draft' permission scope, the target folder is restricted to drafts-type "
+    "folders; the 'organize' scope lifts that restriction.",
+    visible_if=lambda: _scope_granted("draft"),
 )
 async def save_to_mailbox(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -396,6 +437,12 @@ async def save_to_mailbox(
         ),
     ] = None,
 ) -> str:
+    _require_scope("draft")
+    if not _scope_granted("organize") and not _is_drafts_mailbox(mailbox):
+        raise PermissionError(
+            f"With only the 'draft' scope, save_to_mailbox may target only drafts-type folders, "
+            f"not '{mailbox}'. Grant the 'organize' scope to save to arbitrary folders."
+        )
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
     result = await handler.save_to_mailbox(
@@ -419,7 +466,8 @@ async def save_to_mailbox(
 
 
 @mcp.tool(
-    description="Delete one or more emails by their email_id. Use list_emails_metadata first to get the email_id."
+    description="Delete one or more emails by their email_id. Use list_emails_metadata first to get the email_id.",
+    visible_if=_scope_visible("delete"),
 )
 async def delete_emails(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -429,6 +477,7 @@ async def delete_emails(
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to delete emails from.")] = "INBOX",
 ) -> str:
+    _require_scope("delete")
     handler = dispatch_handler(account_name)
     deleted_ids, failed_ids = await handler.delete_emails(email_ids, mailbox)
 
@@ -439,7 +488,8 @@ async def delete_emails(
 
 
 @mcp.tool(
-    description="Mark one or more emails as read by their email_id. Use list_emails_metadata first to get the email_id."
+    description="Mark one or more emails as read by their email_id. Use list_emails_metadata first to get the email_id.",
+    visible_if=_scope_visible("organize"),
 )
 async def mark_emails_as_read(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -449,6 +499,7 @@ async def mark_emails_as_read(
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The mailbox containing the emails.")] = "INBOX",
 ) -> str:
+    _require_scope("organize")
     handler = dispatch_handler(account_name)
     marked_ids, failed_ids = await handler.mark_emails_as_read(email_ids, mailbox)
 
@@ -459,7 +510,8 @@ async def mark_emails_as_read(
 
 
 @mcp.tool(
-    description="Move one or more emails between IMAP folders by their email_id. Use list_emails_metadata first to get the email_id and list_mailboxes to discover available folders."
+    description="Move one or more emails between IMAP folders by their email_id. Use list_emails_metadata first to get the email_id and list_mailboxes to discover available folders.",
+    visible_if=_scope_visible("organize"),
 )
 async def move_emails(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -472,6 +524,7 @@ async def move_emails(
         str, Field(default="INBOX", description="The source mailbox containing the emails.")
     ] = "INBOX",
 ) -> str:
+    _require_scope("organize")
     handler = dispatch_handler(account_name)
     moved_ids, failed_ids = await handler.move_emails(email_ids, source_mailbox, destination_mailbox)
 
@@ -484,7 +537,8 @@ async def move_emails(
 @mcp.tool(
     description="Archive one or more emails by moving them to the account's Archive folder, "
     "auto-detected via the RFC 6154 \\Archive flag (falling back to common names like Archive or "
-    "[Gmail]/All Mail). Use list_emails_metadata first to get the email_id."
+    "[Gmail]/All Mail). Use list_emails_metadata first to get the email_id.",
+    visible_if=_scope_visible("organize"),
 )
 async def archive_emails(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -494,6 +548,7 @@ async def archive_emails(
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The source mailbox containing the emails.")] = "INBOX",
 ) -> str:
+    _require_scope("organize")
     handler = dispatch_handler(account_name)
     archived_ids, failed_ids, archive_folder = await handler.archive_emails(email_ids, mailbox)
 

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -13,7 +13,16 @@ from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
 import tomli_w
-from pydantic import BaseModel, Field, PrivateAttr, SecretStr, SerializationInfo, field_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    SecretStr,
+    SerializationInfo,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -31,6 +40,7 @@ else:
 
 DEFAULT_CONFIG_PATH = "~/.config/zerolib/mcp_email_server/config.toml"
 _VALID_CREDENTIAL_STORAGE_MODES = ("auto", "keyring", "plaintext")
+_VALID_PERMISSION_SCOPES = ("read", "draft", "organize", "delete", "send", "manage", "full")
 
 # Set by Settings.load_for_migration() around construction so __init__ can skip
 # env-composited state (override pickup, env-account injection, allowlist/bool env
@@ -79,6 +89,17 @@ def _normalize_address_list(raw: Iterable[str]) -> list[str]:
 def _normalize_pattern_list(raw: Iterable[str]) -> list[str]:
     """Lowercase, strip, de-duplicate (order-preserving). Glob characters are preserved."""
     return list(dict.fromkeys(p.strip().lower() for p in raw if p.strip()))
+
+
+def _normalize_scope_list(raw: Iterable[str]) -> list[str]:
+    """Lowercase, strip, de-duplicate (order-preserving); reject unknown scope names."""
+    scopes = list(dict.fromkeys(s.strip().lower() for s in raw if s.strip()))
+    unknown = [s for s in scopes if s not in _VALID_PERMISSION_SCOPES]
+    if unknown:
+        raise ValueError(
+            f"Unknown permission scope(s): {', '.join(unknown)}; valid scopes are {', '.join(_VALID_PERMISSION_SCOPES)}"
+        )
+    return scopes
 
 
 def _reject_sentinel_secret(secret: SecretStr, label: str) -> None:
@@ -321,14 +342,21 @@ class Settings(BaseSettings):
     enable_attachment_download: bool = False
     allowed_recipients: list[str] = []
     allowed_senders: list[str] = []
+    # Capability scopes gating which MCP tools are exposed/callable. Default is
+    # read-only; "full" grants everything. See Settings.has_scope for semantics.
+    permissions: list[str] = ["read"]
     report_blocked_mutations: bool = False
     credential_storage: Literal["auto", "keyring", "plaintext"] = "auto"
 
-    # Env-var override for credential_storage. Kept separate from the loaded field
-    # so environment precedence is explicit. A later store serializes the effective
-    # value because the override controls the credential representation written to
-    # that same file; persisting the old mode would make the file self-contradictory.
+    # Env-var overrides kept off the persisted fields so a later store() never
+    # bakes a temporary override into the TOML (unlike the bool overrides below,
+    # which intentionally do persist). For permissions this matters doubly:
+    # persisting an env-granted "full" would silently escalate the on-disk config.
+    # _credential_storage_override controls the credential representation written
+    # to the file, so store() serializes the effective value rather than the old
+    # mode, which would otherwise make the file self-contradictory.
     _credential_storage_override: str | None = PrivateAttr(default=None)
+    _permissions_override: list[str] | None = PrivateAttr(default=None)
     _loaded_keyring_references: set[tuple[str, str]] = PrivateAttr(default_factory=set)
 
     model_config = SettingsConfigDict(toml_file=CONFIG_PATH, validate_assignment=True, revalidate_instances="always")
@@ -341,6 +369,27 @@ class Settings(BaseSettings):
         store() maps "auto" to a concrete backend via keyring_store.keyring_usable().
         """
         return self._credential_storage_override or self.credential_storage
+
+    @field_validator("permissions")
+    @classmethod
+    def _validate_permissions(cls, v: list[str]) -> list[str]:
+        """Normalize and reject unknown scopes on TOML load and on assignment."""
+        return _normalize_scope_list(v)
+
+    @property
+    def effective_permissions(self) -> list[str]:
+        """The scopes that actually govern tool access: env override, else the field."""
+        return self._permissions_override or self.permissions
+
+    def has_scope(self, scope: str) -> bool:
+        """Return True if the given capability scope is granted.
+
+        "read" is always granted; "full" grants every scope (including "manage").
+        """
+        granted = self.effective_permissions
+        if scope == "read" or "full" in granted:
+            return True
+        return scope in granted
 
     def _apply_bool_env_override(self, attr: str, env_var: str) -> None:
         value = os.getenv(env_var)
@@ -402,6 +451,13 @@ class Settings(BaseSettings):
         env_senders = os.getenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS")
         if env_senders is not None:
             self.allowed_senders = _normalize_pattern_list(env_senders.split(","))
+
+        # Environment variable overrides TOML (comma-separated); an empty string
+        # resets to the read-only default. Held in a PrivateAttr (not the field)
+        # so store() never persists the override.
+        env_permissions = os.getenv("MCP_EMAIL_SERVER_PERMISSIONS")
+        if env_permissions is not None:
+            self._permissions_override = _normalize_scope_list(env_permissions.split(",")) or ["read"]
 
         self._inject_env_account()
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ copyright: Maintained by <a href="https://ai-zerolab.com">ai-zerolab</a>.
 
 nav:
   - Home: index.md
+  - Installation & Configuration: installation.md
   - Modules: modules.md
 plugins:
   - search

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ os.environ["MCP_EMAIL_SERVER_LOG_LEVEL"] = "DEBUG"
 # performs best-effort keyring cleanup — a fixture-based guard could apply too late.
 # Individual tests override this via monkeypatch.setenv(...).
 os.environ["MCP_EMAIL_SERVER_CREDENTIAL_STORAGE"] = "plaintext"
+# The server defaults to read-only permissions; the pre-existing suite exercises
+# every tool, so grant everything at import time (same rationale as above).
+# Scope-specific tests override this via monkeypatch.setenv(...).
+os.environ["MCP_EMAIL_SERVER_PERMISSIONS"] = "full"
 
 import asyncio
 from datetime import datetime

--- a/tests/test_permission_scopes.py
+++ b/tests/test_permission_scopes.py
@@ -168,9 +168,12 @@ class TestToolVisibility:
 
     @pytest.mark.asyncio
     async def test_send_scope_still_requires_send_capable_account(self, monkeypatch):
+        # send_email needs an SMTP-capable account. save_to_mailbox is a pure IMAP
+        # operation (decoupled from SMTP in #194) and stays visible on the draft
+        # scope alone, independent of send capability.
         tools = await visible_tools(make_settings(monkeypatch, ["send", "draft"]))
         assert "send_email" not in tools
-        assert "save_to_mailbox" not in tools
+        assert "save_to_mailbox" in tools
 
     @pytest.mark.asyncio
     async def test_manage_gates_add_email_account(self, monkeypatch):

--- a/tests/test_permission_scopes.py
+++ b/tests/test_permission_scopes.py
@@ -1,0 +1,305 @@
+"""Capability-scope permission model: config semantics, tool visibility, call-time enforcement."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_email_server import app as app_module
+from mcp_email_server.app import (
+    _is_drafts_mailbox,
+    add_email_account,
+    archive_emails,
+    delete_emails,
+    get_emails_content,
+    mark_emails_as_read,
+    move_emails,
+    save_to_mailbox,
+    send_email,
+)
+from mcp_email_server.config import EmailServer, EmailSettings, Settings
+
+READ_TOOLS = {
+    "list_available_accounts",
+    "list_emails_metadata",
+    "get_emails_content",
+    "list_mailboxes",
+    "download_attachment",
+}
+ORGANIZE_TOOLS = {"mark_emails_as_read", "move_emails", "archive_emails"}
+
+
+def make_settings(monkeypatch, scopes=None, send_capable=False):
+    """Real Settings with the given scopes and no env permissions override.
+
+    Settings' only source is the TOML file (init kwargs are ignored), so fields
+    are assigned post-construction; validate_assignment covers validation.
+    """
+    monkeypatch.delenv("MCP_EMAIL_SERVER_PERMISSIONS", raising=False)
+    settings = Settings()
+    if scopes is not None:
+        settings.permissions = scopes
+    if send_capable:
+        server = EmailServer(
+            user_name="u",
+            password="p",
+            host="mail.example.com",
+            port=993,
+            use_ssl=True,
+        )
+        settings.emails = [
+            EmailSettings(
+                account_name="acct",
+                full_name="U",
+                email_address="u@example.com",
+                incoming=server,
+                outgoing=server,
+            )
+        ]
+    return settings
+
+
+async def visible_tools(settings):
+    with patch("mcp_email_server.app.get_settings", return_value=settings):
+        return {tool.name for tool in await app_module.mcp.list_tools()}
+
+
+class TestScopeConfig:
+    def test_default_is_read_only(self, monkeypatch):
+        settings = make_settings(monkeypatch)
+        assert settings.permissions == ["read"]
+        assert settings.has_scope("read")
+        for scope in ("draft", "organize", "delete", "send", "manage"):
+            assert not settings.has_scope(scope)
+
+    def test_full_grants_everything(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["full"])
+        for scope in ("read", "draft", "organize", "delete", "send", "manage"):
+            assert settings.has_scope(scope)
+
+    def test_explicit_scopes_only(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["draft", "send"])
+        assert settings.has_scope("read")  # always implied
+        assert settings.has_scope("draft")
+        assert settings.has_scope("send")
+        for scope in ("organize", "delete", "manage"):
+            assert not settings.has_scope(scope)
+
+    def test_unknown_scope_rejected(self, monkeypatch):
+        with pytest.raises(ValueError, match="Unknown permission scope"):
+            make_settings(monkeypatch, ["write"])
+
+    def test_scopes_normalized(self, monkeypatch):
+        settings = make_settings(monkeypatch, [" Send ", "DELETE", "send"])
+        assert settings.permissions == ["send", "delete"]
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PERMISSIONS", "send, ORGANIZE")
+        settings = Settings()
+        assert settings.effective_permissions == ["send", "organize"]
+        assert settings.has_scope("send")
+        assert settings.has_scope("organize")
+        assert not settings.has_scope("delete")
+
+    def test_env_empty_string_resets_to_read_only(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PERMISSIONS", "")
+        settings = Settings()
+        settings.permissions = ["full"]  # env override still wins over the field
+        assert settings.effective_permissions == ["read"]
+        assert not settings.has_scope("send")
+
+    def test_env_unknown_scope_rejected(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PERMISSIONS", "admin")
+        with pytest.raises(ValueError, match="Unknown permission scope"):
+            Settings()
+
+    def test_env_override_not_persisted_by_store(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PERMISSIONS", "full")
+        cfg = tmp_path / "config.toml"
+        monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+        settings = Settings()
+        assert settings.has_scope("delete")  # env grants full at runtime
+        settings.store()
+        import tomllib
+
+        stored = tomllib.loads(cfg.read_text())
+        assert stored["permissions"] == ["read"]
+
+
+class TestDraftsMailboxDetection:
+    @pytest.mark.parametrize(
+        "mailbox", ["Drafts", "drafts", "Draft", "INBOX.Drafts", "[Gmail]/Drafts", '"Drafts"', "INBOX/Drafts"]
+    )
+    def test_drafts_folders(self, mailbox):
+        assert _is_drafts_mailbox(mailbox)
+
+    @pytest.mark.parametrize("mailbox", ["INBOX", "Sent", "Drafts2", "Archive", "INBOX.Drafts.Old"])
+    def test_non_drafts_folders(self, mailbox):
+        assert not _is_drafts_mailbox(mailbox)
+
+
+class TestToolVisibility:
+    @pytest.mark.asyncio
+    async def test_read_only_hides_all_mutation_tools(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, send_capable=True))
+        assert tools >= READ_TOOLS
+        assert not (ORGANIZE_TOOLS & tools)
+        for hidden in ("delete_emails", "send_email", "save_to_mailbox", "add_email_account"):
+            assert hidden not in tools
+
+    @pytest.mark.asyncio
+    async def test_full_shows_everything(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, ["full"], send_capable=True))
+        assert tools >= READ_TOOLS | ORGANIZE_TOOLS
+        for name in ("delete_emails", "send_email", "save_to_mailbox", "add_email_account"):
+            assert name in tools
+
+    @pytest.mark.asyncio
+    async def test_organize_without_delete(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, ["organize"]))
+        assert tools >= ORGANIZE_TOOLS
+        assert "delete_emails" not in tools
+
+    @pytest.mark.asyncio
+    async def test_send_without_delete(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, ["send"], send_capable=True))
+        assert "send_email" in tools
+        assert "delete_emails" not in tools
+        assert "save_to_mailbox" not in tools
+
+    @pytest.mark.asyncio
+    async def test_send_scope_still_requires_send_capable_account(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, ["send", "draft"]))
+        assert "send_email" not in tools
+        assert "save_to_mailbox" not in tools
+
+    @pytest.mark.asyncio
+    async def test_manage_gates_add_email_account(self, monkeypatch):
+        assert "add_email_account" in await visible_tools(make_settings(monkeypatch, ["manage"]))
+        assert "add_email_account" not in await visible_tools(make_settings(monkeypatch, ["send", "delete"]))
+
+
+class TestCallTimeEnforcement:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "tool,kwargs",
+        [
+            (delete_emails, {"account_name": "a", "email_ids": ["1"]}),
+            (mark_emails_as_read, {"account_name": "a", "email_ids": ["1"]}),
+            (move_emails, {"account_name": "a", "email_ids": ["1"], "destination_mailbox": "X"}),
+            (archive_emails, {"account_name": "a", "email_ids": ["1"]}),
+            (send_email, {"account_name": "a", "recipients": ["x@example.com"], "subject": "s", "body": "b"}),
+        ],
+    )
+    async def test_mutation_tools_blocked_read_only(self, monkeypatch, tool, kwargs):
+        settings = make_settings(monkeypatch)
+        mock_handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            with pytest.raises(PermissionError, match="not granted"):
+                await tool(**kwargs)
+        assert not mock_handler.method_calls
+
+    @pytest.mark.asyncio
+    async def test_add_email_account_blocked_without_manage(self, monkeypatch, email_settings):
+        settings = make_settings(monkeypatch, ["send", "delete"])
+        with patch("mcp_email_server.app.get_settings", return_value=settings):
+            with pytest.raises(PermissionError, match="'manage'"):
+                await add_email_account(email_settings)
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_mark_as_read_needs_organize(self, monkeypatch):
+        settings = make_settings(monkeypatch)
+        mock_handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            with pytest.raises(PermissionError, match="'organize'"):
+                await get_emails_content(account_name="a", email_ids=["1"], mark_as_read=True)
+        mock_handler.get_emails_content.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_plain_read_allowed_read_only(self, monkeypatch):
+        settings = make_settings(monkeypatch)
+        mock_handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            await get_emails_content(account_name="a", email_ids=["1"])
+        mock_handler.get_emails_content.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_mark_as_read_allowed_with_organize(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["organize"])
+        mock_handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            await get_emails_content(account_name="a", email_ids=["1"], mark_as_read=True)
+        mock_handler.get_emails_content.assert_called_once()
+
+
+class TestDraftScopeFolderRestriction:
+    def _mock_handler(self):
+        handler = AsyncMock()
+        handler.save_to_mailbox.return_value = "<msg-id>|uid:7"
+        return handler
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mailbox", ["Drafts", "INBOX.Drafts", "[Gmail]/Drafts"])
+    async def test_draft_only_allows_drafts_folders(self, monkeypatch, mailbox):
+        settings = make_settings(monkeypatch, ["draft"], send_capable=True)
+        mock_handler = self._mock_handler()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            result = await save_to_mailbox(
+                account_name="a", recipients=["x@example.com"], subject="s", body="b", mailbox=mailbox
+            )
+        assert "saved" in result
+        mock_handler.save_to_mailbox.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mailbox", ["INBOX", "Sent", "Archive"])
+    async def test_draft_only_blocks_other_folders(self, monkeypatch, mailbox):
+        settings = make_settings(monkeypatch, ["draft"], send_capable=True)
+        mock_handler = self._mock_handler()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            with pytest.raises(PermissionError, match="drafts-type"):
+                await save_to_mailbox(
+                    account_name="a", recipients=["x@example.com"], subject="s", body="b", mailbox=mailbox
+                )
+        mock_handler.save_to_mailbox.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_draft_plus_organize_allows_any_folder(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["draft", "organize"], send_capable=True)
+        mock_handler = self._mock_handler()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            result = await save_to_mailbox(
+                account_name="a", recipients=["x@example.com"], subject="s", body="b", mailbox="Templates"
+            )
+        assert "saved" in result
+
+    @pytest.mark.asyncio
+    async def test_save_to_mailbox_blocked_without_draft_scope(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["organize"], send_capable=True)
+        mock_handler = self._mock_handler()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            with pytest.raises(PermissionError, match="'draft'"):
+                await save_to_mailbox(account_name="a", recipients=["x@example.com"], subject="s", body="b")
+        mock_handler.save_to_mailbox.assert_not_called()


### PR DESCRIPTION
## What this delivers

A **capability-scope permission model** (read-only by default) plus a restructured installation guide, rebased cleanly onto current `main` (post-#199).

### 1. Capability-scope permission model (read-only default)
Every MCP tool is gated behind a capability scope, set via `permissions` in the config or `MCP_EMAIL_SERVER_PERMISSIONS`. A fresh install is **read-only** — it can list/read mail but cannot modify, delete, or send until scopes are granted. Out-of-scope tools are hidden from the tool list *and* rejected at call time.

| Scope | Grants |
|---|---|
| `read` | Always granted: list/read mail, mailboxes, attachments |
| `draft` | `save_to_mailbox` (drafts-type folders unless `organize` also granted) |
| `organize` | `move_emails`, `archive_emails`, `mark_emails_as_read` |
| `delete` | `delete_emails` |
| `send` | `send_email` |
| `manage` | `add_email_account` |
| `full` | Everything |

Upgrading from a pre-scopes version? Set `permissions = ["full"]` to restore prior behavior.

### 2. Docs restructure → `docs/installation.md`
README's long config reference moved into a dedicated **Installation & Configuration guide** (uv/pip/Docker/Claude Code install, Updating, env vars, credential storage, HTTP transport security, attachment downloads, allowlists). README keeps a quickstart + the new Permissions section + a pointer.

### 3. Chore
Ignore `.DS_Store` everywhere.

## Reconciliation notes (why this isn't a plain cherry-pick)

This work was authored before #194/#199 landed, so integrating onto current `main` required resolving real semantic conflicts — surfaced honestly here:

- **`save_to_mailbox` is now gated on the `draft` scope only**, not on send-capability. The permission model originally required a send-capable (SMTP) account, but #194 decoupled `save_to_mailbox` from SMTP (pure IMAP APPEND). Keeping the old gate would have re-hidden it in IMAP-only setups. Test and docs updated to match (`test: reconcile save_to_mailbox visibility with #194`).
- **Credential-storage docs preserved from #199** — the `auto`/`keyring`/`plaintext` section, the env-override persistence note, and the full **Known limitations** subsection (Windows perms, backend-trust, non-transactional writes) were carried into `docs/installation.md` rather than dropped.
- `config.py` merge keeps #199's `_loaded_keyring_references` alongside the new `_permissions_override`.

## Test plan
- [x] `uv run pytest -q` — **558 passed**
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `prettier --check README.md docs/installation.md` — clean
- [x] Verified every env var from the old README is still documented; no config content lost

Opened as **draft** — the reconciliation decisions above (esp. `save_to_mailbox` gating) warrant a review before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pd8meRq4jSiqaLq715nSD
