### PR TITLE
docs: reorganize user documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# Repository Overview
+
+`mcp-email-server` is a Python MCP server that connects MCP clients to email
+accounts through IMAP and SMTP.
+
+Primary repository areas:
+
+- `mcp_email_server/app.py` — FastMCP server, resources, tools, and tool visibility.
+- `mcp_email_server/cli.py` — stdio, SSE, Streamable HTTP, UI, reset, and credential migration commands.
+- `mcp_email_server/config.py` — TOML settings, environment composition, account models, and persistence.
+- `mcp_email_server/keyring_store.py` — operating system keyring integration.
+- `mcp_email_server/emails/` — IMAP and SMTP behavior and response models.
+- `mcp_email_server/ui.py` — Gradio account configuration UI.
+- `tests/` — unit and integration-style tests with mocked mail services.
+- `docs/` — user documentation published with MkDocs.
+
+## Project Conventions
+
+- Support Python 3.11 and later.
+- Use `uv` for dependency management and command execution.
+- Follow the existing typed, asynchronous Python style.
+- Prefer explicit types and `isinstance` checks over dynamic attribute checks.
+- Use Pydantic models for configuration and structured responses.
+- Keep MCP-facing descriptions accurate because clients derive tool schemas from them.
+- Preserve the distinction between persistent TOML settings and the environment-composited runtime view.
+- Treat credential storage, allowlists, attachment paths, and HTTP transport settings as security-sensitive behavior.
+- Do not log, document, or commit real email credentials, API keys, message contents, or tokens.
+
+## Development Workflow
+
+Install the environment and pre-commit hooks:
+
+```bash
+make install
+```
+
+Before completing a change, run:
+
+```bash
+make check
+make test
+make docs-test
+```
+
+During development, focused checks are encouraged, but the full relevant suite
+must pass before a change is considered complete.
+
+Useful commands:
+
+| Command                         | Description                                                  |
+| ------------------------------- | ------------------------------------------------------------ |
+| `uv run mcp-email-server stdio` | Run the local stdio MCP server.                              |
+| `uv run mcp-email-server ui`    | Open the account configuration UI.                           |
+| `make check`                    | Run lockfile, formatting, lint, type, and dependency checks. |
+| `make test`                     | Run the test suite with coverage.                            |
+| `make docs-test`                | Build the MkDocs site in strict mode.                        |
+| `make docs`                     | Serve the documentation locally.                             |
+
+## Documentation Requirements
+
+Code and documentation must remain aligned.
+
+- Every code change must include a review and corresponding update of the relevant documentation in the same change.
+- User-visible behavior changes must always update the appropriate page under `docs/`; internal changes must still keep docstrings and developer guidance accurate.
+- Configuration fields or environment variables require updates to `docs/configuration.md` and, when security-sensitive, `docs/security.md`.
+- CLI commands, arguments, transport defaults, or HTTP security behavior require updates to `docs/transports.md`.
+- MCP tool names, parameters, responses, visibility, or workflows require updates to `docs/tools.md`.
+- New special cases and operational caveats belong in `docs/guides.md` or `docs/troubleshooting.md`.
+- Keep `README.md` limited to the quickest supported configuration path and links to the full documentation.
+- Update `CONTRIBUTING.md` when contributor or release workflows change.
+- Run `make docs-test` after changing code or documentation that can affect published docs.
+
+## Testing Expectations
+
+- Add or update tests for every behavior change and regression fix.
+- Keep tests deterministic and independent of live IMAP, SMTP, or keyring services.
+- Cover both successful operations and security or failure boundaries.
+- When changing configuration, test TOML loading, supported environment overrides, persistence, and migration behavior as applicable.
+- When changing MCP tools, test schemas, responses, conditional visibility, and account-specific error paths.
+
+## Repository Change Checklist
+
+Keep related files synchronized:
+
+- Dependency changes: `pyproject.toml` and `uv.lock`.
+- Public configuration changes: implementation, tests, and `docs/configuration.md`.
+- Credential or access-control changes: implementation, tests, `docs/security.md`, and troubleshooting guidance.
+- MCP surface changes: `mcp_email_server/app.py`, tests, and `docs/tools.md`.
+- CLI or transport changes: `mcp_email_server/cli.py`, tests, and `docs/transports.md`.
+- Quick-start changes: `README.md`, `docs/getting-started.md`, and `mkdocs.yml` when navigation changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,10 +90,11 @@ Now you can make your changes locally.
 make check
 ```
 
-8. Validate that all unit tests are passing:
+8. Validate that all unit tests and documentation checks are passing:
 
 ```bash
 make test
+make docs-test
 ```
 
 The CI pipeline runs the test suite against every supported Python version.
@@ -114,5 +115,16 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
 
-2. If the pull request adds functionality, the docs should be updated.
-   Put your new functionality into a function with a docstring, and add the feature to the list in `README.md`.
+2. If the pull request adds or changes user-facing functionality, update the relevant page in `docs/`.
+   Keep `README.md` focused on the quick-start path.
+
+# Releasing a New Version
+
+This section is for project maintainers.
+
+1. Create an API token on [PyPI](https://pypi.org/).
+2. Add it to the repository's GitHub Actions secrets as `PYPI_TOKEN`.
+3. Create a [GitHub release](https://github.com/wh1isper/mcp-email-server/releases/new).
+4. Create a version tag in the form `X.Y.Z` as part of the release.
+
+The release workflow publishes the package associated with the tagged release.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
 # mcp-email-server
 
-[![Release](https://img.shields.io/github/v/release/wh1isper/mcp-email-server)](https://img.shields.io/github/v/release/wh1isper/mcp-email-server)
+[![Release](https://img.shields.io/github/v/release/wh1isper/mcp-email-server)](https://github.com/wh1isper/mcp-email-server/releases)
 [![Build status](https://img.shields.io/github/actions/workflow/status/wh1isper/mcp-email-server/main.yml?branch=main)](https://github.com/wh1isper/mcp-email-server/actions/workflows/main.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/Wh1isper/mcp-email-server/graph/badge.svg?token=0mToRybKx8)](https://codecov.io/gh/Wh1isper/mcp-email-server)
-[![Commit activity](https://img.shields.io/github/commit-activity/m/wh1isper/mcp-email-server)](https://img.shields.io/github/commit-activity/m/wh1isper/mcp-email-server)
-[![License](https://img.shields.io/github/license/wh1isper/mcp-email-server)](https://img.shields.io/github/license/wh1isper/mcp-email-server)
+[![License](https://img.shields.io/github/license/wh1isper/mcp-email-server)](https://github.com/wh1isper/mcp-email-server/blob/main/LICENSE)
 
-IMAP and SMTP via MCP Server
+An MCP server for reading, searching, organizing, and sending email through
+IMAP and SMTP.
 
-- **Github repository**: <https://github.com/wh1isper/mcp-email-server/>
-- **Documentation** <https://mcp-email-server.wh1isper.top/>
+## Quick start
 
-## Installation
+### 1. Configure an email account
 
-### Manual Installation
+Run the configuration UI with [`uv`](https://docs.astral.sh/uv/):
 
-We recommend using [uv](https://github.com/astral-sh/uv) to manage your environment.
+```bash
+uvx mcp-email-server@latest ui
+```
 
-Try `uvx mcp-email-server@latest ui` to config, and use following configuration for mcp client:
+Add your IMAP account in the browser window. SMTP is optional if the account
+does not need to send email.
+
+### 2. Configure the MCP client
+
+Add the following server definition to the MCP client:
 
 ```json
 {
@@ -30,405 +36,31 @@ Try `uvx mcp-email-server@latest ui` to config, and use following configuration 
 }
 ```
 
-This package is available on PyPI, so you can install it using `pip install mcp-email-server`
+Restart the MCP client after updating its configuration.
 
-After that, configure your email server using the ui: `mcp-email-server ui`
+### 3. Verify the connection
 
-### Credential Storage
+Ask the client to list the configured email accounts or recent messages.
 
-Accounts added via the UI or the `add_email_account` tool are persisted to a TOML
-file at `~/.config/mcp-email-server/config.toml`. On first use, an existing
-config from the previous `~/.config/zerolib/mcp_email_server/config.toml`
-location is copied automatically when the new file does not exist. Where the
-actual passwords/API keys live depends on `credential_storage` (also settable via
-`MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`), one of:
+## Other configuration methods
 
-- **`auto`** (default): store credentials in the OS keyring — macOS Keychain,
-  Linux Secret Service (GNOME Keyring / KWallet) — when a usable backend is
-  detected; otherwise fall back to the plaintext TOML file (`0o600`
-  permissions, owner-only). Falls back automatically on headless Linux,
-  containers, or any environment without a D-Bus session.
-- **`keyring`**: require the OS keyring; fail loudly instead of silently
-  falling back if no backend is usable.
-- **`plaintext`**: never touch the keyring. Useful for containers, CI, or if
-  you simply prefer a portable config file.
+For headless environments, containers, multiple accounts, custom TLS settings,
+and environment-variable configuration, see the
+[documentation](https://mcp-email-server.wh1isper.top/).
 
-When credentials are keyring-backed, the TOML file stores only a placeholder
-(`__KEYRING__`) and non-secret metadata — the real secret lives in the OS
-keyring under service `mcp-email-server`, one entry per
-`<account_name>:<incoming|outgoing|api_key>` (viewable in Keychain Access on
-macOS, or Seahorse on Linux).
+## Documentation
 
-**Migrating an existing config** between storage modes:
-
-```sh
-mcp-email-server migrate-credentials --to keyring    # move plaintext secrets into the OS keyring
-mcp-email-server migrate-credentials --to plaintext  # move keyring secrets back into the TOML file
-```
-
-Migration also happens implicitly: any time you add/edit an account while
-`credential_storage` is `auto` or `keyring` with a usable backend, that
-account's secrets move into the keyring on the next save. If
-`MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` is active during a save, its effective
-mode is persisted too, keeping the mode marker consistent with the credential
-representation written to the same file.
-
-#### Failure modes & troubleshooting
-
-- **Server won't start / UI won't load accounts, keychain-related error**: the
-  OS keyring is locked or unreachable. This is expected if credentials are
-  keyring-backed — the secret simply isn't in the config file. Unlock your
-  keychain, or run `mcp-email-server migrate-credentials --to plaintext` if
-  you'd rather not depend on it.
-- **`credential_storage` is 'plaintext' but the config references
-  keyring-stored credentials**: run `migrate-credentials --to plaintext`, or
-  unset `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` / the `credential_storage`
-  setting so the config can resolve them from the keyring instead.
-- **macOS Keychain access prompt, or the server can't read a secret it wrote
-  earlier**: Keychain ACLs are per-application. If the server is spawned via
-  `uvx` (as in the Claude Desktop config above), a fresh `uvx` resolution can
-  present a different binary path than the one that stored the secret,
-  triggering a "Keychain wants to use a password" prompt. Choose "Always
-  Allow" the first time this happens.
-- **A migration seems to have had no effect**: if
-  `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` is set in your environment, it takes
-  precedence over whatever `migrate-credentials --to ...` just wrote to the
-  file on every subsequent run. Unset it, or keep it in sync with your
-  intended mode.
-
-#### Known limitations
-
-- **Non-POSIX (Windows) file permissions**: the `0o600` owner-only guarantee on
-  the plaintext TOML is enforced only on POSIX systems. On Windows the file is
-  written without an owner-restricted ACL, so prefer `keyring` mode (Windows
-  Credential Locker) there when secrets must not be readable by other accounts.
-- **`auto`/`keyring` trusts whatever `keyring` backend is active**: usability is
-  decided by a live set/get round-trip, not by the backend's storage guarantees.
-  A third-party `keyring` plugin that persists secrets in plaintext would pass
-  that probe. If you install custom `keyring` backends, verify the active one
-  (`keyring --list-backends`) stores secrets securely.
-- **Keyring and TOML writes are not transactional**: a save pushes secrets to
-  the keyring and then rewrites the TOML. The TOML rewrite is atomic on its own
-  (temp file + `os.replace`), but a crash _between_ the two steps can leave a
-  keyring entry with no matching config reference (an orphaned secret), or a
-  config reference whose keyring write partly failed. A plaintext migration
-  reports keyring entries it could not remove so you can clean them up manually.
-
-### Environment Variable Configuration
-
-You can also configure the email server using environment variables, which is particularly useful for CI/CD environments like Jenkins. mcp-email-server supports both UI configuration (via TOML file) and environment variables, with environment variables taking precedence.
-
-```json
-{
-  "mcpServers": {
-    "mcp-email-server": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_ACCOUNT_NAME": "work",
-        "MCP_EMAIL_SERVER_FULL_NAME": "John Doe",
-        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
-        "MCP_EMAIL_SERVER_USER_NAME": "john@example.com",
-        "MCP_EMAIL_SERVER_PASSWORD": "your_password",
-        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.gmail.com",
-        "MCP_EMAIL_SERVER_IMAP_PORT": "993",
-        "MCP_EMAIL_SERVER_SMTP_HOST": "smtp.gmail.com",
-        "MCP_EMAIL_SERVER_SMTP_PORT": "465"
-      }
-    }
-  }
-}
-```
-
-#### Available Environment Variables
-
-| Variable                                      | Description                                                  | Default       | Required |
-| --------------------------------------------- | ------------------------------------------------------------ | ------------- | -------- |
-| `MCP_EMAIL_SERVER_ACCOUNT_NAME`               | Account identifier                                           | `"default"`   | No       |
-| `MCP_EMAIL_SERVER_FULL_NAME`                  | Display name                                                 | Email prefix  | No       |
-| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`              | Email address                                                | -             | Yes      |
-| `MCP_EMAIL_SERVER_USER_NAME`                  | Login username                                               | Same as email | No       |
-| `MCP_EMAIL_SERVER_PASSWORD`                   | Email password                                               | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_HOST`                  | IMAP server host                                             | -             | Yes      |
-| `MCP_EMAIL_SERVER_IMAP_PORT`                  | IMAP server port                                             | `993`         | No       |
-| `MCP_EMAIL_SERVER_IMAP_SSL`                   | Enable IMAP SSL                                              | `true`        | No       |
-| `MCP_EMAIL_SERVER_IMAP_START_SSL`             | Enable IMAP STARTTLS                                         | `false`       | No       |
-| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`            | Verify IMAP SSL certificates (disable for self-signed)       | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_HOST`                  | SMTP server host; omit for IMAP-only mode (no sending)       | -             | No       |
-| `MCP_EMAIL_SERVER_SMTP_PORT`                  | SMTP server port                                             | `465`         | No       |
-| `MCP_EMAIL_SERVER_SMTP_SSL`                   | Enable SMTP SSL                                              | `true`        | No       |
-| `MCP_EMAIL_SERVER_SMTP_START_SSL`             | Enable STARTTLS                                              | `false`       | No       |
-| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`            | Verify SSL certificates (disable for self-signed)            | `true`        | No       |
-| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | Enable attachment download                                   | `false`       | No       |
-| `MCP_EMAIL_SERVER_SAVE_TO_SENT`               | Save sent emails to IMAP Sent folder                         | `true`        | No       |
-| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME`           | Custom Sent folder name (auto-detect if not set)             | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Recipient allowlist (comma-separated); empty = all           | -             | No       |
-| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Sender allowlist (comma-separated globs); empty = all        | -             | No       |
-| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | Report blocked mutations as failures (default: silent no-op) | `false`       | No       |
-| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | Credential storage mode: `auto`, `keyring`, or `plaintext`   | `auto`        | No       |
-
-### IMAP-only mode (no SMTP)
-
-SMTP configuration is optional. When `MCP_EMAIL_SERVER_SMTP_HOST` is omitted, the account runs in IMAP-only mode: `send_email` is hidden (when every configured email account lacks SMTP) and no mail can leave the server. Note that IMAP-only is not strictly read-only — IMAP-backed write tools such as `save_to_mailbox` (which composes a message and stores it in a folder via IMAP APPEND), `delete_emails`, `move_emails`, and `archive_emails` remain available.
-
-```json
-{
-  "mcpServers": {
-    "mcp-email-server": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
-        "MCP_EMAIL_SERVER_PASSWORD": "your_password",
-        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.gmail.com"
-      }
-    }
-  }
-}
-```
-
-### HTTP Transport Security
-
-HTTP transports (`sse` and `streamable-http`) validate request `Host` and `Origin` headers to protect against DNS rebinding attacks. Localhost is allowed by default. For container networks or reverse proxies, configure the expected service names explicitly.
-
-| Variable                              | Description                                                      | Default           |
-| ------------------------------------- | ---------------------------------------------------------------- | ----------------- |
-| `MCP_HOST`                            | HTTP bind host for `streamable-http`                             | `localhost`       |
-| `MCP_PORT`                            | HTTP bind port for `streamable-http`                             | `9557`            |
-| `MCP_ALLOWED_HOSTS`                   | Comma-separated allowed `Host` values. Supports `host:*` ports   | Localhost hosts   |
-| `MCP_ALLOWED_ORIGINS`                 | Comma-separated allowed `Origin` values. Supports `host:*` ports | Localhost origins |
-| `MCP_ENABLE_DNS_REBINDING_PROTECTION` | Enable DNS rebinding protection                                  | `true`            |
-
-Bare host entries such as `MCP_ALLOWED_HOSTS=mcp-email-server` also allow any port on that host. `MCP_ENABLE_DNS_REBINDING_PROTECTION=false`, `MCP_ALLOWED_HOSTS=*`, or `MCP_ALLOWED_ORIGINS=*` disables Host and Origin validation entirely. Use those options only in isolated local development environments.
-
-IPv6 literals in allowlists should use bracketed notation, such as `[::1]:*` and `http://[::1]:*`.
-
-### Enabling Attachment Downloads
-
-By default, downloading email attachments is disabled for security reasons. To enable this feature, you can either:
-
-**Option 1: Environment Variable**
-
-```json
-{
-  "mcpServers": {
-    "mcp-email-server": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD": "true"
-      }
-    }
-  }
-}
-```
-
-**Option 2: TOML Configuration**
-
-Add `enable_attachment_download = true` to your TOML configuration file (`~/.config/mcp-email-server/config.toml`):
-
-```toml
-enable_attachment_download = true
-
-[[emails]]
-# ... your email configuration
-```
-
-Once enabled, you can use the `download_attachment` tool to save email attachments to a specified path.
-
-### Saving Sent Emails to IMAP Sent Folder
-
-By default, sent emails are automatically saved to your IMAP Sent folder. This ensures that emails sent via the MCP server appear in your email client (Thunderbird, webmail, etc.).
-
-The server auto-detects common Sent folder names: `Sent`, `INBOX.Sent`, `Sent Items`, `Sent Mail`, `[Gmail]/Sent Mail`.
-
-**To specify a custom Sent folder name** (useful for providers with non-standard folder names):
-
-**Option 1: Environment Variable**
-
-```json
-{
-  "mcpServers": {
-    "mcp-email-server": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_SENT_FOLDER_NAME": "INBOX.Sent"
-      }
-    }
-  }
-}
-```
-
-**Option 2: TOML Configuration**
-
-```toml
-[[emails]]
-account_name = "work"
-save_to_sent = true
-sent_folder_name = "INBOX.Sent"
-# ... rest of your email configuration
-```
-
-**To disable saving to Sent folder**, set `MCP_EMAIL_SERVER_SAVE_TO_SENT=false` or `save_to_sent = false` in your TOML config.
-
-### Restricting Recipients (Allowlist)
-
-By default the server can send to any address. Set `allowed_recipients` to restrict **both**
-`send_email` and `save_to_mailbox` to a trusted set. Leave it empty (the default) to allow all.
-
-```toml
-allowed_recipients = ["alice@example.com", "bob@example.com"]
-```
-
-Or via environment variable (comma-separated):
-
-```
-MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS="alice@example.com,bob@example.com"
-```
-
-When configured, any To/CC/BCC address not on the list is rejected with a clear error. Matching is
-case-insensitive and understands the `Name <addr@example.com>` form. The `list_allowed_recipients`
-tool appears only when an allowlist is configured, so default installs keep a minimal tool surface.
-
-### Filtering Incoming Mail (Sender Allowlist)
-
-By default all senders are visible. Set `allowed_senders` to show mail only from trusted senders.
-Patterns support globs (e.g. `*@company.com`) and exact addresses, matched case-insensitively. Leave
-it empty (the default) to show everything.
-
-```toml
-allowed_senders = ["*@company.com", "alice@example.com"]
-```
-
-Or via environment variable (comma-separated):
-
-```
-MCP_EMAIL_SERVER_ALLOWED_SENDERS="*@company.com,alice@example.com"
-```
-
-When configured, filtering is applied to inbound read and mutation paths: `list_emails_metadata` excludes
-non-allowed senders **before** pagination, so `total` and page sizes reflect only allowed mail;
-`get_emails_content` and `download_attachment` check the sender before reading a message, so a non-allowed
-message's body and attachments are never fetched or marked read, and it is reported as inaccessible —
-indistinguishable from a missing message. Mutation tools first check the sender and never delete, flag, or
-move blocked mail. The `list_allowed_senders` tool appears only when an allowlist is configured.
-
-**Scope:** the allowlist protects every inbound path — read (`list_emails_metadata`, `get_emails_content`,
-`download_attachment`) and mutation (`delete_emails`, `mark_emails_as_read`, `move_emails`,
-`archive_emails`). A blocked sender's mail is never read, deleted, flagged, or moved.
-
-**Blocked mutations (`report_blocked_mutations`, default `false`):** when a mutation targets a blocked
-sender's message, it is never performed. By default the result is reported as a successful no-op —
-indistinguishable from acting on a non-existent message, so the allowlist does not reveal that a hidden
-message exists. Set `report_blocked_mutations = true` (or `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS=true`)
-to instead report blocked UIDs as failures (explicit, but reveals a blocked-but-real message differs from
-a missing one).
-
-**Note:** matching is against the message's `From` header — local filtering only, not sender
-authentication. A spoofed `From` will pass the allowlist, so this is not a substitute for provider-side
-SPF / DKIM / DMARC enforcement.
-
-### Self-Signed Certificates and IMAP STARTTLS (e.g., ProtonMail Bridge)
-
-Local mail bridges such as ProtonMail Bridge commonly use STARTTLS with self-signed certificates. Configure IMAP with plaintext connect plus STARTTLS upgrade, and disable certificate verification for the local bridge certificate:
-
-```json
-{
-  "mcpServers": {
-    "mcp-email-server": {
-      "command": "uvx",
-      "args": ["mcp-email-server@latest", "stdio"],
-      "env": {
-        "MCP_EMAIL_SERVER_IMAP_HOST": "127.0.0.1",
-        "MCP_EMAIL_SERVER_IMAP_PORT": "1143",
-        "MCP_EMAIL_SERVER_IMAP_SSL": "false",
-        "MCP_EMAIL_SERVER_IMAP_START_SSL": "true",
-        "MCP_EMAIL_SERVER_IMAP_VERIFY_SSL": "false",
-        "MCP_EMAIL_SERVER_SMTP_VERIFY_SSL": "false"
-      }
-    }
-  }
-}
-```
-
-Or in TOML configuration:
-
-```toml
-[[emails]]
-account_name = "protonmail"
-# ... other settings ...
-
-[emails.incoming]
-host = "127.0.0.1"
-port = 1143
-use_ssl = false
-start_ssl = true
-verify_ssl = false
-
-[emails.outgoing]
-verify_ssl = false
-```
-
-For separate IMAP/SMTP credentials, you can also use:
-
-- `MCP_EMAIL_SERVER_IMAP_USER_NAME` / `MCP_EMAIL_SERVER_IMAP_PASSWORD`
-- `MCP_EMAIL_SERVER_SMTP_USER_NAME` / `MCP_EMAIL_SERVER_SMTP_PASSWORD`
-
-Then you can try it in [Claude Desktop](https://claude.ai/download). If you want to intergrate it with other mcp client, run `$which mcp-email-server` for the path and configure it in your client like:
-
-```json
-{
-  "mcpServers": {
-    "mcp-email-server": {
-      "command": "{{ ENTRYPOINT }}",
-      "args": ["stdio"]
-    }
-  }
-}
-```
-
-## Usage
-
-### Replying to Emails
-
-To reply to an email with proper threading (so it appears in the same conversation in email clients):
-
-1. First, fetch the original email to get its `message_id`:
-
-```python
-emails = await get_emails_content(account_name="work", email_ids=["123"])
-original = emails.emails[0]
-```
-
-2. Send your reply using `in_reply_to` and `references`:
-
-```python
-await send_email(
-    account_name="work",
-    recipients=[original.sender],
-    subject=f"Re: {original.subject}",
-    body="Thank you for your email...",
-    in_reply_to=original.message_id,
-    references=original.message_id,
-)
-```
-
-The `in_reply_to` parameter sets the `In-Reply-To` header, and `references` sets the `References` header. Both are used by email clients to thread conversations properly.
+- [Getting Started](https://mcp-email-server.wh1isper.top/getting-started/)
+- [Configuration](https://mcp-email-server.wh1isper.top/configuration/)
+- [MCP Tools](https://mcp-email-server.wh1isper.top/tools/)
+- [Transports](https://mcp-email-server.wh1isper.top/transports/)
+- [Security](https://mcp-email-server.wh1isper.top/security/)
+- [Troubleshooting](https://mcp-email-server.wh1isper.top/troubleshooting/)
 
 ## Development
 
-This project is managed using [uv](https://github.com/astral-sh/uv).
+See [CONTRIBUTING.md](https://github.com/wh1isper/mcp-email-server/blob/main/CONTRIBUTING.md).
 
-Try `make install` to install the virtual environment and install the pre-commit hooks.
+## License
 
-Use `uv run mcp-email-server` for local development.
-
-## Releasing a new version
-
-- Create an API Token on [PyPI](https://pypi.org/).
-- Add the API Token to your projects secrets with the name `PYPI_TOKEN` by visiting [this page](https://github.com/wh1isper/mcp-email-server/settings/secrets/actions/new).
-- Create a [new release](https://github.com/wh1isper/mcp-email-server/releases/new) on Github.
-- Create a new tag in the form `*.*.*`.
-
-For more details, see [here](https://fpgmaas.github.io/cookiecutter-uv/features/cicd/#how-to-trigger-a-release).
+This project is licensed under the terms of the [LICENSE](https://github.com/wh1isper/mcp-email-server/blob/main/LICENSE).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,267 @@
+# Configuration
+
+mcp-email-server loads persistent settings from a TOML file and can compose an
+additional account and global overrides from environment variables.
+
+## Configuration file
+
+The default path is:
+
+```text
+~/.config/mcp-email-server/config.toml
+```
+
+Set `MCP_EMAIL_SERVER_CONFIG_PATH` to use a different path. Relative paths are
+resolved against the server process's working directory.
+
+On first use, if the current file does not exist and a legacy file exists at
+`~/.config/zerolib/mcp_email_server/config.toml`, the legacy file is copied to
+the current location automatically.
+
+## Configuration precedence
+
+The TOML file provides the base settings. Environment variables are then
+applied as follows:
+
+- Global boolean and allowlist environment variables override the matching TOML
+  values.
+- `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` overrides the TOML storage mode.
+- A complete environment-provided email account replaces a TOML account with
+  the same `account_name`.
+- If no TOML account has that name, the environment-provided account is added
+  before the TOML accounts.
+
+An environment account is created only when `MCP_EMAIL_SERVER_EMAIL_ADDRESS`,
+`MCP_EMAIL_SERVER_PASSWORD`, and `MCP_EMAIL_SERVER_IMAP_HOST` are all present.
+The generic password remains required even when separate IMAP or SMTP password
+variables are provided.
+
+`migrate-credentials` is intentionally different: it migrates only the stored
+TOML configuration and ignores environment-provided accounts and overrides.
+
+Saving from the UI or `add_email_account` serializes the current runtime
+settings. If that process also contains an environment-provided account or
+global overrides, those effective values can be persisted to TOML or the
+keyring. Avoid mixing mutable UI/tool configuration with secret-bearing
+environment overrides unless that persistence is intended.
+
+`credential_storage` controls only how persistent settings are written. It does
+not protect passwords stored in an MCP client configuration, process
+environment, CI definition, or container metadata. Prefer the platform's secret
+injection mechanism and restrict access to any file containing literal values.
+
+## TOML example
+
+The following example contains all commonly used account fields:
+
+```toml
+credential_storage = "auto"
+enable_attachment_download = false
+allowed_recipients = []
+allowed_senders = []
+report_blocked_mutations = false
+
+[[emails]]
+account_name = "work"
+description = "Work mailbox"
+full_name = "John Doe"
+email_address = "john@example.com"
+save_to_sent = true
+sent_folder_name = "Sent"
+
+[emails.incoming]
+user_name = "john@example.com"
+password = "your-password"
+host = "imap.example.com"
+port = 993
+use_ssl = true
+start_ssl = false
+verify_ssl = true
+
+[emails.outgoing]
+user_name = "john@example.com"
+password = "your-password"
+host = "smtp.example.com"
+port = 465
+use_ssl = true
+start_ssl = false
+verify_ssl = true
+```
+
+`description`, `save_to_sent`, and `sent_folder_name` are optional. Remove the
+entire `[emails.outgoing]` table for an IMAP-only account.
+
+When credentials are stored in the operating system keyring, password values in
+this file are replaced by the reserved `__KEYRING__` marker. Do not enter that
+value as a real password. See [Credential storage](security.md#credential-storage).
+
+## Multiple accounts
+
+Add one `[[emails]]` entry per account:
+
+```toml
+[[emails]]
+account_name = "personal"
+full_name = "John Doe"
+email_address = "john@example.com"
+
+[emails.incoming]
+user_name = "john@example.com"
+password = "personal-password"
+host = "imap.example.com"
+port = 993
+use_ssl = true
+start_ssl = false
+verify_ssl = true
+
+[[emails]]
+account_name = "work"
+full_name = "John Doe"
+email_address = "john@company.example"
+
+[emails.incoming]
+user_name = "john@company.example"
+password = "work-password"
+host = "imap.company.example"
+port = 993
+use_ssl = true
+start_ssl = false
+verify_ssl = true
+```
+
+Every `account_name` must be unique across the configuration. MCP tools use this
+name to select an account.
+
+The environment variable interface describes one account. Use TOML or the UI
+when persistent configuration requires multiple accounts.
+
+## TLS modes
+
+Each IMAP or SMTP server has three related fields:
+
+| Mode                       | `use_ssl` | `start_ssl` | Typical port                            |
+| -------------------------- | --------- | ----------- | --------------------------------------- |
+| Implicit TLS               | `true`    | `false`     | IMAP 993, SMTP 465                      |
+| STARTTLS                   | `false`   | `true`      | IMAP 143, SMTP 587                      |
+| Plain connection, insecure | `false`   | `false`     | Trusted local or isolated networks only |
+
+Do not enable both implicit TLS and STARTTLS for the same server. Keep
+`verify_ssl = true` unless connecting to a trusted local service with a
+self-signed certificate.
+
+Without implicit TLS or STARTTLS, credentials and message content can travel in
+plaintext, and `verify_ssl` has no effect. Do not use a plain connection to a
+remote mail service. Limit it to a trusted local bridge, an encrypted tunnel,
+or an otherwise isolated network.
+
+## IMAP-only accounts
+
+SMTP configuration is optional. When every configured account omits SMTP,
+`send_email` is hidden from the MCP tool list.
+
+IMAP-only does not mean read-only. These tools can still change mailbox state:
+
+- `save_to_mailbox`
+- `mark_emails_as_read`
+- `move_emails`
+- `archive_emails`
+- `delete_emails`
+
+See [IMAP-only accounts](guides.md#imap-only-accounts) for examples.
+
+## Saving sent email
+
+After SMTP delivery, `save_to_sent = true` asks the server to append the sent
+message to an IMAP Sent folder. This is enabled by default.
+
+The server attempts to detect common folders, including:
+
+- `Sent`
+- `INBOX.Sent`
+- `Sent Items`
+- `Sent Mail`
+- `[Gmail]/Sent Mail`
+
+Set a custom folder when auto-detection is not suitable:
+
+```toml
+[[emails]]
+account_name = "work"
+save_to_sent = true
+sent_folder_name = "INBOX.Sent"
+```
+
+Set `save_to_sent = false` to disable the IMAP append after sending. The
+environment equivalents are `MCP_EMAIL_SERVER_SAVE_TO_SENT` and
+`MCP_EMAIL_SERVER_SENT_FOLDER_NAME`.
+
+## Global settings
+
+| Setting                      | Default  | Description                                                                |
+| ---------------------------- | -------- | -------------------------------------------------------------------------- |
+| `credential_storage`         | `"auto"` | Select `auto`, `keyring`, or `plaintext` credential storage.               |
+| `enable_attachment_download` | `false`  | Allow `download_attachment` to write files.                                |
+| `allowed_recipients`         | `[]`     | Restrict recipients used by `send_email` and `save_to_mailbox`.            |
+| `allowed_senders`            | `[]`     | Restrict incoming messages by `From` address pattern.                      |
+| `report_blocked_mutations`   | `false`  | Report blocked message IDs instead of returning privacy-preserving no-ops. |
+
+See [Security](security.md) before enabling attachment downloads or applying
+allowlists.
+
+## Environment variable reference
+
+### Account variables
+
+| Variable                            | Default          | Required | Description                                               |
+| ----------------------------------- | ---------------- | -------- | --------------------------------------------------------- |
+| `MCP_EMAIL_SERVER_ACCOUNT_NAME`     | `default`        | No       | Account identifier used by MCP tools.                     |
+| `MCP_EMAIL_SERVER_FULL_NAME`        | Email local part | No       | Display name used in outgoing messages.                   |
+| `MCP_EMAIL_SERVER_EMAIL_ADDRESS`    | None             | Yes      | Account email address.                                    |
+| `MCP_EMAIL_SERVER_USER_NAME`        | Email address    | No       | Shared IMAP and SMTP username.                            |
+| `MCP_EMAIL_SERVER_PASSWORD`         | None             | Yes      | Shared password and required environment-account trigger. |
+| `MCP_EMAIL_SERVER_IMAP_HOST`        | None             | Yes      | IMAP server host.                                         |
+| `MCP_EMAIL_SERVER_IMAP_PORT`        | `993`            | No       | IMAP server port.                                         |
+| `MCP_EMAIL_SERVER_IMAP_SSL`         | `true`           | No       | Use implicit TLS for IMAP.                                |
+| `MCP_EMAIL_SERVER_IMAP_START_SSL`   | `false`          | No       | Upgrade the IMAP connection with STARTTLS.                |
+| `MCP_EMAIL_SERVER_IMAP_VERIFY_SSL`  | `true`           | No       | Verify the IMAP TLS certificate.                          |
+| `MCP_EMAIL_SERVER_IMAP_USER_NAME`   | Shared username  | No       | IMAP-specific username.                                   |
+| `MCP_EMAIL_SERVER_IMAP_PASSWORD`    | Shared password  | No       | IMAP-specific password.                                   |
+| `MCP_EMAIL_SERVER_SMTP_HOST`        | None             | No       | SMTP server host; enables sending when present.           |
+| `MCP_EMAIL_SERVER_SMTP_PORT`        | `465`            | No       | SMTP server port.                                         |
+| `MCP_EMAIL_SERVER_SMTP_SSL`         | `true`           | No       | Use implicit TLS for SMTP.                                |
+| `MCP_EMAIL_SERVER_SMTP_START_SSL`   | `false`          | No       | Upgrade the SMTP connection with STARTTLS.                |
+| `MCP_EMAIL_SERVER_SMTP_VERIFY_SSL`  | `true`           | No       | Verify the SMTP TLS certificate.                          |
+| `MCP_EMAIL_SERVER_SMTP_USER_NAME`   | Shared username  | No       | SMTP-specific username.                                   |
+| `MCP_EMAIL_SERVER_SMTP_PASSWORD`    | Shared password  | No       | SMTP-specific password.                                   |
+| `MCP_EMAIL_SERVER_SAVE_TO_SENT`     | `true`           | No       | Append sent messages to an IMAP Sent folder.              |
+| `MCP_EMAIL_SERVER_SENT_FOLDER_NAME` | Auto-detected    | No       | Override the Sent folder name.                            |
+
+Boolean values accept `true`, `1`, `yes`, or `on` as true, ignoring case. Other
+values are treated as false. Do not add surrounding whitespace to these values.
+
+### Global variables
+
+| Variable                                      | Default                                  | Description                                                               |
+| --------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
+| `MCP_EMAIL_SERVER_CONFIG_PATH`                | `~/.config/mcp-email-server/config.toml` | Use a custom TOML path.                                                   |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | `false`                                  | Override attachment download access.                                      |
+| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Empty                                    | Comma-separated recipient addresses; an empty value clears the TOML list. |
+| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Empty                                    | Comma-separated sender globs; an empty value clears the TOML list.        |
+| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | `false`                                  | Override blocked mutation reporting.                                      |
+| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | TOML value or `auto`                     | Override credential storage with `auto`, `keyring`, or `plaintext`.       |
+| `MCP_EMAIL_SERVER_LOG_LEVEL`                  | `INFO`                                   | Set the Loguru logging level, such as `DEBUG` or `WARNING`.               |
+
+HTTP transport variables are documented separately in
+[Transports](transports.md#streamable-http).
+
+## Reset configuration
+
+Delete the configuration file and perform best-effort cleanup of referenced
+keyring entries with:
+
+```bash
+mcp-email-server reset
+```
+
+This operation removes all persistently configured accounts. Environment-based
+configuration remains effective as long as its variables are present.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,155 @@
+# Getting Started
+
+This guide configures one email account and connects it to an MCP client over
+stdio. See [Configuration](configuration.md) for headless environments,
+multiple accounts, and advanced email server settings.
+
+## Requirements
+
+- Python 3.11 or later.
+- IMAP credentials for the email account.
+- SMTP credentials if the account must send email.
+- An MCP-compatible client.
+
+[`uv`](https://docs.astral.sh/uv/) is recommended because `uvx` can run the
+latest package without a permanent installation.
+
+## Configure an account with the UI
+
+Run:
+
+```bash
+uvx mcp-email-server@latest ui
+```
+
+The command opens a local configuration interface in the browser. Add an email
+account with the following information:
+
+- A unique account name used by MCP tools, such as `work`.
+- The display name and email address.
+- IMAP host, port, username, and password.
+- Optional SMTP host, port, username, and password.
+
+Leave the SMTP host empty to create an IMAP-only account. IMAP-only accounts can
+still modify mailboxes; see [IMAP-only accounts](guides.md#imap-only-accounts).
+
+The UI covers common implicit-TLS IMAP and SMTP configurations. Use TOML or
+environment variables for advanced settings such as IMAP STARTTLS, custom
+certificate verification, allowlists, or a custom Sent mailbox.
+
+By default, settings are stored at:
+
+```text
+~/.config/mcp-email-server/config.toml
+```
+
+Credentials use the operating system keyring when a usable backend is
+available. See [Credential storage](security.md#credential-storage).
+
+## Configure the MCP client
+
+Add this server definition to the MCP client:
+
+```json
+{
+  "mcpServers": {
+    "mcp-email-server": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"]
+    }
+  }
+}
+```
+
+Restart the client after changing its configuration.
+
+The UI also includes an installer for Claude Desktop on supported desktop
+platforms. The explicit JSON configuration above works with Claude Desktop and
+other clients that use the same `mcpServers` format.
+
+## Verify the connection
+
+After restarting the client:
+
+1. Ask it to list available email accounts. This calls
+   `list_available_accounts`.
+2. Ask it to list recent messages for the configured account. This calls
+   `list_emails_metadata`.
+3. If SMTP is configured, ask which email tools are available and confirm that
+   `send_email` is present.
+
+If the account is listed but a mail operation fails, check the IMAP or SMTP
+host, port, TLS mode, username, and password. See
+[Troubleshooting](troubleshooting.md) for common failures.
+
+## Install the package permanently
+
+Instead of `uvx`, install the package into a managed environment:
+
+```bash
+pip install mcp-email-server
+mcp-email-server ui
+```
+
+Then configure the client to invoke the installed executable:
+
+```json
+{
+  "mcpServers": {
+    "mcp-email-server": {
+      "command": "mcp-email-server",
+      "args": ["stdio"]
+    }
+  }
+}
+```
+
+If the executable is not on the client's `PATH`, replace
+`mcp-email-server` with the absolute path returned by:
+
+```bash
+which mcp-email-server
+```
+
+On Windows, use `where mcp-email-server` instead.
+
+## Configure without the UI
+
+For containers, CI, and headless systems, pass account settings as environment
+variables in the MCP server definition. A minimal IMAP account looks like this:
+
+```json
+{
+  "mcpServers": {
+    "mcp-email-server": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_ACCOUNT_NAME": "work",
+        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
+        "MCP_EMAIL_SERVER_PASSWORD": "your-password",
+        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.example.com"
+      }
+    }
+  }
+}
+```
+
+Add `MCP_EMAIL_SERVER_SMTP_HOST` to enable sending. See the complete
+[environment variable reference](configuration.md#environment-variable-reference)
+before deploying credentials this way.
+
+The password in this example remains plaintext in the MCP client configuration
+and process environment; `credential_storage` does not protect it. Prefer the
+client, CI, or container platform's secret injection mechanism. If a literal
+value is unavoidable, restrict the configuration file's permissions and keep
+it out of version control and diagnostic output. Do not use the UI or
+`add_email_account` in the same secret-bearing process unless persisting the
+effective environment settings is intended.
+
+## Next steps
+
+- [Configure multiple accounts or advanced TLS settings](configuration.md)
+- [Review the available MCP tools](tools.md)
+- [Apply recipient or sender allowlists](security.md)
+- [Run an HTTP transport](transports.md)

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,0 +1,238 @@
+# Guides
+
+These examples cover common configurations that need more control than the
+basic UI provides.
+
+## IMAP-only accounts
+
+Remove SMTP configuration when an account must not send email:
+
+```toml
+[[emails]]
+account_name = "archive"
+full_name = "Archive Reader"
+email_address = "archive@example.com"
+
+[emails.incoming]
+user_name = "archive@example.com"
+password = "your-password"
+host = "imap.example.com"
+port = 993
+use_ssl = true
+start_ssl = false
+verify_ssl = true
+```
+
+Or configure one through environment variables without
+`MCP_EMAIL_SERVER_SMTP_HOST`:
+
+```json
+{
+  "mcpServers": {
+    "mcp-email-server": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_ACCOUNT_NAME": "archive",
+        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "archive@example.com",
+        "MCP_EMAIL_SERVER_PASSWORD": "your-password",
+        "MCP_EMAIL_SERVER_IMAP_HOST": "imap.example.com"
+      }
+    }
+  }
+}
+```
+
+If no configured account has SMTP, `send_email` is omitted from the MCP tool
+list. IMAP mutation tools remain available, so this is not a strict read-only
+mode. To limit mutations, also constrain which MCP tools the client may call or
+run the server with an account whose provider permissions are read-only.
+
+## ProtonMail Bridge and self-signed TLS
+
+Local bridges commonly expose IMAP through STARTTLS with a locally issued
+certificate. A typical environment configuration is:
+
+```json
+{
+  "mcpServers": {
+    "mcp-email-server": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"],
+      "env": {
+        "MCP_EMAIL_SERVER_ACCOUNT_NAME": "protonmail",
+        "MCP_EMAIL_SERVER_EMAIL_ADDRESS": "john@example.com",
+        "MCP_EMAIL_SERVER_PASSWORD": "bridge-password",
+        "MCP_EMAIL_SERVER_IMAP_HOST": "127.0.0.1",
+        "MCP_EMAIL_SERVER_IMAP_PORT": "1143",
+        "MCP_EMAIL_SERVER_IMAP_SSL": "false",
+        "MCP_EMAIL_SERVER_IMAP_START_SSL": "true",
+        "MCP_EMAIL_SERVER_IMAP_VERIFY_SSL": "false",
+        "MCP_EMAIL_SERVER_SMTP_HOST": "127.0.0.1",
+        "MCP_EMAIL_SERVER_SMTP_PORT": "1025",
+        "MCP_EMAIL_SERVER_SMTP_SSL": "false",
+        "MCP_EMAIL_SERVER_SMTP_START_SSL": "true",
+        "MCP_EMAIL_SERVER_SMTP_VERIFY_SSL": "false"
+      }
+    }
+  }
+}
+```
+
+Equivalent TOML:
+
+```toml
+[[emails]]
+account_name = "protonmail"
+full_name = "John Doe"
+email_address = "john@example.com"
+
+[emails.incoming]
+user_name = "bridge-username"
+password = "bridge-password"
+host = "127.0.0.1"
+port = 1143
+use_ssl = false
+start_ssl = true
+verify_ssl = false
+
+[emails.outgoing]
+user_name = "bridge-username"
+password = "bridge-password"
+host = "127.0.0.1"
+port = 1025
+use_ssl = false
+start_ssl = true
+verify_ssl = false
+```
+
+Use the exact credentials and ports shown by the local bridge. Disable
+certificate verification only for a bridge running on a trusted local endpoint.
+
+## Separate IMAP and SMTP credentials
+
+Some providers or bridges issue separate credentials. With environment
+variables, keep the required shared password and override each protocol:
+
+```bash
+MCP_EMAIL_SERVER_EMAIL_ADDRESS='john@example.com'
+MCP_EMAIL_SERVER_USER_NAME='john@example.com'
+MCP_EMAIL_SERVER_PASSWORD='required-shared-fallback'
+MCP_EMAIL_SERVER_IMAP_USER_NAME='imap-user'
+MCP_EMAIL_SERVER_IMAP_PASSWORD='imap-password'
+MCP_EMAIL_SERVER_IMAP_HOST='imap.example.com'
+MCP_EMAIL_SERVER_SMTP_USER_NAME='smtp-user'
+MCP_EMAIL_SERVER_SMTP_PASSWORD='smtp-password'
+MCP_EMAIL_SERVER_SMTP_HOST='smtp.example.com'
+```
+
+The generic `MCP_EMAIL_SERVER_PASSWORD` currently remains required to create an
+environment-provided account, even when both protocol-specific passwords are
+set.
+
+In TOML, set `user_name` and `password` independently in the incoming and
+outgoing tables.
+
+## Save messages to a custom Sent folder
+
+If Sent folder auto-detection does not select the provider's folder, set it
+explicitly:
+
+```toml
+[[emails]]
+account_name = "work"
+save_to_sent = true
+sent_folder_name = "INBOX.Sent"
+```
+
+Before choosing a value, call `list_mailboxes` and inspect the returned names
+and flags. Set `save_to_sent = false` if the provider already saves SMTP mail
+and a second IMAP append would create duplicates.
+
+## Save a draft
+
+Call `save_to_mailbox` with the account and message fields. The default mailbox
+is `Drafts`, and the default flags are `\Draft` and `\Seen`.
+
+Conceptual MCP call:
+
+```python
+await save_to_mailbox(
+    account_name="work",
+    recipients=["alice@example.com"],
+    subject="Project update",
+    body="Draft content",
+    mailbox="Drafts",
+)
+```
+
+Mailbox names vary by provider. Use `list_mailboxes` first when `Drafts` is not
+the correct name.
+
+## Reply with proper threading
+
+First fetch the original message and read its RFC `message_id`:
+
+```python
+result = await get_emails_content(
+    account_name="work",
+    email_ids=["123"],
+)
+original = result.emails[0]
+```
+
+Then send the reply using both threading headers:
+
+```python
+await send_email(
+    account_name="work",
+    recipients=[original.sender],
+    subject=f"Re: {original.subject}",
+    body="Thank you for your email.",
+    in_reply_to=original.message_id,
+    references=original.message_id,
+)
+```
+
+For an existing thread, `references` should contain the known ancestor message
+IDs followed by the immediate parent's ID, separated by spaces.
+
+## Read a long message in chunks
+
+`get_emails_content` returns at most `max_body_length` characters for each
+message. If the body ends with `...[TRUNCATED]`, request the next window:
+
+```python
+first = await get_emails_content(
+    account_name="work",
+    email_ids=["123"],
+    body_offset=0,
+    max_body_length=20000,
+)
+
+second = await get_emails_content(
+    account_name="work",
+    email_ids=["123"],
+    body_offset=20000,
+    max_body_length=20000,
+)
+```
+
+Keep the mailbox argument consistent with the mailbox used to obtain the
+`email_id`.
+
+## Containers and CI
+
+For non-interactive environments:
+
+- Supply account settings through environment variables or mount a protected
+  TOML file and set `MCP_EMAIL_SERVER_CONFIG_PATH`.
+- Use `credential_storage = "plaintext"` only when the mounted secret file is
+  appropriately protected, or provide a functional keyring backend.
+- Expect `auto` to fall back to plaintext when no D-Bus keyring session exists.
+- Bind HTTP transports to the required interface and configure explicit allowed
+  hosts and origins.
+- Mount only the directories needed for attachment upload or download.
+
+See [Security](security.md) and [Transports](transports.md) before exposing the
+service outside a local development environment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,33 @@
 # mcp-email-server
 
-[![Release](https://img.shields.io/github/v/release/wh1isper/mcp-email-server)](https://img.shields.io/github/v/release/wh1isper/mcp-email-server)
-[![Build status](https://img.shields.io/github/actions/workflow/status/wh1isper/mcp-email-server/main.yml?branch=main)](https://github.com/wh1isper/mcp-email-server/actions/workflows/main.yml?query=branch%3Amain)
-[![Commit activity](https://img.shields.io/github/commit-activity/m/wh1isper/mcp-email-server)](https://img.shields.io/github/commit-activity/m/wh1isper/mcp-email-server)
-[![License](https://img.shields.io/github/license/wh1isper/mcp-email-server)](https://img.shields.io/github/license/wh1isper/mcp-email-server)
+mcp-email-server connects MCP clients to email accounts through IMAP and SMTP.
+It provides tools for reading, searching, organizing, composing, and sending
+email without tying the client to a specific email provider.
 
-IMAP and SMTP via MCP Server
+## Start here
+
+- [Getting Started](getting-started.md) — configure your first account and MCP client.
+- [Configuration](configuration.md) — configure accounts with TOML or environment variables.
+- [MCP Tools](tools.md) — understand the tools exposed to MCP clients.
+- [Transports](transports.md) — run the server over stdio, SSE, or Streamable HTTP.
+- [Security](security.md) — manage credentials, allowlists, TLS, and attachment access.
+- [Guides](guides.md) — configure IMAP-only accounts, ProtonMail Bridge, drafts, and replies.
+- [Troubleshooting](troubleshooting.md) — resolve common account, keyring, TLS, and transport problems.
+
+## Core capabilities
+
+- Connect to standard IMAP and SMTP servers.
+- Configure multiple email accounts in one server.
+- Run without SMTP for IMAP-only workflows.
+- Search messages by mailbox, date, address, status, subject, body, or text.
+- Read long messages in bounded chunks.
+- Send plain-text or HTML messages with attachments.
+- Preserve reply threading with `In-Reply-To` and `References` headers.
+- Save drafts and other composed messages through IMAP.
+- Move, archive, mark, and delete messages.
+- Store credentials in the operating system keyring when available.
+- Restrict outgoing recipients and visible incoming senders.
+- Run locally over stdio or remotely over an HTTP transport.
+
+Continue with [Getting Started](getting-started.md) to configure an account and
+connect an MCP client.

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,1 +1,0 @@
-::: mcp_email_server.app

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,264 @@
+# Security
+
+An email MCP server can read private messages, modify mailboxes, send messages,
+and access local files. Review the controls on this page before exposing it to
+an MCP client or network.
+
+## Credential storage
+
+Persistent configuration is stored in
+`~/.config/mcp-email-server/config.toml` by default. The `credential_storage`
+setting controls where passwords are written.
+
+### `auto`
+
+`auto` is the default. The server performs a live usability check against the
+active operating system keyring backend:
+
+- macOS commonly uses Keychain.
+- Linux desktop environments commonly use Secret Service through GNOME Keyring
+  or KWallet.
+- Other platforms use the backend selected by the Python `keyring` package.
+
+If the keyring works, secrets are stored there. If no usable backend is
+detected, such as in many headless Linux sessions or containers, the server
+falls back to the TOML file and logs a warning. The usability result is cached
+for the life of the process, so restart after unlocking or repairing a backend
+that failed its first probe.
+
+### `keyring`
+
+`keyring` requires a usable keyring. A failed keyring write is reported instead
+of falling back to plaintext.
+
+Use this mode when storing credentials outside the operating system keyring is
+not acceptable:
+
+```toml
+credential_storage = "keyring"
+```
+
+### `plaintext`
+
+`plaintext` writes credentials directly into the TOML file and never uses the
+keyring for normal loads or saves:
+
+```toml
+credential_storage = "plaintext"
+```
+
+On POSIX systems, the file is created atomically with owner-only `0600`
+permissions. On non-POSIX systems, the application does not install an
+equivalent owner-restricted ACL. Protect the file using operating system or
+container controls.
+
+### Keyring representation
+
+When keyring storage is active, the TOML file contains `__KEYRING__` instead of
+the secret. The actual value is stored under:
+
+```text
+service: mcp-email-server
+entry: <account_name>:<incoming|outgoing|api_key>
+```
+
+`__KEYRING__` is reserved and cannot be used as a real password.
+
+### Environment-provided secrets
+
+`credential_storage` controls only credentials persisted by mcp-email-server.
+It does not move or protect a password supplied through an MCP client JSON
+file, process environment, CI configuration, or container metadata.
+
+Prefer the secret injection facility provided by the MCP client, CI system, or
+container platform. If a literal secret must be stored in a client
+configuration, restrict that file to the account running the client and keep it
+out of version control and diagnostic output.
+
+Do not use the UI or call `add_email_account` in a process with secret-bearing
+environment overrides unless persisting the effective runtime settings is
+intended. A normal settings save serializes that runtime view.
+
+## Credential migration
+
+Move all credentials represented by the stored configuration into the keyring:
+
+```bash
+mcp-email-server migrate-credentials --to keyring
+```
+
+Move referenced keyring credentials back into the TOML file:
+
+```bash
+mcp-email-server migrate-credentials --to plaintext
+```
+
+Migration operates on the stored TOML file. It intentionally ignores
+environment-provided accounts, allowlists, boolean overrides, and the
+credential storage environment override while loading the source data.
+
+If `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE` is set to a different mode, the command
+warns because future server runs will continue to obey the environment value.
+Unset it or keep it synchronized with the intended storage mode.
+
+A plaintext migration attempts to delete the keyring entries referenced by the
+original file. It reports entries that remain or whose removal cannot be
+verified.
+
+## Keyring limitations
+
+### Application-specific Keychain access
+
+On macOS, Keychain access control can be associated with an executable. A fresh
+`uvx` resolution may run the server from a different path than the process that
+stored the secret. Keychain can then display a permission prompt or deny access.
+Choose the appropriate persistent permission when prompted, or use a stable
+installation path.
+
+### Backend trust
+
+The `auto` usability check verifies that the active backend can store and read a
+probe value. It does not audit how a third-party keyring backend protects data.
+If custom backends are installed, verify that the selected backend meets the
+required security properties.
+
+### Non-transactional backends
+
+Writing secrets to the keyring and replacing the TOML file are separate
+operations. A crash between them can leave an orphaned keyring entry or a
+configuration marker whose corresponding write did not complete. Migration
+reports cleanup failures, but backup and recovery remain the operator's
+responsibility.
+
+## Recipient allowlist
+
+By default, the server can address any recipient. Restrict both `send_email`
+and `save_to_mailbox` with exact addresses:
+
+```toml
+allowed_recipients = [
+  "alice@example.com",
+  "bob@example.com",
+]
+```
+
+Or use a comma-separated environment variable:
+
+```bash
+MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS='alice@example.com,bob@example.com'
+```
+
+Every To, CC, and BCC address must be allowed. Matching is case-insensitive and
+understands display-name forms such as `Alice <alice@example.com>`.
+
+When the list is configured, `list_allowed_recipients` becomes visible to MCP
+clients. An empty list permits all recipients.
+
+## Sender allowlist
+
+Restrict incoming messages by exact address or glob pattern:
+
+```toml
+allowed_senders = [
+  "alice@example.com",
+  "*@company.example",
+]
+```
+
+Or:
+
+```bash
+MCP_EMAIL_SERVER_ALLOWED_SENDERS='alice@example.com,*@company.example'
+```
+
+Matching is case-insensitive and applies to the single address parsed from the
+message's `From` header. Malformed, empty, or multi-address `From` headers fail
+closed when the allowlist is active.
+
+The allowlist protects:
+
+- Metadata listing and pagination.
+- Body retrieval and optional read marking.
+- Attachment download.
+- Deletion and read-state mutations.
+- Move and archive operations.
+
+A blocked message's body and attachments are not fetched or marked as read. By
+default, blocked mutation IDs are returned as successful no-ops so the caller
+cannot distinguish a hidden message from a nonexistent one.
+
+Set this option to report blocked IDs as failures instead:
+
+```toml
+report_blocked_mutations = true
+```
+
+This is more explicit but reveals that a blocked message exists. When the
+sender list is configured, `list_allowed_senders` becomes visible to MCP
+clients.
+
+The sender allowlist is local filtering, not sender authentication. A spoofed
+`From` header can match. Continue to rely on provider-side SPF, DKIM, DMARC,
+and spam controls.
+
+## Attachment access
+
+Attachment downloads are disabled by default because the tool writes data from
+email to the server's filesystem.
+
+Enable the operation with:
+
+```toml
+enable_attachment_download = true
+```
+
+Or:
+
+```bash
+MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD=true
+```
+
+Use an absolute destination path with `download_attachment` so the target is
+unambiguous. The implementation also accepts relative paths and resolves them
+against the server process's working directory. Run the server with filesystem
+permissions that limit where it can write, and do not assume attachments are
+safe to open or execute.
+
+The separate `attachments` parameter on `send_email` and `save_to_mailbox`
+reads local file paths. Relative paths are likewise resolved against the server
+process's working directory. Only connect clients that should be trusted to
+request access to files visible to that process.
+
+## TLS certificate verification
+
+Keep `verify_ssl = true` for remote IMAP and SMTP services. Disabling
+verification permits interception and credential exposure if the network or
+endpoint is not fully trusted.
+
+If both `use_ssl` and `start_ssl` are false, there is no TLS layer and
+`verify_ssl` has no effect. Credentials and message contents may cross the
+network in plaintext. Use that mode only for a trusted local bridge, an
+encrypted tunnel, or an isolated network; remote services should use implicit
+TLS or STARTTLS.
+
+A trusted local bridge with a self-signed certificate can require:
+
+```toml
+[emails.incoming]
+use_ssl = false
+start_ssl = true
+verify_ssl = false
+```
+
+Limit this exception to the specific local connection. See
+[ProtonMail Bridge and self-signed TLS](guides.md#protonmail-bridge-and-self-signed-tls).
+
+## HTTP transport security
+
+SSE and Streamable HTTP validate `Host` and `Origin` headers by default to
+reduce DNS rebinding risk. Network exposure still requires appropriate
+authentication, authorization, TLS termination, and firewall policy around the
+server.
+
+See [Transports](transports.md#dns-rebinding-protection) for allowed host and
+origin settings.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,204 @@
+# MCP Tools
+
+mcp-email-server exposes account, message, mailbox, and composition operations as
+MCP tools. Tool schemas are generated from the running server, so the MCP client
+can inspect each parameter and response type directly.
+
+## Typical workflow
+
+Most message workflows follow this sequence:
+
+1. Call `list_available_accounts` to select an `account_name`.
+2. Call `list_emails_metadata` to search a mailbox and obtain `email_id` values.
+3. Pass those IDs to a read or mutation tool with the same mailbox name.
+4. Call `get_emails_content` only for messages whose bodies are needed.
+
+This separates lightweight metadata searches from potentially large body
+retrievals.
+
+## Account resource
+
+The resource URI `email://{account_name}` returns the selected account's
+configuration with credentials masked.
+
+## Account tools
+
+### `list_available_accounts`
+
+Lists all configured accounts with masked credentials. Use the returned
+`account_name` in other tools.
+
+### `add_email_account`
+
+Adds and persists an email account. The input follows the nested account schema
+documented in [Configuration](configuration.md#toml-example).
+
+Account names must be unique. This tool changes persistent configuration and
+may also move the supplied credentials into the operating system keyring,
+depending on `credential_storage`.
+
+## Reading and searching
+
+### `list_emails_metadata`
+
+Searches one mailbox without downloading message bodies.
+
+Important parameters include:
+
+| Parameter                     | Default  | Description                                 |
+| ----------------------------- | -------- | ------------------------------------------- |
+| `account_name`                | Required | Configured account identifier.              |
+| `page`                        | `1`      | One-based result page.                      |
+| `page_size`                   | `10`     | Number of results per page.                 |
+| `mailbox`                     | `INBOX`  | Mailbox to search.                          |
+| `before` / `since`            | None     | UTC datetime boundaries.                    |
+| `subject`                     | None     | Subject filter.                             |
+| `from_address` / `to_address` | None     | Address filters.                            |
+| `seen`                        | None     | Filter by read status.                      |
+| `flagged`                     | None     | Filter by flagged or starred status.        |
+| `answered`                    | None     | Filter by replied status.                   |
+| `body`                        | None     | Search message bodies with IMAP `BODY`.     |
+| `text`                        | None     | Search headers and bodies with IMAP `TEXT`. |
+| `has_attachment`              | None     | Apply a multipart attachment heuristic.     |
+| `order`                       | `desc`   | Return ascending or descending results.     |
+
+The response contains pagination metadata, a filtered `total`, and message
+metadata including `email_id`, `message_id`, subject, sender, recipients, and
+date. Because this operation fetches headers only, its `attachments` field is
+empty. `get_emails_content` populates attachment names from the full message.
+
+`has_attachment` uses a `multipart/mixed` heuristic. It can miss inline content
+or report multipart messages that do not contain a conventional attachment.
+
+When a sender allowlist is configured, blocked messages are removed before
+pagination, so `total` and page sizes describe only visible messages.
+
+### `get_emails_content`
+
+Fetches the body of one or more messages by `email_id`.
+
+| Parameter         | Default  | Description                                                     |
+| ----------------- | -------- | --------------------------------------------------------------- |
+| `account_name`    | Required | Configured account identifier.                                  |
+| `email_ids`       | Required | IDs returned by `list_emails_metadata`.                         |
+| `mailbox`         | `INBOX`  | Mailbox containing the messages.                                |
+| `mark_as_read`    | `false`  | Mark successfully retrieved messages as read.                   |
+| `body_offset`     | `0`      | Character offset at which body output starts.                   |
+| `max_body_length` | `20000`  | Maximum body characters returned per message, from 1 to 100000. |
+
+If a body extends beyond the requested window, the returned body ends with
+`...[TRUNCATED]`. Fetch the next chunk by increasing `body_offset` by
+`max_body_length`.
+
+The batch response reports requested and retrieved counts and includes
+`failed_ids` for messages that could not be fetched. A failure to apply
+`mark_as_read` is logged but does not discard successfully retrieved content.
+
+## Composing messages
+
+### `send_email`
+
+Sends a message through the selected account's SMTP server. It supports:
+
+- To, CC, and BCC recipients.
+- Plain-text or HTML bodies.
+- Attachments from file paths available to the server process. Relative paths use the process working directory; absolute paths are recommended.
+- `Reply-To`, `In-Reply-To`, and `References` headers.
+
+This tool is visible only when at least one configured account has SMTP
+settings. The selected `account_name` must itself be send-capable.
+
+If a recipient allowlist is configured, every To, CC, and BCC address must be
+allowed.
+
+### `save_to_mailbox`
+
+Composes a message and appends it to an IMAP mailbox instead of sending it. It
+works without SMTP and is useful for drafts or templates. It shares recipient,
+body, attachment, and threading fields with `send_email`, adds `mailbox` and
+`flags`, and does not support `reply_to`.
+
+The default mailbox is `Drafts`. When no explicit flags are supplied, the
+message is saved with `\Draft` and `\Seen`. The response includes the RFC
+message ID. It includes an assigned IMAP `email_id` only when the server returns
+RFC 4315 `APPENDUID`; otherwise the value is `unknown`, and the target mailbox
+must be searched before a later operation can address the saved message.
+
+The same recipient allowlist used by `send_email` applies to this tool.
+
+## Mailbox and mutation tools
+
+### `list_mailboxes`
+
+Lists IMAP mailboxes with their names, hierarchy delimiters, and flags. Call it
+before moving or saving messages when provider-specific folder names are not
+known.
+
+`pattern` defaults to `*`, and `reference` defaults to an empty string.
+
+### `mark_emails_as_read`
+
+Marks one or more message IDs as read in the selected mailbox.
+
+### `move_emails`
+
+Moves messages from `source_mailbox`, which defaults to `INBOX`, to a required
+`destination_mailbox`.
+
+### `archive_emails`
+
+Moves messages to the account's archive mailbox. The server first uses the RFC
+6154 `\Archive` mailbox flag and then falls back to `Archive`, `Archives`, or
+`[Gmail]/All Mail`.
+
+### `delete_emails`
+
+Deletes one or more messages from the selected mailbox.
+
+Mutation tools return successful and failed counts. When a sender allowlist is
+active, blocked messages are never changed. See
+[Sender allowlist](security.md#sender-allowlist) for the privacy behavior of
+blocked IDs.
+
+## Attachments
+
+### `download_attachment`
+
+Downloads one named attachment from a message and writes it to a path on the
+server host. Use an absolute path when possible. A relative path is resolved
+against the server process's working directory.
+
+The tool is registered even when downloading is disabled, but calling it then
+raises a permission error. Enable it explicitly with:
+
+```toml
+enable_attachment_download = true
+```
+
+Review [Attachment access](security.md#attachment-access) before enabling this
+operation.
+
+## Conditional tools
+
+The tool list adapts to the active configuration:
+
+| Tool                      | Visibility condition                                     |
+| ------------------------- | -------------------------------------------------------- |
+| `send_email`              | At least one configured email account has SMTP settings. |
+| `list_allowed_recipients` | `allowed_recipients` is not empty.                       |
+| `list_allowed_senders`    | `allowed_senders` is not empty.                          |
+
+`download_attachment` is not hidden when disabled; it checks permission when
+called.
+
+## Reply threading
+
+To preserve conversation threading:
+
+1. Fetch the original message with `get_emails_content`.
+2. Use its RFC `message_id` as `in_reply_to`.
+3. Include that ID and any known ancestor IDs in `references`, separated by
+   spaces.
+4. Send the reply with a suitable `Re:` subject.
+
+For a complete example, see [Reply with proper threading](guides.md#reply-with-proper-threading).

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -1,0 +1,173 @@
+# Transports
+
+mcp-email-server supports stdio, SSE, and Streamable HTTP transports. Use stdio
+for a local MCP client unless a network transport is specifically required.
+
+## CLI commands
+
+```text
+mcp-email-server stdio
+mcp-email-server sse [--host HOST] [--port PORT]
+mcp-email-server streamable-http [--host HOST] [--port PORT]
+mcp-email-server ui
+mcp-email-server reset
+mcp-email-server migrate-credentials [--to keyring|plaintext]
+```
+
+Run `mcp-email-server COMMAND --help` for the command's current options.
+
+## stdio
+
+stdio is the recommended transport for Claude Desktop and other local MCP
+clients. The client starts the server and communicates through standard input
+and output.
+
+```json
+{
+  "mcpServers": {
+    "mcp-email-server": {
+      "command": "uvx",
+      "args": ["mcp-email-server@latest", "stdio"]
+    }
+  }
+}
+```
+
+Do not write unrelated output to stdout when wrapping a stdio server process,
+because stdout carries the MCP protocol.
+
+## SSE
+
+Start the legacy SSE transport with:
+
+```bash
+mcp-email-server sse --host localhost --port 9557
+```
+
+With the default host and port, the FastMCP endpoints are:
+
+```text
+SSE stream:      http://localhost:9557/sse
+SSE messages:    http://localhost:9557/messages/
+```
+
+MCP clients normally configure the `/sse` URL; the stream tells the client
+where to send messages.
+
+The default host is `localhost` and the default port is `9557`. Configure the
+SSE bind address with command-line options; `MCP_HOST` and `MCP_PORT` are not
+used as defaults by this command.
+
+Prefer Streamable HTTP for new network integrations when the MCP client
+supports it.
+
+## Streamable HTTP
+
+Start the server with:
+
+```bash
+mcp-email-server streamable-http --host localhost --port 9557
+```
+
+Connect the MCP client to:
+
+```text
+http://localhost:9557/mcp
+```
+
+The host and port can also be supplied as defaults through environment
+variables:
+
+```bash
+MCP_HOST=0.0.0.0 \
+MCP_PORT=9557 \
+mcp-email-server streamable-http
+```
+
+Explicit `--host` and `--port` options override those defaults.
+
+| Variable                              | Default             | Description                                   |
+| ------------------------------------- | ------------------- | --------------------------------------------- |
+| `MCP_HOST`                            | `localhost`         | Bind host for Streamable HTTP.                |
+| `MCP_PORT`                            | `9557`              | Bind port for Streamable HTTP.                |
+| `MCP_ALLOWED_HOSTS`                   | Derived safe values | Comma-separated allowed HTTP `Host` values.   |
+| `MCP_ALLOWED_ORIGINS`                 | Derived safe values | Comma-separated allowed HTTP `Origin` values. |
+| `MCP_ENABLE_DNS_REBINDING_PROTECTION` | `true`              | Enable `Host` and `Origin` validation.        |
+
+## DNS rebinding protection
+
+Both HTTP transports validate `Host` and `Origin` headers by default. Loopback
+hosts and origins are allowed for local use.
+
+When binding to a named non-loopback host, that host is included in the derived
+allowlist. When binding to a wildcard address such as `0.0.0.0` or `::`, the
+server cannot infer the public hostname. Configure the expected service names
+explicitly:
+
+```bash
+MCP_HOST=0.0.0.0 \
+MCP_ALLOWED_HOSTS='mail-mcp.example.com,mcp-email-server' \
+MCP_ALLOWED_ORIGINS='https://mail-mcp.example.com' \
+mcp-email-server streamable-http
+```
+
+A bare host entry also permits any port on that host. For example,
+`mcp-email-server` expands to include `mcp-email-server:*`.
+
+Specify IPv6 literals with brackets:
+
+```bash
+MCP_ALLOWED_HOSTS='[::1]:*,[2001:db8::10]:*'
+MCP_ALLOWED_ORIGINS='http://[::1]:*,https://[2001:db8::10]:*'
+```
+
+Any of the following disables `Host` and `Origin` validation entirely:
+
+```bash
+MCP_ENABLE_DNS_REBINDING_PROTECTION=false
+MCP_ALLOWED_HOSTS='*'
+MCP_ALLOWED_ORIGINS='*'
+```
+
+Use these escape hatches only in an isolated development environment. Prefer
+explicit allowlists behind containers and reverse proxies.
+
+## Reverse proxies
+
+Preserve the FastMCP endpoint paths through the proxy: `/sse` and `/messages/`
+for SSE, or `/mcp` for Streamable HTTP. These are the current SDK defaults
+because this project does not override the path settings.
+
+When a reverse proxy terminates TLS:
+
+- Bind the server to a private interface whenever possible.
+- Add the externally visible host to `MCP_ALLOWED_HOSTS`.
+- Add the browser or client origin, including its scheme, to
+  `MCP_ALLOWED_ORIGINS`.
+- Preserve the request headers expected by the MCP transport.
+- Apply authentication and network access controls at the proxy or surrounding
+  platform; transport exposure does not by itself authenticate arbitrary users.
+
+## Other CLI operations
+
+Open the account configuration interface with:
+
+```bash
+mcp-email-server ui
+```
+
+Remove persistent configuration with:
+
+```bash
+mcp-email-server reset
+```
+
+Move credentials between the TOML file and operating system keyring with:
+
+```bash
+mcp-email-server migrate-credentials --to keyring
+mcp-email-server migrate-credentials --to plaintext
+```
+
+Credential behavior and migration caveats are covered in
+[Security](security.md#credential-migration).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,253 @@
+# Troubleshooting
+
+Start by running the relevant command with a visible terminal so server logs and
+keyring prompts are not hidden by the MCP client.
+
+Set a more detailed log level when needed:
+
+```bash
+MCP_EMAIL_SERVER_LOG_LEVEL=DEBUG mcp-email-server stdio
+```
+
+Restart the server after changing configuration paths or environment variables.
+
+## The server reports `Missing command`
+
+The CLI requires a subcommand. Use one of:
+
+```bash
+mcp-email-server stdio
+mcp-email-server sse
+mcp-email-server streamable-http
+mcp-email-server ui
+```
+
+For local development, use `uv run mcp-email-server stdio` rather than
+`uv run mcp-email-server`.
+
+## An environment account does not appear
+
+An environment-provided account requires all three variables:
+
+```text
+MCP_EMAIL_SERVER_EMAIL_ADDRESS
+MCP_EMAIL_SERVER_PASSWORD
+MCP_EMAIL_SERVER_IMAP_HOST
+```
+
+The generic password remains required even when
+`MCP_EMAIL_SERVER_IMAP_PASSWORD` is set. Invalid integer ports or invalid
+account fields cause the environment account to be skipped and an error to be
+logged.
+
+If the environment account has the same `MCP_EMAIL_SERVER_ACCOUNT_NAME` as a
+TOML account, it replaces that entire account for the current process rather
+than merging individual fields.
+
+## A different configuration file is loaded
+
+The default file is:
+
+```text
+~/.config/mcp-email-server/config.toml
+```
+
+`MCP_EMAIL_SERVER_CONFIG_PATH` selects another path. The path is resolved when
+the configuration module is imported, so restart the server after changing it.
+
+On first use, the server can copy a legacy file from:
+
+```text
+~/.config/zerolib/mcp_email_server/config.toml
+```
+
+Check server logs for the resolved path.
+
+## The UI cannot load accounts
+
+If the UI displays a keyring error, the TOML file probably contains
+`__KEYRING__` markers whose secrets cannot currently be read. Unlock or restore
+the operating system keyring, approve any pending Keychain prompt, or migrate
+the credentials to plaintext after keyring access is restored:
+
+```bash
+mcp-email-server migrate-credentials --to plaintext
+```
+
+If the stored configuration is no longer recoverable, reset it and re-add the
+accounts:
+
+```bash
+mcp-email-server reset
+```
+
+`reset` removes all persistently configured accounts and performs best-effort
+keyring cleanup.
+
+## Keychain repeatedly asks for permission
+
+On macOS, Keychain access can be associated with the application path. `uvx`
+may resolve a new executable path after an update, causing another prompt.
+Grant the appropriate persistent permission when prompted or install the
+package at a stable path and point the MCP client to that executable.
+
+## A keyring-stored secret cannot be resolved
+
+The error identifies the service and entry, for example:
+
+```text
+service: mcp-email-server
+entry: work:incoming
+```
+
+Check that:
+
+- The keyring is unlocked and available in the server's session.
+- The entry was not removed by another application or cleanup operation.
+- The server process has access to the same keyring as the configuration UI.
+- A macOS Keychain access prompt is not waiting behind another window.
+
+Re-add the account if the referenced secret no longer exists.
+
+## `credential_storage` is `plaintext` but the file contains `__KEYRING__`
+
+The file references keyring entries while the active mode refuses to resolve
+them. Use one of these approaches:
+
+- Remove the `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE=plaintext` override.
+- Change the stored mode back to `auto` or `keyring` long enough to load it.
+- Run `mcp-email-server migrate-credentials --to plaintext` while the keyring
+  is accessible.
+
+Do not replace `__KEYRING__` with an unknown value; it is only a marker.
+
+## Credential migration appears to have no effect
+
+Check `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`. If it remains set, every later run
+uses that value even when a migration wrote a different mode to the TOML file.
+The migration command prints a warning when the values conflict.
+
+Migration changes only persistent TOML accounts. It does not migrate an
+account supplied solely through environment variables.
+
+## `send_email` is missing
+
+`send_email` is advertised only when at least one configured account contains
+an SMTP `outgoing` section or `MCP_EMAIL_SERVER_SMTP_HOST` is set for the
+environment account.
+
+If the tool is visible but sending fails for one account, confirm that the
+selected `account_name` itself has SMTP settings. Visibility is based on all
+accounts, not the selected one.
+
+## SMTP delivery succeeds but saving to Sent fails
+
+SMTP delivery and the IMAP append are separate operations. List the provider's
+folders with `list_mailboxes`, then configure the exact folder:
+
+```toml
+[[emails]]
+account_name = "work"
+save_to_sent = true
+sent_folder_name = "INBOX.Sent"
+```
+
+Set `save_to_sent = false` if the provider already stores sent messages and an
+additional append is unnecessary.
+
+## IMAP or SMTP TLS fails
+
+Verify that the port and TLS mode match the provider:
+
+| Connection        | Common settings                                 |
+| ----------------- | ----------------------------------------------- |
+| IMAP implicit TLS | Port 993, `use_ssl = true`, `start_ssl = false` |
+| IMAP STARTTLS     | Port 143, `use_ssl = false`, `start_ssl = true` |
+| SMTP implicit TLS | Port 465, `use_ssl = true`, `start_ssl = false` |
+| SMTP STARTTLS     | Port 587, `use_ssl = false`, `start_ssl = true` |
+
+Do not enable both implicit TLS and STARTTLS. Disable certificate verification
+only for a trusted local endpoint with a known self-signed certificate.
+
+For ProtonMail Bridge, copy the host, ports, username, and password shown by the
+bridge rather than using the normal account password.
+
+## Attachment download is denied
+
+The tool is visible even when permission is disabled. Enable it explicitly:
+
+```toml
+enable_attachment_download = true
+```
+
+Or:
+
+```bash
+MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD=true
+```
+
+Use an absolute `save_path` when possible and ensure the server process can
+write to its parent directory. A relative path is resolved against the server
+process's working directory.
+
+## A message mutation reports success but nothing changed
+
+With `allowed_senders` configured, blocked message IDs are reported as
+successful no-ops by default. This prevents callers from using mutation results
+to discover hidden messages.
+
+To report blocked IDs as failures instead:
+
+```toml
+report_blocked_mutations = true
+```
+
+Also confirm that the `email_id` belongs to the mailbox supplied to the
+mutation tool.
+
+## Archive folder cannot be found
+
+`archive_emails` first looks for an RFC 6154 `\Archive` flag and then checks
+`Archive`, `Archives`, and `[Gmail]/All Mail`.
+
+Call `list_mailboxes` to discover the actual folder and use `move_emails` with
+an explicit destination when the provider uses another name.
+
+## HTTP requests are rejected by `Host` or `Origin` validation
+
+For a container, proxy, or non-loopback hostname, configure the names seen by
+the server:
+
+```bash
+MCP_ALLOWED_HOSTS='mail-mcp.example.com,mcp-email-server'
+MCP_ALLOWED_ORIGINS='https://mail-mcp.example.com'
+```
+
+A wildcard bind such as `0.0.0.0` does not tell the server which public
+hostname a request will use. Do not disable DNS rebinding protection merely to
+avoid configuring an explicit allowlist.
+
+See [DNS rebinding protection](transports.md#dns-rebinding-protection).
+
+## Duplicate account name
+
+Account names must be unique across all stored account types. Choose a new
+`account_name`, or remove the existing account before adding its replacement.
+
+An environment account with the same name as a TOML email account is the one
+exception: it intentionally replaces that account in the runtime view.
+
+## Collect information for a bug report
+
+Include:
+
+- Operating system and version.
+- Python and `mcp-email-server` versions.
+- Installation method, such as `uvx` or `pip`.
+- Transport and MCP client.
+- IMAP/SMTP provider and TLS mode, without credentials.
+- Relevant logs with email addresses, message contents, tokens, and passwords
+  removed.
+- Minimal steps to reproduce the problem.
+
+Report issues at <https://github.com/wh1isper/mcp-email-server/issues>.

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -308,7 +308,7 @@ async def send_email(
         list[str] | None,
         Field(
             default=None,
-            description="A list of absolute file paths to attach to the email. Supports common file types (documents, images, archives, etc.).",
+            description="A list of file paths to attach. Relative paths are resolved against the server process working directory; absolute paths are recommended.",
         ),
     ] = None,
     in_reply_to: Annotated[
@@ -354,7 +354,8 @@ async def send_email(
 
 @mcp.tool(
     description="Compose an email and save it to an IMAP folder (e.g., Drafts). "
-    "Same parameters as send_email, but saves instead of sending. "
+    "Shares recipient, body, attachment, and threading parameters with send_email; "
+    "adds mailbox and flags, and does not support reply_to. "
     "Default folder is Drafts with \\Draft and \\Seen flags. "
     "Pure IMAP operation — works without SMTP configuration.",
 )
@@ -386,7 +387,7 @@ async def save_to_mailbox(
         list[str] | None,
         Field(
             default=None,
-            description="A list of absolute file paths to attach to the email.",
+            description="A list of file paths to attach. Relative paths are resolved against the server process working directory; absolute paths are recommended.",
         ),
     ] = None,
     in_reply_to: Annotated[
@@ -407,7 +408,7 @@ async def save_to_mailbox(
         list[str] | None,
         Field(
             default=None,
-            description=r"IMAP flags to set on the message. Defaults to ['\\Draft', '\\Seen']. Common flags: '\\Draft', '\\Seen', '\\Flagged'.",
+            description=r"IMAP flags to set on the message. Defaults to ['\Draft', '\Seen']. Common flags: '\Draft', '\Seen', '\Flagged'.",
         ),
     ] = None,
 ) -> str:
@@ -547,7 +548,12 @@ async def download_attachment(
     attachment_name: Annotated[
         str, Field(description="The name of the attachment to download (as shown in the attachments list).")
     ],
-    save_path: Annotated[str, Field(description="The absolute path where the attachment should be saved.")],
+    save_path: Annotated[
+        str,
+        Field(
+            description="The destination path. Relative paths are resolved against the server process working directory; absolute paths are recommended."
+        ),
+    ],
     mailbox: Annotated[str, Field(description="The mailbox to search in (default: INBOX).")] = "INBOX",
 ) -> AttachmentDownloadResponse:
     settings = get_settings()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: mcp-email-server
 repo_url: https://github.com/wh1isper/mcp-email-server
 site_url: https://mcp-email-server.wh1isper.top
-site_description: IMAP and SMTP via MCP Server
+site_description: Read, search, organize, and send email through IMAP and SMTP with MCP
 site_author: wh1isper
 edit_uri: edit/main/docs/
 repo_name: wh1isper/mcp-email-server
@@ -9,17 +9,23 @@ copyright: Maintained by <a href="https://github.com/wh1isper">wh1isper</a>.
 
 nav:
   - Home: index.md
-  - Modules: modules.md
+  - Getting Started: getting-started.md
+  - Configuration: configuration.md
+  - MCP Tools: tools.md
+  - Transports: transports.md
+  - Security: security.md
+  - Guides: guides.md
+  - Troubleshooting: troubleshooting.md
+  - Contributing: https://github.com/wh1isper/mcp-email-server/blob/main/CONTRIBUTING.md
+
 plugins:
   - search
-  - mkdocstrings:
-      handlers:
-        python:
-          paths: ["mcp_email_server"]
+
 theme:
   name: material
-  feature:
-    tabs: true
+  features:
+    - navigation.tabs
+    - navigation.sections
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dev = [
     "ruff>=0.9.2",
     "mkdocs>=1.4.2",
     "mkdocs-material>=8.5.10",
-    "mkdocstrings[python]>=0.26.1",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -668,18 +668,6 @@ wheels = [
 ]
 
 [[package]]
-name = "griffe"
-version = "1.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/d7/6c09dd7ce4c7837e4cdb11dce980cb45ae3cd87677298dc3b781b6bce7d3/griffe-1.14.0.tar.gz", hash = "sha256:9d2a15c1eca966d68e00517de5d69dd1bc5c9f2335ef6c1775362ba5b8651a13", size = 424684, upload-time = "2025-09-05T15:02:29.167Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/b1/9ff6578d789a89812ff21e4e0f80ffae20a65d5dd84e7a17873fe3b365be/griffe-1.14.0-py3-none-any.whl", hash = "sha256:0e9d52832cccf0f7188cfe585ba962d2674b241c01916d780925df34873bceb0", size = 144439, upload-time = "2025-09-05T15:02:27.511Z" },
-]
-
-[[package]]
 name = "groovy"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1072,7 +1060,6 @@ dev = [
     { name = "deptry" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
@@ -1103,7 +1090,6 @@ dev = [
     { name = "deptry", specifier = ">=0.22.0" },
     { name = "mkdocs", specifier = ">=1.4.2" },
     { name = "mkdocs-material", specifier = ">=8.5.10" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.1" },
     { name = "pre-commit", specifier = ">=2.20.0" },
     { name = "pyright", specifier = ">=1.1.0" },
     { name = "pytest", specifier = ">=7.2.0" },
@@ -1156,20 +1142,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mkdocs-autorefs"
-version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown" },
-    { name = "markupsafe" },
-    { name = "mkdocs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/51/fa/9124cd63d822e2bcbea1450ae68cdc3faf3655c69b455f3a7ed36ce6c628/mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75", size = 55425, upload-time = "2025-08-26T14:23:17.223Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9", size = 25034, upload-time = "2025-08-26T14:23:15.906Z" },
-]
-
-[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1212,42 +1184,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
-]
-
-[[package]]
-name = "mkdocstrings"
-version = "0.30.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2" },
-    { name = "markdown" },
-    { name = "markupsafe" },
-    { name = "mkdocs" },
-    { name = "mkdocs-autorefs" },
-    { name = "pymdown-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/33/2fa3243439f794e685d3e694590d28469a9b8ea733af4b48c250a3ffc9a0/mkdocstrings-0.30.1.tar.gz", hash = "sha256:84a007aae9b707fb0aebfc9da23db4b26fc9ab562eb56e335e9ec480cb19744f", size = 106350, upload-time = "2025-09-19T10:49:26.446Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl", hash = "sha256:41bd71f284ca4d44a668816193e4025c950b002252081e387433656ae9a70a82", size = 36704, upload-time = "2025-09-19T10:49:24.805Z" },
-]
-
-[package.optional-dependencies]
-python = [
-    { name = "mkdocstrings-python" },
-]
-
-[[package]]
-name = "mkdocstrings-python"
-version = "1.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffe" },
-    { name = "mkdocs-autorefs" },
-    { name = "mkdocstrings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/ae/58ab2bfbee2792e92a98b97e872f7c003deb903071f75d8d83aa55db28fa/mkdocstrings_python-1.18.2.tar.gz", hash = "sha256:4ad536920a07b6336f50d4c6d5603316fafb1172c5c882370cbbc954770ad323", size = 207972, upload-time = "2025-08-28T16:11:19.847Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/8f/ce008599d9adebf33ed144e7736914385e8537f5fc686fdb7cceb8c22431/mkdocstrings_python-1.18.2-py3-none-any.whl", hash = "sha256:944fe6deb8f08f33fa936d538233c4036e9f53e840994f6146e8e94eb71b600d", size = 138215, upload-time = "2025-08-28T16:11:18.176Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Move detailed configuration, tools, transport, security, guides, and
troubleshooting content from the README into the MkDocs site.

Add repository guidance, align MCP tool descriptions with runtime behavior,
and remove the unused mkdocstrings setup.

Assisted-by: YAAI <261597362+yaai-bot@users.noreply.github.com>
