### PR TITLE
security: download-path confinement, CRLF rejection, resource limits, HTTP-transport warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ You can also configure the email server using environment variables, which is pa
 | `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                              | `false`       | No       |
 | `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)            | `true`        | No       |
 | `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                   | `false`       | No       |
+| `MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR`    | Directory that `download_attachment` save paths must resolve within | `~/Downloads` | No       |
 | `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                         | `true`        | No       |
 | `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)             | -             | No       |
 | `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all           | -             | No       |
@@ -188,6 +189,12 @@ SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, th
 
 ### HTTP Transport Security
 
+> **⚠️ The HTTP transports have no authentication. Do not expose them to an untrusted network.**
+>
+> `sse` and `streamable-http` ship **no bearer token, API key, or any auth layer** — the only gate is `Host`/`Origin` validation, which defends against browser-driven DNS rebinding, **not** against a direct network attacker. The `Host` header is attacker-supplied: when the server is bound to a wildcard address (`0.0.0.0`/`::`), the allowlist falls back to loopback names, so anyone who can reach the port simply sends `Host: localhost` and passes. When bound to a concrete LAN IP, that IP is auto-allowed, so `Host: <lan-ip>` passes too. **Either way, once past `Host` validation every email tool — read, send, delete — is fully accessible with zero authentication.**
+>
+> Treat any non-loopback bind (`MCP_HOST=0.0.0.0`, a LAN IP, or a container published to the host) as publishing an **unauthenticated email gateway**. Only do it on a trusted, isolated network, and put your own authentication in front of it (a reverse proxy requiring a token, mTLS, or a private network / VPN). The safe default is the `localhost` bind below.
+
 HTTP transports (`sse` and `streamable-http`) validate request `Host` and `Origin` headers to protect against DNS rebinding attacks. Localhost is allowed by default. For Docker networks or reverse proxies, configure the expected service names explicitly.
 
 | Variable                              | Description                                                      | Default           |
@@ -212,7 +219,9 @@ services:
       MCP_ALLOWED_ORIGINS: http://mcp-email-server:*,http://localhost:*,http://127.0.0.1:*
 ```
 
-Bare host entries such as `MCP_ALLOWED_HOSTS=mcp-email-server` also allow any port on that host. `MCP_ENABLE_DNS_REBINDING_PROTECTION=false`, `MCP_ALLOWED_HOSTS=*`, or `MCP_ALLOWED_ORIGINS=*` disables Host and Origin validation entirely. Use those options only in isolated local development environments.
+The Compose example above binds `0.0.0.0` and therefore exposes the unauthenticated gateway described at the top of this section to everything that can route to the container — keep it on an internal Docker network and/or gate it behind an authenticating reverse proxy.
+
+Bare host entries such as `MCP_ALLOWED_HOSTS=mcp-email-server` also allow any port on that host. `MCP_ENABLE_DNS_REBINDING_PROTECTION=false`, `MCP_ALLOWED_HOSTS=*`, or `MCP_ALLOWED_ORIGINS=*` disables Host and Origin validation entirely — which, per the warning above, removes the _only_ request-level check the server has. Use those options only in isolated local development environments.
 
 IPv6 literals in allowlists should use bracketed notation, such as `[::1]:*` and `http://[::1]:*`.
 
@@ -247,7 +256,16 @@ enable_attachment_download = true
 # ... your email configuration
 ```
 
-Once enabled, you can use the `download_attachment` tool to save email attachments to a specified path.
+Once enabled, you can use the `download_attachment` tool to save email attachments.
+
+**Save paths are confined to a download directory.** Because attachment bytes are attacker-controlled (anyone can email you a file), `download_attachment` will only write within `attachment_download_dir` — default `~/Downloads`. A `save_path` that resolves outside it (including via `..` or a symlink) is rejected, so the tool can't be steered into overwriting `~/.ssh/authorized_keys`, a crontab, or the config file. Relative save paths resolve under the directory. Change it with:
+
+```toml
+enable_attachment_download = true
+attachment_download_dir = "/home/me/mail-attachments"
+```
+
+or `MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR=/home/me/mail-attachments` (empty string resets to the `~/Downloads` default).
 
 ### Saving Sent Emails to IMAP Sent Folder
 

--- a/README.md
+++ b/README.md
@@ -141,31 +141,31 @@ You can also configure the email server using environment variables, which is pa
 
 #### Available Environment Variables
 
-| Variable                                      | Description                                                  | Default       | Required |
-| --------------------------------------------- | ------------------------------------------------------------ | ------------- | -------- |
-| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                           | `"default"`   | No       |
-| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                                 | Email prefix  | No       |
-| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                                | -             | Yes      |
-| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                               | Same as email | No       |
-| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                               | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                             | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                             | `993`         | No       |
-| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                              | `true`        | No       |
-| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                         | `false`       | No       |
-| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)       | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for IMAP-only mode (no sending)       | -             | No       |
-| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                             | `465`         | No       |
-| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                              | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                              | `false`       | No       |
-| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)            | `true`        | No       |
-| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                   | `false`       | No       |
+| Variable                                      | Description                                                         | Default       | Required |
+| --------------------------------------------- | ------------------------------------------------------------------- | ------------- | -------- |
+| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                                  | `"default"`   | No       |
+| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                                        | Email prefix  | No       |
+| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                                       | -             | Yes      |
+| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                                      | Same as email | No       |
+| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                                      | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                                    | -             | Yes      |
+| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                                    | `993`         | No       |
+| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                                     | `true`        | No       |
+| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                                | `false`       | No       |
+| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)              | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for IMAP-only mode (no sending)              | -             | No       |
+| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                                    | `465`         | No       |
+| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                                     | `true`        | No       |
+| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                                     | `false`       | No       |
+| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)                   | `true`        | No       |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                          | `false`       | No       |
 | `MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR`    | Directory that `download_attachment` save paths must resolve within | `~/Downloads` | No       |
-| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                         | `true`        | No       |
-| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)             | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all           | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all        | -             | No       |
-| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op) | `false`       | No       |
-| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | Credential storage mode: `auto`, `keyring`, or `plaintext`   | `auto`        | No       |
+| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                                | `true`        | No       |
+| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)                    | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all                  | -             | No       |
+| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all               | -             | No       |
+| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op)        | `false`       | No       |
+| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | Credential storage mode: `auto`, `keyring`, or `plaintext`          | `auto`        | No       |
 
 ### IMAP-only mode (no SMTP)
 

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -65,6 +65,19 @@ def _resolve_download_path(save_path: str, root: Path) -> Path:
     return resolved
 
 
+def _reject_crlf(values: list[str | None], label: str) -> None:
+    """Raise ValueError if any value contains a CR or LF.
+
+    Header CRLF is caught by the stdlib email serializer, but SMTP-envelope
+    recipients (notably bcc, which is never placed in a header) are passed
+    straight to aiosmtplib, which writes RCPT TO raw without a CRLF check — so a
+    newline there injects extra SMTP commands/recipients. Reject at the boundary.
+    """
+    for value in values:
+        if value is not None and ("\r" in value or "\n" in value):
+            raise ValueError(f"{label} must not contain newline characters: {value!r}")
+
+
 def _enforce_recipient_allowlist(
     recipients: list[str],
     cc: list[str] | None,
@@ -345,6 +358,9 @@ async def send_email(
         ),
     ] = None,
 ) -> str:
+    _reject_crlf([*recipients, *(cc or []), *(bcc or [])], "Recipient address")
+    _reject_crlf([in_reply_to, references, reply_to], "Header value")
+    _reject_crlf(attachments or [], "Attachment path")
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
     await handler.send_email(
@@ -423,6 +439,9 @@ async def save_to_mailbox(
         ),
     ] = None,
 ) -> str:
+    _reject_crlf([*recipients, *(cc or []), *(bcc or [])], "Recipient address")
+    _reject_crlf([in_reply_to, references], "Header value")
+    _reject_crlf(attachments or [], "Attachment path")
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
     result = await handler.save_to_mailbox(

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -27,6 +27,10 @@ from mcp_email_server.emails.models import (
 
 ToolVisibilityPredicate = Callable[[], bool]
 
+# Resource-exhaustion ceilings on tool inputs (self-DoS guards).
+MAX_PAGE_SIZE = 500
+MAX_EMAIL_IDS_PER_CALL = 100
+
 
 def _has_send_capable_account() -> bool:
     settings = get_settings()
@@ -166,9 +170,12 @@ async def list_emails_metadata(
     account_name: Annotated[str, Field(description="The name of the email account.")],
     page: Annotated[
         int,
-        Field(default=1, description="The page number to retrieve (starting from 1)."),
+        Field(default=1, ge=1, description="The page number to retrieve (starting from 1)."),
     ] = 1,
-    page_size: Annotated[int, Field(default=10, description="The number of emails to retrieve per page.")] = 10,
+    page_size: Annotated[
+        int,
+        Field(default=10, ge=1, le=MAX_PAGE_SIZE, description="The number of emails to retrieve per page (max 500)."),
+    ] = 10,
     before: Annotated[
         datetime | None,
         Field(default=None, description="Retrieve emails before this datetime (UTC)."),
@@ -246,7 +253,10 @@ async def get_emails_content(
     email_ids: Annotated[
         list[str],
         Field(
-            description="List of email_id to retrieve (obtained from list_emails_metadata). Can be a single email_id or multiple email_ids."
+            min_length=1,
+            max_length=MAX_EMAIL_IDS_PER_CALL,
+            description="List of email_id to retrieve (obtained from list_emails_metadata). Can be a single "
+            "email_id or multiple email_ids (max 100 per call).",
         ),
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to retrieve emails from.")] = "INBOX",

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -1,6 +1,9 @@
+import os
+import re
 from collections.abc import Callable
 from datetime import datetime
 from email.utils import getaddresses
+from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from mcp.server.fastmcp import FastMCP
@@ -36,6 +39,30 @@ def _has_allowed_recipients() -> bool:
 
 def _has_allowed_senders() -> bool:
     return bool(get_settings().allowed_senders)
+
+
+def _resolve_download_path(save_path: str, root: Path) -> Path:
+    """Resolve save_path and confine it within root, resolving symlinks.
+
+    Relative paths resolve under root; absolute paths must already be within it.
+    A symlink component pointing outside root is caught because the parent is
+    canonicalised with realpath before the containment check. Raises
+    PermissionError on any path that escapes root.
+    """
+    candidate = Path(save_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    # The target file need not exist yet (write happens later), so canonicalise the
+    # parent — which resolves any symlinks along the existing prefix — then re-attach
+    # the final component and check containment against the canonical root.
+    resolved = Path(os.path.realpath(candidate.parent)) / candidate.name
+    if not resolved.is_relative_to(root):
+        raise PermissionError(
+            f"Attachment save_path {save_path!r} resolves outside the permitted download "
+            f"directory {root}. Set 'attachment_download_dir' (or "
+            "MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR) to permit it."
+        )
+    return resolved
 
 
 def _enforce_recipient_allowlist(
@@ -522,7 +549,9 @@ async def list_mailboxes(
 
 
 @mcp.tool(
-    description="Download an email attachment and save it to the specified path. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
+    description="Download an email attachment and save it under the permitted download directory. This "
+    "feature must be explicitly enabled in settings (enable_attachment_download=true). The save_path is "
+    "confined to attachment_download_dir (default ~/Downloads); paths resolving outside it are rejected.",
 )
 async def download_attachment(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -532,7 +561,13 @@ async def download_attachment(
     attachment_name: Annotated[
         str, Field(description="The name of the attachment to download (as shown in the attachments list).")
     ],
-    save_path: Annotated[str, Field(description="The absolute path where the attachment should be saved.")],
+    save_path: Annotated[
+        str,
+        Field(
+            description="Where to save the attachment. Must resolve within the configured "
+            "attachment_download_dir (default ~/Downloads); a relative path is taken relative to it."
+        ),
+    ],
     mailbox: Annotated[str, Field(description="The mailbox to search in (default: INBOX).")] = "INBOX",
 ) -> AttachmentDownloadResponse:
     settings = get_settings()
@@ -542,5 +577,6 @@ async def download_attachment(
         )
         raise PermissionError(msg)
 
+    confined_path = _resolve_download_path(save_path, settings.attachment_download_root)
     handler = dispatch_handler(account_name)
-    return await handler.download_attachment(email_id, attachment_name, save_path, mailbox)
+    return await handler.download_attachment(email_id, attachment_name, str(confined_path), mailbox)

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -49,23 +49,26 @@ def _resolve_download_path(save_path: str, root: Path) -> Path:
     """Resolve save_path and confine it within root, resolving symlinks.
 
     Relative paths resolve under root; absolute paths must already be within it.
-    A symlink component pointing outside root is caught because the parent is
-    canonicalised with realpath before the containment check. Raises
-    PermissionError on any path that escapes root.
+    The FULL candidate is canonicalised with realpath — including the final
+    component — so a symlink planted at the target path can't redirect the write
+    outside root. Raises PermissionError on any path that escapes root, or on a
+    path with no filename component.
     """
     candidate = Path(save_path).expanduser()
     if not candidate.is_absolute():
         candidate = root / candidate
-    # The target file need not exist yet (write happens later), so canonicalise the
-    # parent — which resolves any symlinks along the existing prefix — then re-attach
-    # the final component and check containment against the canonical root.
-    resolved = Path(os.path.realpath(candidate.parent)) / candidate.name
+    # realpath resolves symlinks in every component (the final one too); a
+    # non-existent trailing name is simply normalised, so a not-yet-created target
+    # still validates. This is what closes final-component symlink escapes.
+    resolved = Path(os.path.realpath(candidate))
     if not resolved.is_relative_to(root):
         raise PermissionError(
             f"Attachment save_path {save_path!r} resolves outside the permitted download "
             f"directory {root}. Set 'attachment_download_dir' (or "
             "MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR) to permit it."
         )
+    if resolved == root or not resolved.name:
+        raise PermissionError(f"Attachment save_path {save_path!r} must name a file, not the download directory.")
     return resolved
 
 
@@ -369,7 +372,7 @@ async def send_email(
     ] = None,
 ) -> str:
     _reject_crlf([*recipients, *(cc or []), *(bcc or [])], "Recipient address")
-    _reject_crlf([in_reply_to, references, reply_to], "Header value")
+    _reject_crlf([subject, in_reply_to, references, reply_to], "Header value")
     _reject_crlf(attachments or [], "Attachment path")
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
@@ -450,7 +453,7 @@ async def save_to_mailbox(
     ] = None,
 ) -> str:
     _reject_crlf([*recipients, *(cc or []), *(bcc or [])], "Recipient address")
-    _reject_crlf([in_reply_to, references], "Header value")
+    _reject_crlf([subject, in_reply_to, references], "Header value")
     _reject_crlf(attachments or [], "Attachment path")
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -1,5 +1,4 @@
 import os
-import re
 from collections.abc import Callable
 from datetime import datetime
 from email.utils import getaddresses

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -319,6 +319,10 @@ class Settings(BaseSettings):
     providers: list[ProviderSettings] = []
     db_location: str = CONFIG_PATH.with_name("db.sqlite3").as_posix()
     enable_attachment_download: bool = False
+    # Directory that download_attachment save paths must resolve within. Confines
+    # the arbitrary-filesystem-write primitive that enable_attachment_download opens
+    # up. Unset => defaults to ~/Downloads (see Settings.attachment_download_root).
+    attachment_download_dir: str | None = None
     allowed_recipients: list[str] = []
     allowed_senders: list[str] = []
     report_blocked_mutations: bool = False
@@ -341,6 +345,16 @@ class Settings(BaseSettings):
         store() maps "auto" to a concrete backend via keyring_store.keyring_usable().
         """
         return self._credential_storage_override or self.credential_storage
+
+    @property
+    def attachment_download_root(self) -> Path:
+        """Directory that download_attachment save paths must resolve within.
+
+        Defaults to ~/Downloads when unset. Fully resolved (symlinks included) so
+        callers can containment-check candidate paths against a canonical root.
+        """
+        raw = self.attachment_download_dir or "~/Downloads"
+        return Path(os.path.realpath(Path(raw).expanduser()))
 
     def _apply_bool_env_override(self, attr: str, env_var: str) -> None:
         value = os.getenv(env_var)
@@ -402,6 +416,11 @@ class Settings(BaseSettings):
         env_senders = os.getenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS")
         if env_senders is not None:
             self.allowed_senders = _normalize_pattern_list(env_senders.split(","))
+
+        env_download_dir = os.getenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR")
+        if env_download_dir is not None:
+            # An empty string resets to the default (~/Downloads) rather than "".
+            self.attachment_download_dir = env_download_dir.strip() or None
 
         self._inject_env_account()
 

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -36,6 +36,10 @@ from mcp_email_server.log import logger
 # Maximum body length before truncation (characters)
 MAX_BODY_LENGTH = 20000
 
+# Maximum size of a single attachment, inbound (download) or outbound (send),
+# in bytes. Guards against reading a multi-GB file fully into memory.
+MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
 # Common Archive folder names, used as a fallback when no RFC 6154 \Archive flag is found.
 _ARCHIVE_FOLDER_CANDIDATES = ("Archive", "Archives", "[Gmail]/All Mail")
 
@@ -1058,6 +1062,23 @@ class EmailClient:
                 return bytes(item) if isinstance(item, bytearray) else item
         return None
 
+    def _find_attachment_in_message(self, email_message, attachment_name: str) -> tuple[bytes | None, str | None]:
+        """Return (data, mime_type) for the named attachment, or (None, None) if absent."""
+        normalized = self._normalize_attachment_name(attachment_name)
+        if not email_message.is_multipart():
+            return None, None
+        for part in email_message.walk():
+            # Match attachments listed by ``_parse_email_data`` — this includes
+            # inline-disposition parts with a filename (e.g. iOS Mail photos).
+            if not self._is_attachment_part(part):
+                continue
+            filename = part.get_filename()
+            if not isinstance(filename, str):
+                continue
+            if self._normalize_attachment_name(filename) == normalized:
+                return part.get_payload(decode=True), part.get_content_type()
+        return None, None
+
     async def _fetch_email_with_formats(self, imap, email_id: str) -> list | None:
         """Try non-mutating fetch formats to get email data."""
         fetch_formats = ["BODY.PEEK[]", "(BODY.PEEK[])"]
@@ -1186,27 +1207,18 @@ class EmailClient:
             parser = BytesParser(policy=default)
             email_message = parser.parsebytes(raw_email)
 
-            # Find the attachment
-            attachment_data = None
-            mime_type = None
-            normalized_attachment_name = self._normalize_attachment_name(attachment_name)
-
-            if email_message.is_multipart():
-                for part in email_message.walk():
-                    # Match attachments listed by ``_parse_email_data`` — this includes
-                    # inline-disposition parts with a filename (e.g. iOS Mail photos).
-                    if not self._is_attachment_part(part):
-                        continue
-                    filename = part.get_filename()
-                    if not isinstance(filename, str):
-                        continue
-                    if self._normalize_attachment_name(filename) == normalized_attachment_name:
-                        attachment_data = part.get_payload(decode=True)
-                        mime_type = part.get_content_type()
-                        break
+            attachment_data, mime_type = self._find_attachment_in_message(email_message, attachment_name)
 
             if attachment_data is None:
                 msg = f"Attachment '{attachment_name}' not found in email {email_id}"
+                logger.error(msg)
+                raise ValueError(msg)
+
+            if len(attachment_data) > MAX_ATTACHMENT_BYTES:
+                msg = (
+                    f"Attachment '{attachment_name}' is {len(attachment_data)} bytes, "
+                    f"exceeding the {MAX_ATTACHMENT_BYTES}-byte limit"
+                )
                 logger.error(msg)
                 raise ValueError(msg)
 
@@ -1241,6 +1253,12 @@ class EmailClient:
 
         if not path.is_file():
             msg = f"Attachment path is not a file: {file_path}"
+            logger.error(msg)
+            raise ValueError(msg)
+
+        size = path.stat().st_size
+        if size > MAX_ATTACHMENT_BYTES:
+            msg = f"Attachment {file_path} is {size} bytes, exceeding the {MAX_ATTACHMENT_BYTES}-byte limit"
             logger.error(msg)
             raise ValueError(msg)
 

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -3,6 +3,7 @@ import base64
 import binascii
 import email.utils
 import mimetypes
+import os
 import re
 import ssl
 import time
@@ -36,9 +37,15 @@ from mcp_email_server.log import logger
 # Maximum body length before truncation (characters)
 MAX_BODY_LENGTH = 20000
 
-# Maximum size of a single attachment, inbound (download) or outbound (send),
-# in bytes. Guards against reading a multi-GB file fully into memory.
+# Maximum size of a single attachment, in bytes. On the outbound (send) path the
+# file is stat'd before it is read, so this genuinely caps memory. On the inbound
+# (download) path the message is already fetched, so this bounds what is written to
+# disk (it does not prevent the fetch itself from loading the message into memory).
 MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
+# Aggregate cap across all attachments on a single outbound message.
+MAX_TOTAL_ATTACHMENT_BYTES = 50 * 1024 * 1024
+MAX_ATTACHMENT_COUNT = 50
 
 # Common Archive folder names, used as a fallback when no RFC 6154 \Archive flag is found.
 _ARCHIVE_FOLDER_CANDIDATES = ("Archive", "Archives", "[Gmail]/All Mail")
@@ -1222,10 +1229,16 @@ class EmailClient:
                 logger.error(msg)
                 raise ValueError(msg)
 
-            # Save to disk
+            # Save to disk. save_path is already confined to the download root by
+            # app._resolve_download_path; O_NOFOLLOW additionally refuses to follow a
+            # symlink swapped into the final component after that check (TOCTOU), and
+            # the attachment lands owner-only.
             save_file = Path(save_path)
             save_file.parent.mkdir(parents=True, exist_ok=True)
-            save_file.write_bytes(attachment_data)
+            open_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(save_file, open_flags, 0o600)
+            with os.fdopen(fd, "wb") as f:
+                f.write(attachment_data)
 
             logger.info(f"Attachment '{attachment_name}' saved to {save_path}")
 
@@ -1284,16 +1297,31 @@ class EmailClient:
 
     def _create_message_with_attachments(self, body: str, html: bool, attachments: list[str]) -> MIMEMultipart:
         """Create multipart message with attachments."""
+        if len(attachments) > MAX_ATTACHMENT_COUNT:
+            msg = f"Too many attachments: {len(attachments)} (max {MAX_ATTACHMENT_COUNT})"
+            logger.error(msg)
+            raise ValueError(msg)
+
         msg = MIMEMultipart()
         content_type = "html" if html else "plain"
         text_part = MIMEText(body, content_type, "utf-8")
         msg.attach(text_part)
 
+        total_bytes = 0
         for file_path in attachments:
             try:
                 path = self._validate_attachment(file_path)
-                attachment_part = self._create_attachment_part(path)
-                msg.attach(attachment_part)
+                size = path.stat().st_size
+            except Exception as e:
+                logger.error(f"Failed to attach file {file_path}: {e}")
+                raise
+            total_bytes += size
+            if total_bytes > MAX_TOTAL_ATTACHMENT_BYTES:
+                # Checked via stat before the file is read, so an over-limit set is
+                # rejected without loading the offending file into memory.
+                raise ValueError(f"Total attachment size exceeds the {MAX_TOTAL_ATTACHMENT_BYTES}-byte limit")
+            try:
+                msg.attach(self._create_attachment_part(path))
             except Exception as e:
                 logger.error(f"Failed to attach file {file_path}: {e}")
                 raise

--- a/tests/test_crlf_injection.py
+++ b/tests/test_crlf_injection.py
@@ -48,6 +48,17 @@ class TestSendEmailCrlf:
         handler.send_email.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_send_email_rejects_crlf_subject(self):
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=_mock_send_settings()),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(ValueError, match="must not contain newline"):
+                await send_email(account_name="a", recipients=["a@b.com"], subject="Hi\r\nBcc: evil@x.com", body="b")
+        handler.send_email.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_send_email_clean_passes(self):
         handler = AsyncMock()
         with (

--- a/tests/test_crlf_injection.py
+++ b/tests/test_crlf_injection.py
@@ -1,0 +1,79 @@
+"""CRLF / SMTP-envelope injection hardening for send_email and save_to_mailbox."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_email_server.app import _reject_crlf, save_to_mailbox, send_email
+
+
+class TestRejectCrlfHelper:
+    @pytest.mark.parametrize("bad", ["a@b.com\r\nRSET", "a@b.com\nBcc: x@y.com", "x\ry", "line1\nline2"])
+    def test_rejects_newlines(self, bad):
+        with pytest.raises(ValueError, match="must not contain newline"):
+            _reject_crlf([bad], "Recipient address")
+
+    def test_allows_clean_values_and_none(self):
+        _reject_crlf(["a@b.com", "b@c.com", None], "Recipient address")  # no raise
+
+
+def _mock_send_settings():
+    settings = MagicMock()
+    settings.has_scope.return_value = True
+    settings.allowed_recipients = []
+    return settings
+
+
+class TestSendEmailCrlf:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"recipients": ["a@b.com\r\nRCPT TO:<evil@x.com>"]},
+            {"recipients": ["a@b.com"], "cc": ["c@d.com\nBcc: evil@x.com"]},
+            {"recipients": ["a@b.com"], "bcc": ["e@f.com\r\nDATA"]},
+            {"recipients": ["a@b.com"], "reply_to": "r@s.com\r\nX-Injected: 1"},
+            {"recipients": ["a@b.com"], "in_reply_to": "<id>\r\nX: y"},
+            {"recipients": ["a@b.com"], "attachments": ["/data/ok\r\n/etc/passwd"]},
+        ],
+    )
+    async def test_send_email_rejects_crlf(self, kwargs):
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=_mock_send_settings()),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(ValueError, match="must not contain newline"):
+                await send_email(account_name="a", subject="s", body="b", **kwargs)
+        handler.send_email.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_email_clean_passes(self):
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=_mock_send_settings()),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            await send_email(account_name="a", recipients=["a@b.com"], subject="s", body="b", bcc=["c@d.com"])
+        handler.send_email.assert_called_once()
+
+
+class TestSaveToMailboxCrlf:
+    @pytest.mark.asyncio
+    async def test_save_to_mailbox_rejects_crlf_bcc(self):
+        handler = AsyncMock()
+        handler.save_to_mailbox.return_value = "<id>|uid:1"
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=_mock_send_settings()),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(ValueError, match="must not contain newline"):
+                await save_to_mailbox(
+                    account_name="a",
+                    recipients=["a@b.com"],
+                    subject="s",
+                    body="b",
+                    mailbox="Drafts",
+                    bcc=["e@f.com\r\nRSET"],
+                )
+        handler.save_to_mailbox.assert_not_called()

--- a/tests/test_download_path_confinement.py
+++ b/tests/test_download_path_confinement.py
@@ -1,0 +1,151 @@
+"""download_attachment save_path confinement (arbitrary-write hardening)."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from mcp_email_server.app import _resolve_download_path
+from mcp_email_server.config import Settings
+
+
+class TestResolveDownloadPath:
+    def test_absolute_within_root_allowed(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path))
+        target = root / "sub" / "file.pdf"
+        assert _resolve_download_path(str(target), root) == target
+
+    def test_relative_resolves_under_root(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path))
+        assert _resolve_download_path("report.pdf", root) == root / "report.pdf"
+        assert _resolve_download_path("nested/report.pdf", root) == root / "nested" / "report.pdf"
+
+    def test_absolute_outside_root_rejected(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path)) / "downloads"
+        root.mkdir()
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path("/etc/cron.d/evil", root)
+
+    def test_dotdot_traversal_rejected(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path)) / "downloads"
+        root.mkdir()
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path(str(root / ".." / "escape.txt"), root)
+
+    def test_relative_dotdot_traversal_rejected(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path)) / "downloads"
+        root.mkdir()
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path("../escape.txt", root)
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        real = Path(os.path.realpath(tmp_path))
+        root = real / "downloads"
+        root.mkdir()
+        outside = real / "outside"
+        outside.mkdir()
+        # A symlink inside root pointing outside must not become a write channel.
+        (root / "link").symlink_to(outside)
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path(str(root / "link" / "pwned.txt"), root)
+
+    def test_symlinked_root_itself_is_canonicalised(self, tmp_path):
+        # If the root is reached via a symlink, a save under it still validates.
+        real = Path(os.path.realpath(tmp_path))
+        actual = real / "actual_downloads"
+        actual.mkdir()
+        result = _resolve_download_path(str(actual / "a.bin"), actual)
+        assert result == actual / "a.bin"
+
+    def test_root_itself_allowed(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path))
+        assert _resolve_download_path(str(root), root) == root
+
+
+class TestAttachmentDownloadRootConfig:
+    def test_defaults_to_downloads(self, monkeypatch):
+        monkeypatch.delenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR", raising=False)
+        settings = Settings()
+        assert settings.attachment_download_dir is None
+        assert settings.attachment_download_root == Path(os.path.realpath(Path("~/Downloads").expanduser()))
+
+    def test_field_sets_root(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR", raising=False)
+        settings = Settings()
+        settings.attachment_download_dir = str(tmp_path)
+        assert settings.attachment_download_root == Path(os.path.realpath(tmp_path))
+
+    def test_env_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR", str(tmp_path))
+        settings = Settings()
+        assert settings.attachment_download_dir == str(tmp_path)
+        assert settings.attachment_download_root == Path(os.path.realpath(tmp_path))
+
+    def test_env_empty_resets_to_default(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR", "   ")
+        settings = Settings()
+        assert settings.attachment_download_dir is None
+        assert settings.attachment_download_root == Path(os.path.realpath(Path("~/Downloads").expanduser()))
+
+
+class TestDownloadAttachmentTool:
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self, monkeypatch):
+        from unittest.mock import AsyncMock, patch
+
+        from mcp_email_server.app import download_attachment
+
+        settings = Settings()
+        settings.enable_attachment_download = False
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(PermissionError, match="disabled"):
+                await download_attachment(account_name="a", email_id="1", attachment_name="x.pdf", save_path="x.pdf")
+        handler.download_attachment.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_escaping_path_rejected_before_handler(self, monkeypatch, tmp_path):
+        from unittest.mock import AsyncMock, patch
+
+        from mcp_email_server.app import download_attachment
+
+        settings = Settings()
+        settings.enable_attachment_download = True
+        settings.attachment_download_dir = str(tmp_path)
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(PermissionError, match="outside the permitted download"):
+                await download_attachment(
+                    account_name="a",
+                    email_id="1",
+                    attachment_name="x.pdf",
+                    save_path="/etc/cron.d/evil",
+                )
+        handler.download_attachment.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_confined_path_passed_to_handler(self, monkeypatch, tmp_path):
+        from unittest.mock import AsyncMock, patch
+
+        from mcp_email_server.app import download_attachment
+
+        settings = Settings()
+        settings.enable_attachment_download = True
+        settings.attachment_download_dir = str(tmp_path)
+        handler = AsyncMock()
+        handler.download_attachment.return_value = None
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            await download_attachment(
+                account_name="a", email_id="1", attachment_name="x.pdf", save_path="reports/x.pdf"
+            )
+        passed = handler.download_attachment.call_args.args[2]
+        assert passed == str(Path(os.path.realpath(tmp_path)) / "reports" / "x.pdf")

--- a/tests/test_download_path_confinement.py
+++ b/tests/test_download_path_confinement.py
@@ -38,16 +38,37 @@ class TestResolveDownloadPath:
         with pytest.raises(PermissionError, match="outside the permitted download"):
             _resolve_download_path("../escape.txt", root)
 
-    def test_symlink_escape_rejected(self, tmp_path):
+    def test_intermediate_symlink_escape_rejected(self, tmp_path):
         real = Path(os.path.realpath(tmp_path))
         root = real / "downloads"
         root.mkdir()
         outside = real / "outside"
         outside.mkdir()
-        # A symlink inside root pointing outside must not become a write channel.
+        # A symlink DIR inside root pointing outside must not become a write channel.
         (root / "link").symlink_to(outside)
         with pytest.raises(PermissionError, match="outside the permitted download"):
             _resolve_download_path(str(root / "link" / "pwned.txt"), root)
+
+    def test_final_component_symlink_escape_rejected(self, tmp_path):
+        # Regression: a symlink AT the target path (final component) pointing outside
+        # root previously slipped through because only the parent was canonicalised.
+        real = Path(os.path.realpath(tmp_path))
+        root = real / "downloads"
+        root.mkdir()
+        secret = real / "secret"
+        secret.mkdir()
+        (root / "authorized_keys").symlink_to(secret / "authorized_keys")
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path(str(root / "authorized_keys"), root)
+
+    def test_final_component_symlink_within_root_allowed(self, tmp_path):
+        # A symlink whose target stays inside root is fine; it resolves in-bounds.
+        real = Path(os.path.realpath(tmp_path))
+        root = real / "downloads"
+        (root / "sub").mkdir(parents=True)
+        (root / "alias").symlink_to(root / "sub" / "real.bin")
+        resolved = _resolve_download_path(str(root / "alias"), root)
+        assert resolved == root / "sub" / "real.bin"
 
     def test_symlinked_root_itself_is_canonicalised(self, tmp_path):
         # If the root is reached via a symlink, a save under it still validates.
@@ -57,9 +78,18 @@ class TestResolveDownloadPath:
         result = _resolve_download_path(str(actual / "a.bin"), actual)
         assert result == actual / "a.bin"
 
-    def test_root_itself_allowed(self, tmp_path):
+    def test_root_itself_rejected(self, tmp_path):
+        # save_path must name a file, not the download directory itself (avoids a
+        # later IsADirectoryError on write).
         root = Path(os.path.realpath(tmp_path))
-        assert _resolve_download_path(str(root), root) == root
+        with pytest.raises(PermissionError, match="must name a file"):
+            _resolve_download_path(str(root), root)
+
+    @pytest.mark.parametrize("empty", ["", ".", "./"])
+    def test_empty_or_dot_path_rejected(self, tmp_path, empty):
+        root = Path(os.path.realpath(tmp_path))
+        with pytest.raises(PermissionError, match="must name a file"):
+            _resolve_download_path(empty, root)
 
 
 class TestAttachmentDownloadRootConfig:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,4 +1,6 @@
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -630,18 +632,20 @@ class TestMcpTools:
             assert "Attachment download is disabled" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_download_attachment_enabled(self):
+    async def test_download_attachment_enabled(self, tmp_path):
         """Test download_attachment MCP tool when feature is enabled."""
+        save_target = tmp_path / "document.pdf"
         attachment_response = AttachmentDownloadResponse(
             email_id="12345",
             attachment_name="document.pdf",
             mime_type="application/pdf",
             size=1024,
-            saved_path="/var/downloads/document.pdf",
+            saved_path=str(save_target),
         )
 
         mock_settings = MagicMock()
         mock_settings.enable_attachment_download = True
+        mock_settings.attachment_download_root = Path(os.path.realpath(tmp_path))
 
         mock_handler = AsyncMock()
         mock_handler.download_attachment.return_value = attachment_response
@@ -652,7 +656,7 @@ class TestMcpTools:
                     account_name="test_account",
                     email_id="12345",
                     attachment_name="document.pdf",
-                    save_path="/var/downloads/document.pdf",
+                    save_path=str(save_target),
                 )
 
                 assert result == attachment_response
@@ -662,7 +666,7 @@ class TestMcpTools:
                 assert result.size == 1024
 
                 mock_handler.download_attachment.assert_called_once_with(
-                    "12345", "document.pdf", "/var/downloads/document.pdf", "INBOX"
+                    "12345", "document.pdf", str(Path(os.path.realpath(save_target))), "INBOX"
                 )
 
     @pytest.mark.asyncio

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -6,7 +6,12 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp_email_server import app as app_module
 from mcp_email_server.app import MAX_EMAIL_IDS_PER_CALL, MAX_PAGE_SIZE
 from mcp_email_server.config import EmailServer
-from mcp_email_server.emails.classic import MAX_ATTACHMENT_BYTES, EmailClient
+from mcp_email_server.emails.classic import (
+    MAX_ATTACHMENT_BYTES,
+    MAX_ATTACHMENT_COUNT,
+    MAX_TOTAL_ATTACHMENT_BYTES,
+    EmailClient,
+)
 
 
 class TestToolInputCeilings:
@@ -67,5 +72,39 @@ class TestAttachmentSizeCap:
         ok.write_bytes(b"x" * 16)
         assert email_client._validate_attachment(str(ok)).name == "ok.bin"
 
-    def test_default_cap_is_25_mib(self):
+    def test_default_caps(self):
         assert MAX_ATTACHMENT_BYTES == 25 * 1024 * 1024
+        assert MAX_TOTAL_ATTACHMENT_BYTES == 50 * 1024 * 1024
+        assert MAX_ATTACHMENT_COUNT == 50
+
+
+class TestAggregateAttachmentCaps:
+    def test_too_many_attachments_rejected(self, email_client, tmp_path, monkeypatch):
+        monkeypatch.setattr("mcp_email_server.emails.classic.MAX_ATTACHMENT_COUNT", 3)
+        files = []
+        for i in range(4):
+            f = tmp_path / f"f{i}.bin"
+            f.write_bytes(b"x")
+            files.append(str(f))
+        with pytest.raises(ValueError, match="Too many attachments"):
+            email_client._create_message_with_attachments("body", False, files)
+
+    def test_total_size_over_limit_rejected(self, email_client, tmp_path, monkeypatch):
+        monkeypatch.setattr("mcp_email_server.emails.classic.MAX_TOTAL_ATTACHMENT_BYTES", 1000)
+        files = []
+        for i in range(3):
+            f = tmp_path / f"f{i}.bin"
+            f.write_bytes(b"x" * 600)  # 3 * 600 = 1800 > 1000
+            files.append(str(f))
+        with pytest.raises(ValueError, match="Total attachment size"):
+            email_client._create_message_with_attachments("body", False, files)
+
+    def test_within_aggregate_limits_ok(self, email_client, tmp_path):
+        files = []
+        for i in range(2):
+            f = tmp_path / f"f{i}.bin"
+            f.write_bytes(b"x" * 16)
+            files.append(str(f))
+        msg = email_client._create_message_with_attachments("body", False, files)
+        # text part + 2 attachments
+        assert len(msg.get_payload()) == 3

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,0 +1,71 @@
+"""Resource-exhaustion ceilings: page_size, email_ids batch, attachment size."""
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from mcp_email_server import app as app_module
+from mcp_email_server.app import MAX_EMAIL_IDS_PER_CALL, MAX_PAGE_SIZE
+from mcp_email_server.config import EmailServer
+from mcp_email_server.emails.classic import MAX_ATTACHMENT_BYTES, EmailClient
+
+
+class TestToolInputCeilings:
+    @pytest.mark.asyncio
+    async def test_page_size_over_limit_rejected(self):
+        with pytest.raises(ToolError):
+            await app_module.mcp.call_tool(
+                "list_emails_metadata", {"account_name": "x", "page_size": MAX_PAGE_SIZE + 1}
+            )
+
+    @pytest.mark.asyncio
+    async def test_page_zero_rejected(self):
+        with pytest.raises(ToolError):
+            await app_module.mcp.call_tool("list_emails_metadata", {"account_name": "x", "page": 0})
+
+    @pytest.mark.asyncio
+    async def test_email_ids_over_limit_rejected(self):
+        ids = [str(i) for i in range(MAX_EMAIL_IDS_PER_CALL + 1)]
+        with pytest.raises(ToolError):
+            await app_module.mcp.call_tool("get_emails_content", {"account_name": "x", "email_ids": ids})
+
+    @pytest.mark.asyncio
+    async def test_empty_email_ids_rejected(self):
+        with pytest.raises(ToolError):
+            await app_module.mcp.call_tool("get_emails_content", {"account_name": "x", "email_ids": []})
+
+    @pytest.mark.asyncio
+    async def test_schema_advertises_bounds(self):
+        # The published inputSchema must carry the constraints so clients see them.
+        tools = await app_module.mcp.list_tools()
+        by_name = {t.name: t for t in tools}
+        meta = by_name["list_emails_metadata"].inputSchema["properties"]
+        assert meta["page_size"]["maximum"] == MAX_PAGE_SIZE
+        assert meta["page_size"]["minimum"] == 1
+        assert meta["page"]["minimum"] == 1
+        content = by_name["get_emails_content"].inputSchema["properties"]
+        assert content["email_ids"]["maxItems"] == MAX_EMAIL_IDS_PER_CALL
+        assert content["email_ids"]["minItems"] == 1
+
+
+@pytest.fixture
+def email_client():
+    server = EmailServer(user_name="u", password="p", host="smtp.example.com", port=465, use_ssl=True)
+    return EmailClient(server, sender="Test User <test@example.com>")
+
+
+class TestAttachmentSizeCap:
+    def test_oversize_attachment_rejected(self, email_client, tmp_path, monkeypatch):
+        # Shrink the cap so we don't have to write 25 MB to disk.
+        monkeypatch.setattr("mcp_email_server.emails.classic.MAX_ATTACHMENT_BYTES", 1024)
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"x" * 2048)
+        with pytest.raises(ValueError, match="exceeding the"):
+            email_client._validate_attachment(str(big))
+
+    def test_within_limit_attachment_accepted(self, email_client, tmp_path):
+        ok = tmp_path / "ok.bin"
+        ok.write_bytes(b"x" * 16)
+        assert email_client._validate_attachment(str(ok)).name == "ok.bin"
+
+    def test_default_cap_is_25_mib(self):
+        assert MAX_ATTACHMENT_BYTES == 25 * 1024 * 1024


### PR DESCRIPTION
## What this delivers

Five **security-hardening** fixes to the email tools, plus the docs that describe them. Independent of the permission-scopes PR (#200) at the code level — branched off current `main`.

### Fixes
1. **`download_attachment` path confinement** (`dd47c6e`) — save paths are confined to `attachment_download_dir` (default `~/Downloads`). A `save_path` escaping it via `..` or an absolute path is rejected, so attacker-controlled attachment bytes can't be written over `~/.ssh/authorized_keys`, a crontab, or the config file. New `attachment_download_dir` setting + `MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR`.
2. **CRLF injection rejection** (`e5fd74e`) — reject CR/LF in recipients, header values, and attachment paths. Closes SMTP-envelope injection via `bcc` (passed raw to aiosmtplib, never header-serialized).
3. **HTTP transport unauthenticated warning** (`e718855`) — prominent docs warning that `sse`/`streamable-http` have **no auth**; `Host`/`Origin` validation is anti-DNS-rebinding, not access control. A non-loopback bind publishes an unauthenticated email gateway.
4. **Resource-exhaustion ceilings** (`40efcd1`) — `MAX_PAGE_SIZE=500`, `MAX_EMAIL_IDS_PER_CALL=100`, and attachment-size bounds guard against self-DoS from unbounded tool inputs.
5. **Final-component symlink escape fix** (`3d0a70a`) — `_resolve_download_path` now `realpath`s the *full* candidate (final component included), so a symlink planted at the target path can't redirect the write outside root. Plus adversarial-review gap closures.

## Test plan
- [x] `uv run pytest -q` — **559 passed** (new: `test_download_path_confinement.py`, `test_crlf_injection.py`, `test_resource_limits.py`)
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `prettier --check README.md` — clean
- [x] Verified each guard is wired to its call site (not just defined)

## Note on overlap with #200
The safety **code** is fully independent of #200. The **docs** overlap: #200 moves the HTTP-transport section from README into `docs/installation.md`, while this PR edits that section in README (its current home). Whichever merges second will need a trivial docs rebase — the code merges cleanly either way.

Opened as **draft** for review of the reconciliation (permission-scope enforcement calls were dropped from the cherry-picks since they belong to #200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pd8meRq4jSiqaLq715nSD
