### PR TITLE
chore: add local email app architecture and validation baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,10 +102,10 @@ discussions by updating those numbered documents and their cross-references.
 
 This project uses [AnyCap](https://anycap.ai) for web research, web crawling,
 multimodal generation and understanding, file sharing, and static page hosting.
-Before using it, read the installed AnyCap skill and verify authentication:
+Before using it, read the installed AnyCap skill and verify the locally installed
+CLI and authentication:
 
 ```bash
-npx -y skills update
 anycap status
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Primary repository areas:
 - `mcp_email_server/ui.py` — Gradio account configuration UI.
 - `tests/` — unit and integration-style tests with mocked mail services.
 - `docs/` — user documentation published with MkDocs.
+- `spec/` — unpublished architecture and product design proposals kept as flat numbered documents.
 
 ## Project Conventions
 
@@ -25,6 +26,15 @@ Primary repository areas:
 - Preserve the distinction between persistent TOML settings and the environment-composited runtime view.
 - Treat credential storage, allowlists, attachment paths, and HTTP transport settings as security-sensitive behavior.
 - Do not log, document, or commit real email credentials, API keys, message contents, or tokens.
+
+## Current Architecture Direction
+
+The proposed target under `spec/` is a local, single-user Email App: MCP uses
+stdio, CLI is the management plane, SQLite stores managed non-secret
+configuration and reusable mail metadata/index state, and a `SecretStore` owns
+credentials. Current TOML, environment, and keyring behavior remains a
+compatibility mode and explicit import source. HTTP, daemon, multi-user, and
+cloud-service design are out of scope for this proposal.
 
 ## Development Workflow
 
@@ -70,10 +80,47 @@ Code and documentation must remain aligned.
 - Update `CONTRIBUTING.md` when contributor or release workflows change.
 - Run `make docs-test` after changing code or documentation that can affect published docs.
 
+## Specification Requirements
+
+`spec/` is the repository's workspace for architecture and product design before
+those decisions become stable implementation or published user behavior.
+
+- Keep `spec/` outside the MkDocs navigation; published, implemented behavior belongs under `docs/`.
+- Maintain `spec/README.md` as the global spec map and keep the current proposal's numbered documents directly under `spec/`.
+- Name detailed documents `NN-topic.md` and order them from system context and boundaries toward workflows, data design, and interfaces.
+- Write specs in English Markdown and use Mermaid for architecture, sequence, state, flow, and ER diagrams.
+- Cross-reference owning specs instead of duplicating contracts across files.
+- Declare each spec `Proposed`, `Accepted`, `Implemented`, or `Superseded`; proposed text must not imply that code already exists.
+- Update the owning spec before or with architecture, workflow, persistence, or security-boundary changes.
+- When a design ships, update its status, implementation/test evidence, and the corresponding user documentation under `docs/`.
+- Keep unresolved product decisions explicit in the owning spec rather than hiding them in implementation plans.
+
+The current Local Email App proposal starts at `spec/README.md`. Continue design
+discussions by updating those numbered documents and their cross-references.
+
+## AnyCap
+
+This project uses [AnyCap](https://anycap.ai) for web research, web crawling,
+multimodal generation and understanding, file sharing, and static page hosting.
+Before using it, read the installed AnyCap skill and verify authentication:
+
+```bash
+npx -y skills update
+anycap status
+```
+
+Submit a bug or feature request when a capability fails or is missing:
+
+```bash
+anycap feedback --type bug -m "describe the issue" --request-id <id>
+anycap feedback --type feature -m "describe the use case"
+```
+
 ## Testing Expectations
 
 - Add or update tests for every behavior change and regression fix.
-- Keep tests deterministic and independent of live IMAP, SMTP, or keyring services.
+- Keep unit tests deterministic and independent of live IMAP, SMTP, or keyring services.
+- Run `make test-e2e` for changes to IMAP, SMTP, MCP stdio, configuration loading, attachment handling, or mailbox mutations. This uses synthetic accounts on a loopback-only GreenMail container.
 - Cover both successful operations and security or failure boundaries.
 - When changing configuration, test TOML loading, supported environment overrides, persistence, and migration behavior as applicable.
 - When changing MCP tools, test schemas, responses, conditional visibility, and account-specific error paths.
@@ -87,4 +134,5 @@ Keep related files synchronized:
 - Credential or access-control changes: implementation, tests, `docs/security.md`, and troubleshooting guidance.
 - MCP surface changes: `mcp_email_server/app.py`, tests, and `docs/tools.md`.
 - CLI or transport changes: `mcp_email_server/cli.py`, tests, and `docs/transports.md`.
+- Architecture, workflow, persistence, or security-boundary changes: owning files under `spec/`, tests, and relevant published docs when implemented.
 - Quick-start changes: `README.md`, `docs/getting-started.md`, and `mkdocs.yml` when navigation changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,21 @@ make test
 make docs-test
 ```
 
-The CI pipeline runs the test suite against every supported Python version.
+Changes to IMAP, SMTP, MCP stdio, configuration loading, attachment handling, or
+mailbox mutations should also run the Docker-backed black-box baseline:
+
+```bash
+make test-e2e
+```
+
+This command requires Docker, starts an isolated GreenMail instance bound only
+to loopback, and removes it after the test. See the
+[validation guide](https://mcp-email-server.wh1isper.top/validation/) for the
+covered flows and limitations.
+
+The CI pipeline runs the unit test suite against every supported Python version.
+The GreenMail baseline is currently an explicit local check rather than a
+required CI job.
 
 9. Commit your changes and push your branch to GitHub:
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ test: ## Test the code with pytest
 	@echo "🚀 Testing code: Running pytest"
 	@uv run python -m pytest --cov --cov-config=pyproject.toml --cov-report=xml -vv -s
 
+.PHONY: test-e2e
+test-e2e: ## Test the stdio MCP server against local GreenMail SMTP and IMAP services
+	@echo "Testing the stdio MCP server against GreenMail"
+	@dev/greenmail/run-e2e.sh
+
 .PHONY: build
 build: clean-build ## Build wheel file
 	@echo "🚀 Creating wheel file"

--- a/dev/greenmail/compose.yml
+++ b/dev/greenmail/compose.yml
@@ -1,0 +1,13 @@
+services:
+  greenmail:
+    image: greenmail/standalone:2.1.11@sha256:53cf220d34e4f2ca9e216f9ae5d9051624780ee510740370b8026915094b87fa
+    environment:
+      GREENMAIL_OPTS: >-
+        -Dgreenmail.setup.test.smtp
+        -Dgreenmail.setup.test.imap
+        -Dgreenmail.hostname=0.0.0.0
+        -Dgreenmail.users=alice:alice-password@example.test,bob:bob-password@example.test
+        -Dgreenmail.users.login=email
+    ports:
+      - "127.0.0.1::3025"
+      - "127.0.0.1::3143"

--- a/dev/greenmail/run-e2e.sh
+++ b/dev/greenmail/run-e2e.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+compose_file="${repository_root}/dev/greenmail/compose.yml"
+compose_project="mcp-email-server-e2e-$$-${RANDOM}"
+compose_started=false
+
+cleanup() {
+    if [[ "${compose_started}" == true ]]; then
+        docker compose --project-name "${compose_project}" --file "${compose_file}" down --volumes --remove-orphans
+    fi
+}
+trap cleanup EXIT
+
+cd "${repository_root}"
+docker info >/dev/null
+compose_started=true
+docker compose --project-name "${compose_project}" --file "${compose_file}" up --detach
+smtp_port="$(docker compose --project-name "${compose_project}" --file "${compose_file}" port greenmail 3025 | sed 's/.*://')"
+imap_port="$(docker compose --project-name "${compose_project}" --file "${compose_file}" port greenmail 3143 | sed 's/.*://')"
+printf 'GreenMail project %s is using SMTP port %s and IMAP port %s\n' "${compose_project}" "${smtp_port}" "${imap_port}"
+MCP_EMAIL_SERVER_E2E_SMTP_PORT="${smtp_port}" \
+    MCP_EMAIL_SERVER_E2E_IMAP_PORT="${imap_port}" \
+    uv run pytest -o addopts= -m e2e tests/e2e

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -21,7 +21,9 @@ The command creates a unique Compose project, publishes SMTP and IMAP on
 dynamic loopback ports, waits by performing authenticated connections, runs the
 E2E test, and removes only that run's container and network even when the test
 fails. Concurrent runs and separate worktrees do not share lifecycle ownership.
-It does not modify the normal user configuration.
+Each MCP request has a 15-second response deadline so a live but unresponsive
+stdio subprocess fails the test instead of hanging indefinitely. The run does
+not modify the normal user configuration.
 
 The regular test suite excludes tests marked `e2e` and remains independent of
 Docker:

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,130 @@
+# Validation
+
+The repository includes a Docker-backed black-box baseline for the current
+application. It verifies that the installed MCP stdio server can communicate
+with real SMTP and IMAP sockets before architecture changes are accepted.
+
+## Run the baseline
+
+Requirements:
+
+- Docker Engine with Docker Compose v2.
+- The development environment installed with `uv sync` or `make install`.
+
+Run:
+
+```bash
+make test-e2e
+```
+
+The command creates a unique Compose project, publishes SMTP and IMAP on
+dynamic loopback ports, waits by performing authenticated connections, runs the
+E2E test, and removes only that run's container and network even when the test
+fails. Concurrent runs and separate worktrees do not share lifecycle ownership.
+It does not modify the normal user configuration.
+
+The regular test suite excludes tests marked `e2e` and remains independent of
+Docker:
+
+```bash
+make test
+```
+
+## Tested boundary
+
+```mermaid
+graph LR
+    CLIENT[MCP ClientSession]
+    STDIO[mcp-email-server stdio subprocess]
+    CONFIG[Temporary TOML configuration]
+    SMTP[GreenMail SMTP]
+    IMAP[GreenMail IMAP]
+    OBSERVER[Independent smtplib and imaplib observer]
+
+    CLIENT -->|initialize, list_tools, call_tool| STDIO
+    CONFIG --> STDIO
+    STDIO -->|SMTP AUTH and delivery| SMTP
+    STDIO -->|IMAP LOGIN and commands| IMAP
+    SMTP --> IMAP
+    OBSERVER -->|seed and independently verify| SMTP
+    OBSERVER -->|inspect MIME, flags, folders, and bytes| IMAP
+```
+
+The test starts the installed `mcp-email-server` console script as a child
+process rather than importing tool functions. The subprocess loads a temporary
+plaintext TOML file containing only synthetic test credentials. Python's
+standard-library `smtplib`, `imaplib`, and MIME parser act as an independent
+seeder and observer, so the system is not solely verifying itself.
+
+## Coverage
+
+| Area          | Assertions                                                                                             |
+| ------------- | ------------------------------------------------------------------------------------------------------ |
+| MCP lifecycle | stdio subprocess starts, `initialize` succeeds, and expected tools are visible                         |
+| Configuration | two accounts load from temporary TOML; SMTP-capable and IMAP-only accounts coexist                     |
+| SMTP          | authenticated Alice-to-Bob delivery succeeds through `send_email`                                      |
+| IMAP read     | Bob can list metadata and retrieve full content by UID                                                 |
+| Attachments   | source bytes arrive in Bob's MIME message, appear in full content, download to disk, and match exactly |
+| Sent copy     | Alice receives the application-created copy in `Sent`                                                  |
+| Flags         | `mark_emails_as_read` produces `\\Seen`; saved drafts have `\\Draft` and `\\Seen`                      |
+| Mailboxes     | the observer provisions `Sent`, `Drafts`, and `Archive`; MCP discovers and uses them                   |
+| Mutations     | explicit move, automatic archive selection, draft save, and delete are observed in IMAP                |
+
+`list_emails_metadata` currently fetches headers only and therefore returns an
+empty attachment list. Attachment names are verified through
+`get_emails_content`, which fetches and parses the complete MIME message. The
+baseline records this existing contract rather than silently changing it.
+
+## Isolation and security
+
+The Compose definition:
+
+- pins GreenMail 2.1.11 by both tag and image digest;
+- exposes only SMTP and IMAP on dynamically assigned loopback ports;
+- gives each invocation a unique Compose project so concurrent cleanup cannot affect another run;
+- uses only `example.test` addresses and fixed synthetic passwords;
+- disables implicit TLS only inside this local test boundary; and
+- never forwards messages to external mail servers.
+
+The application configuration lives in a pytest-managed temporary directory
+and contains only the fixed synthetic credentials above. Do not replace the
+synthetic accounts with real credentials or personal message data.
+
+## Why GreenMail
+
+[GreenMail](https://greenmail-mail-test.github.io/greenmail/) is designed as a
+sandbox mail server for integration tests and provides SMTP and IMAP with a
+small, deterministic setup. The repository uses the official
+[`greenmail/standalone`](https://hub.docker.com/r/greenmail/standalone) image.
+
+GreenMail is a compatibility baseline, not proof against every provider. This
+baseline also does not cover implicit TLS or STARTTLS; those paths retain their
+focused unit tests until a dedicated certificate-backed integration service is
+added. A future nightly matrix can add a production-oriented server such as
+[Stalwart](https://stalw.art/docs/install/platform/docker/) and targeted canary
+accounts for provider-specific behavior. Real-provider canaries must use
+separate test accounts, minimal retention, and credentials supplied outside the
+repository.
+
+## Troubleshooting
+
+The runner prints its unique Compose project name and assigned ports. If a run
+is interrupted before cleanup completes, list matching projects with:
+
+```bash
+docker compose ls --all | grep mcp-email-server-e2e
+```
+
+Use the printed project name to inspect logs or remove only that run:
+
+```bash
+docker compose \
+  --project-name <printed-project-name> \
+  --file dev/greenmail/compose.yml \
+  logs greenmail
+
+docker compose \
+  --project-name <printed-project-name> \
+  --file dev/greenmail/compose.yml \
+  down --volumes --remove-orphans
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Configuration: configuration.md
+  - Validation: validation.md
   - MCP Tools: tools.md
   - Transports: transports.md
   - Security: security.md

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 # pytest.ini
 [pytest]
 asyncio_mode = auto
+addopts = -m "not e2e"
+markers =
+    e2e: requires the repository GreenMail Docker service and exercises real SMTP/IMAP sockets
 # asyncio_default_fixture_loop_scope =

--- a/spec/01-system-context.md
+++ b/spec/01-system-context.md
@@ -1,0 +1,250 @@
+# 01. System Context
+
+Status: Proposed
+
+Previous: [`README.md`](README.md)
+Next: [`02-application-boundaries.md`](02-application-boundaries.md)
+
+## Purpose
+
+The target product is a local Email App for one operating-system user. It
+connects to existing IMAP and SMTP services, maintains a performant local index
+in SQLite, exposes mail operations to MCP clients over stdio, and exposes local
+management through a CLI.
+
+The application is not a mail server. IMAP remains authoritative for mailbox
+contents and flags, and SMTP remains authoritative for delivery acceptance.
+SQLite accelerates discovery, search, and repeated reads and records enough
+local state to reconcile non-atomic mail workflows.
+
+## Actors and External Systems
+
+```mermaid
+flowchart LR
+    USER[Local user]
+    MCP_CLIENT[MCP client]
+    SHELL[Shell]
+    APP[Local Email App]
+    SQLITE[(SQLite)]
+    KEYRING[OS keyring]
+    LEGACY[Legacy TOML and environment]
+    IMAP[Remote IMAP server]
+    SMTP[Remote SMTP server]
+    WORKSPACE[Private local workspace]
+
+    USER --> MCP_CLIENT
+    USER --> SHELL
+    MCP_CLIENT -->|stdio| APP
+    SHELL -->|management CLI| APP
+    APP --> SQLITE
+    APP --> KEYRING
+    APP --> LEGACY
+    APP --> IMAP
+    APP --> SMTP
+    APP --> WORKSPACE
+```
+
+### Local user
+
+The local user chooses the accounts, credential backend, sender and recipient
+policies, index scope, cache limits, and client configuration. Filesystem and
+keyring access run with that user's operating-system permissions.
+
+### MCP client
+
+The MCP client starts one server subprocess and exchanges newline-delimited MCP
+messages over stdin and stdout. It may independently decide how tools,
+resources, prompts, approvals, and structured results appear to the user.
+
+### Management CLI
+
+The CLI is the trusted local management plane. It accepts secret input through a
+masked prompt, manages the SQLite catalog, imports legacy configuration,
+validates account connectivity, and performs explicit index and cache
+maintenance. Secret-bearing account creation is not a target MCP workflow.
+
+### IMAP and SMTP services
+
+IMAP supplies mailbox structure, message metadata, bodies, flags, and mutation
+results. SMTP accepts outbound messages. Provider-specific capabilities remain
+behind mail adapters.
+
+## Goals
+
+- Separate MCP and CLI mapping from email policy, persistence, secrets, and
+  provider protocols.
+- Make common mailbox listing and search operations fast through a local SQLite
+  metadata index.
+- Reuse indexed state across independent MCP and CLI processes.
+- Preserve current TOML, environment, and keyring configurations while providing
+  an explicit path into the managed SQLite catalog.
+- Keep credentials out of ordinary database rows and model-visible MCP input.
+- Bound tool schemas and results so a large mailbox or message cannot exhaust an
+  LLM context window.
+- Preserve mail consistency rules across the MCP and CLI interfaces.
+- Keep the architecture understandable: introduce only boundaries required by
+  the local product.
+
+## Non-goals
+
+- Streamable HTTP, SSE, remote MCP access, or a hosted API.
+- Multi-user, tenant, role, or remote authentication models.
+- A daemon, scheduler, or always-running background synchronizer.
+- Replacing IMAP with a complete offline replica.
+- Persisting all bodies, raw MIME, or attachment payloads.
+- Supporting interchangeable SQL engines.
+- Building a web UI or MCP App as part of this proposal.
+- Moving secrets into unencrypted SQLite columns.
+- Guaranteeing exactly-once behavior across ambiguous SMTP or IMAP network
+  failures.
+
+An additional interface could be designed later because application services do
+not import FastMCP, but this proposal defines no remote transport abstractions.
+
+## Process Model
+
+### MCP process
+
+The MCP client owns the stdio subprocess lifecycle:
+
+1. the process resolves bootstrap settings and opens the local database;
+2. it validates or applies SQLite migrations;
+3. it constructs repositories, secret stores, mail gateways, policies, and
+   application services;
+4. it constructs a stable MCP server and completes capability negotiation;
+5. it handles tool requests until stdin closes or the process is terminated;
+6. it closes mail sessions and database resources before exit when possible.
+
+The process does not start an independent synchronization loop. Metadata refresh
+occurs within an explicit tool request or management command.
+
+### CLI process
+
+Each CLI command creates the same application runtime with a CLI adapter. It may
+run concurrently with a client-owned MCP process against the same SQLite file.
+Commands therefore use short transactions, revisions, and idempotent upserts;
+they do not assume exclusive process ownership.
+
+```mermaid
+sequenceDiagram
+    participant C as MCP client
+    participant P as stdio process
+    participant D as SQLite
+    participant M as IMAP or SMTP
+
+    C->>P: start process
+    P->>D: open, validate schema, load bootstrap state
+    C->>P: initialize
+    P-->>C: negotiated capabilities and stable catalog
+    C->>P: tools/call
+    P->>D: resolve operational identity and index state
+    P->>M: bounded mail operation from effective config when required
+    M-->>P: provider result
+    P->>D: short reconciliation transaction
+    P-->>C: bounded result
+    C->>P: close stdin or terminate
+    P->>P: close resources
+```
+
+## Runtime State
+
+Runtime state is deliberately small:
+
+- immutable bootstrap settings for database location, compatibility mode, and
+  only the safety ceilings required before SQLite can be opened;
+- process-local environment overlays captured at startup;
+- a stable application service graph;
+- lazy, bounded IMAP and SMTP sessions;
+- SQLite connections owned by the persistence adapter;
+- cancellation and correlation context for the current operation.
+
+Managed accounts and managed policy are read through revision-aware repositories
+rather than copied into mutable global settings. Legacy and environment accounts
+reuse SQLite operational identities without becoming managed configuration rows.
+Ordinary updates within the same mode become visible to the next MCP operation
+without replacing the tool catalog. Managed-mode cache, index, artifact, and
+mutation policy comes from SQLite; legacy compatibility policy remains in its
+TOML/environment adapter. Bootstrap holds only pre-database safety ceilings.
+
+A mode/catalog-generation transition requires a stdio restart. For mutations,
+the attempt's effect-boundary transition verifies generation atomically with
+advancing to `REMOTE_EFFECT_POSSIBLE` or its typed equivalent. An older process
+therefore returns `RESTART_REQUIRED` without a new provider side effect if the
+catalog transition committed first. A provider call whose boundary committed
+first may finish and reconcile with its original validated snapshot; every later
+independent side-effect substep checks generation again.
+
+## Local Concurrency Model
+
+SQLite is shared by local processes, not by tenants or remote users.
+
+- WAL mode allows readers while another process commits a short write.
+- A bounded busy timeout handles brief writer contention.
+- Database migrations and destructive maintenance use an explicit local lock.
+- IMAP, SMTP, keyring, and large filesystem operations occur outside database
+  transactions.
+- Synchronization writes use idempotent upserts and compare the cursor revision
+  before advancing it.
+- A stale or conflicting refresh may discard its cursor advancement and retry
+  reconciliation; it does not hold a database lock during network access.
+- Provider-effect operations use fenced attempt records. The conditional effect
+  transition verifies both claim ownership and catalog generation. A stale claim
+  from before that persisted boundary may be reclaimed, while a stale claim after
+  it becomes an unknown outcome and is not replayed.
+- Sending is never automatically repeated merely because a local lock or
+  reconciliation write failed.
+
+No renewable runtime lease or single-daemon ownership protocol is required.
+
+## Online and Indexed Behavior
+
+The app supports three explicit data states:
+
+| State       | Meaning                                                                                                                    |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `indexed`   | The requested result is satisfied by SQLite within the declared freshness policy.                                          |
+| `refreshed` | The operation contacted IMAP, reconciled SQLite, and returned the new view.                                                |
+| `partial`   | The local index does not cover the full requested range; the result reports coverage and a continuation or refresh action. |
+
+A local result never silently claims complete mailbox coverage when only a
+partial index exists. Exact counts are returned only when they are known.
+
+## Trust Boundaries
+
+The process runs as the local user, but its inputs are still untrusted:
+
+- MCP tool arguments are model-generated and client-mediated.
+- Email headers, HTML, bodies, filenames, and MIME metadata are attacker-controlled.
+- IMAP and SMTP responses may be malformed or inconsistent.
+- Legacy TOML and environment values may be invalid or secret-bearing.
+- Local paths may attempt traversal or access outside approved roots.
+
+Application policy validates every operation even when the MCP client already
+showed an approval dialog. Detailed tool and file controls are defined in
+[`06-mcp-interface-and-client-compatibility.md`](06-mcp-interface-and-client-compatibility.md).
+
+## Product Invariants
+
+- There is one local operating-system user, not an application principal model.
+- Rebuildable mail-index rows may be purged and recreated, but deleting the whole
+  SQLite file also destroys managed configuration and operation evidence and is
+  not an index-rebuild procedure.
+- A guarded database reset inventories persisted secret bindings before deletion
+  and requires cleanup or an explicit backup/retention decision. Uncoordinated
+  SQLite-file loss can leave keyring values that a non-enumerable backend cannot
+  rediscover; diagnostics must state that limitation rather than promise complete
+  orphan detection.
+- Deleting a keyring secret does not silently downgrade to a different secret
+  backend.
+- Mail reads do not mutate remote state unless the operation explicitly requests
+  a mutation.
+- Every response reports whether it came from indexed, refreshed, or partial
+  state when that distinction affects correctness.
+
+## Related Specs
+
+- Module and service ownership: [`02-application-boundaries.md`](02-application-boundaries.md)
+- Configuration and secrets: [`03-configuration-and-credentials.md`](03-configuration-and-credentials.md)
+- Mail consistency: [`04-mail-workflows-and-consistency.md`](04-mail-workflows-and-consistency.md)
+- SQLite and cache behavior: [`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md)
+- MCP and client behavior: [`06-mcp-interface-and-client-compatibility.md`](06-mcp-interface-and-client-compatibility.md)

--- a/spec/02-application-boundaries.md
+++ b/spec/02-application-boundaries.md
@@ -1,0 +1,371 @@
+# 02. Application Boundaries
+
+Status: Proposed
+
+Previous: [`01-system-context.md`](01-system-context.md)
+Next: [`03-configuration-and-credentials.md`](03-configuration-and-credentials.md)
+
+## Design Principle
+
+The architecture separates user actions from the protocols and storage used to
+perform them. FastMCP, Typer, SQLite, keyring, IMAP, SMTP, MIME parsing, and the
+filesystem are adapters. Application services own use-case sequencing and
+policy. Domain models describe mail concepts without carrying framework types.
+
+This is a focused local architecture, not a generic framework. Ports exist only
+where the product already needs multiple behavior implementations, a test seam,
+or a strict security boundary.
+
+## Composition Root
+
+A single `create_runtime()` composition root constructs the local application.
+It accepts explicit bootstrap settings and an interface profile and returns
+interface-ready services.
+
+```mermaid
+flowchart TD
+    BOOT[create_runtime]
+    RUNTIME[ApplicationRuntime]
+    ACCOUNTS[AccountManagementService]
+    QUERIES[MailQueryService]
+    COMMANDS[MailCommandService]
+    INDEX[IndexService]
+    ARTIFACTS[ArtifactService]
+    PORTS[Application ports]
+    ADAPTERS[Local adapters]
+
+    BOOT --> RUNTIME
+    RUNTIME --> ACCOUNTS
+    RUNTIME --> QUERIES
+    RUNTIME --> COMMANDS
+    RUNTIME --> INDEX
+    RUNTIME --> ARTIFACTS
+    ACCOUNTS --> PORTS
+    QUERIES --> PORTS
+    COMMANDS --> PORTS
+    INDEX --> PORTS
+    ARTIFACTS --> PORTS
+    ADAPTERS -. implement .-> PORTS
+```
+
+`create_runtime()` is responsible for:
+
+- resolving the database path and compatibility mode;
+- opening and validating SQLite;
+- selecting the secret backend explicitly;
+- constructing the legacy configuration and environment overlay adapters;
+- constructing repository, mail, MIME, clock, and artifact adapters;
+- constructing application services with policy and limit values;
+- registering shutdown callbacks.
+
+It does not start stdio, parse CLI arguments, register tools, or perform mail
+network calls.
+
+## Layers
+
+### Domain
+
+The domain layer owns values and policies that remain meaningful without a
+particular transport or database:
+
+- `AccountId`, `AccountName`, and account capability values;
+- `MailboxRef`, `MessageId`, and `MessagePlacement`;
+- normalized email addresses and recipient roles;
+- flags, attachment metadata, freshness, and index coverage values;
+- sender, recipient, mutation, and local-path policies;
+- operation states and typed domain errors.
+
+Domain models never contain:
+
+- `sqlite3.Row` or SQL column names;
+- FastMCP content blocks or tool exceptions;
+- IMAP response tuples or SMTP client objects;
+- keyring service names or plaintext credentials;
+- arbitrary filesystem paths used as storage identifiers.
+
+### Application
+
+The application layer owns commands, queries, transaction intent, policy
+enforcement, and typed DTOs.
+
+#### `AccountManagementService`
+
+Used primarily by CLI management commands:
+
+- initialize and inspect managed configuration;
+- list account summaries and their source;
+- create, update, disable, soft-remove, guarded hard-purge, and test managed
+  accounts;
+- bind, rotate, migrate, repair, and remove credentials through persisted
+  secret-change state;
+- preview and import legacy configuration;
+- report shadowed environment accounts and unresolved secrets.
+
+#### `MailQueryService`
+
+Used by MCP read tools and optional CLI diagnostics:
+
+- list accounts and account capabilities;
+- list mailboxes;
+- search indexed message metadata;
+- refresh a bounded metadata range when requested;
+- read bounded message body sections;
+- list attachment metadata;
+- report freshness and index coverage.
+
+#### `MailCommandService`
+
+Owns externally visible mutations:
+
+- send a message;
+- save a draft or message to a mailbox;
+- mark, move, archive, and delete messages;
+- reconcile confirmed remote outcomes into SQLite;
+- distinguish complete, partial, uncertain, and failed outcomes.
+
+#### `IndexService`
+
+Owns explicit and on-demand metadata maintenance:
+
+- discover mailbox changes;
+- upsert metadata and placements;
+- advance cursors transactionally;
+- invalidate a mailbox on UIDVALIDITY change;
+- rebuild FTS projections;
+- purge expired body cache and stale metadata.
+
+#### `ArtifactService`
+
+Owns bounded local materialization:
+
+- validate approved input and output roots;
+- stream attachment and export data without arbitrary path traversal;
+- create private temporary files;
+- return opaque artifact metadata or an approved local path;
+- clean up expired temporary artifacts.
+
+### Interfaces
+
+Interfaces map external syntax to application DTOs and map typed results and
+errors back to the external contract.
+
+- The MCP adapter registers a stable stdio tool catalog and optional resource or
+  prompt enhancements.
+- The CLI adapter parses human input, masks secret prompts, renders status and
+  diagnostics, and chooses exit codes.
+
+An interface must not instantiate `EmailClient`, access global settings, execute
+SQL, or decide sender/recipient policy.
+
+### Adapters
+
+Adapters implement concrete side effects:
+
+- SQLite migrations, repositories, FTS, and unit-of-work behavior;
+- current TOML loading and legacy persistence behavior;
+- environment runtime overlays;
+- OS keyring and explicit plaintext compatibility storage;
+- IMAP, SMTP, MIME parsing, mailbox discovery, and provider quirks;
+- private filesystem workspace operations;
+- process time and ID generation.
+
+## Application Ports
+
+Ports are narrow and use application or domain types.
+
+### Persistence ports
+
+- `AccountIdentityRepository`: stable operational IDs and non-secret source
+  mappings for managed, legacy, and environment accounts without copying legacy
+  configuration into managed rows.
+- `AccountRepository`: managed catalog lifecycle and generation, global/account
+  policy, normalized rule sets, non-secret managed account definitions, endpoint
+  settings, revisions, and tombstones.
+- `CredentialChangeRepository`: active, candidate, and pending-cleanup bindings
+  plus persisted secret-change saga states.
+- `MailIndexRepository`: mailboxes, messages, placements, addresses, body cache,
+  attachments, search projections, and sync cursors.
+- `OperationRepository`: durable per-recipient and compound-step evidence plus
+  fenced pre-effect and remote-effect-possible attempt transitions for send and
+  other mutations.
+- `UnitOfWork`: one short SQLite transaction across repositories when an
+  application invariant requires atomic local state.
+
+These ports are not a promise to support another database. They isolate SQL
+schema details and permit deterministic service tests.
+
+### Configuration and credential ports
+
+- `LegacyConfigReader`: reads the existing stored TOML model without accidental
+  environment persistence.
+- `RuntimeOverlayProvider`: supplies the process-local environment overlay.
+- `SecretStore`: resolves values and creates or deletes independently addressable
+  managed secret versions by opaque reference. Candidate identity is reservable
+  before the value write. A compatibility backend that can only replace in place
+  must expose atomic compare-and-swap plus a durable rollback/version handle
+  recoverable by pre-persisted change ID after process loss.
+
+Read-only and mutable secret backends expose different capabilities. Application
+code must not call a write method and discover only at runtime that an
+environment backend is immutable.
+
+### Mail ports
+
+- `MailGateway`: account-scoped mailbox discovery, metadata fetch, body and
+  attachment fetch, flags, move, append, and delete operations.
+- `MessageSender`: SMTP submission with per-envelope-recipient accepted,
+  rejected, or unknown evidence.
+- `MimeCodec`: bounded parsing and message composition.
+
+Splitting SMTP submission from IMAP mailbox operations makes the sent-copy
+partial-success boundary explicit.
+
+### Local service ports
+
+- `ArtifactWorkspace`: private, quota-aware stream storage and approved-path
+  materialization.
+- `Clock`: testable time.
+- `IdFactory`: stable account, message, operation, and artifact identifiers.
+
+No `HostIntegration`, daemon lease, tenant repository, or HTTP session port is
+part of this design.
+
+## Request and Transaction Boundary
+
+Every external action maps to one application command or query:
+
+```mermaid
+sequenceDiagram
+    participant I as MCP or CLI adapter
+    participant A as Application service
+    participant P as Policy
+    participant R as Repository port
+    participant M as Mail port
+
+    I->>A: typed command or query
+    A->>R: load local snapshot
+    R-->>A: domain values and revision
+    A->>P: validate capability and policy
+    alt remote access required
+        A->>M: bounded provider operation
+        M-->>A: typed provider result
+        A->>R: short reconciliation unit of work
+    end
+    A-->>I: typed result or typed error
+    I-->>I: interface-specific mapping only
+```
+
+Network activity happens before or after, never during, the short local
+transaction. Where a remote result and local write cannot be atomic, the
+application persists an explicit reconciliation state rather than claiming
+transactional behavior across systems.
+
+## Runtime Scope
+
+`ApplicationRuntime` is process-scoped and immutable after construction except
+for owned connection/session pools. Managed account and policy data is loaded
+through repositories for each operation or a revision-aware cache.
+
+An `OperationContext` is call-scoped and contains only:
+
+- correlation and cancellation state;
+- current time budget;
+- requested freshness and output limits;
+- an immutable account snapshot once resolved.
+
+There is no user principal, tenant, HTTP session, or global mutable `Settings`
+object in the application contract.
+
+## Target Package Ownership
+
+```text
+mcp_email_server/
+  domain/
+    accounts.py
+    mail.py
+    policies.py
+    errors.py
+  application/
+    dto.py
+    ports.py
+    accounts.py
+    mail_queries.py
+    mail_commands.py
+    indexing.py
+    artifacts.py
+  adapters/
+    sqlite/
+      database.py
+      migrations.py
+      repositories.py
+      search.py
+    config/
+      legacy.py
+      environment.py
+    secrets/
+      keyring.py
+      plaintext.py
+    mail/
+      imap.py
+      smtp.py
+      mime.py
+    artifacts.py
+  interfaces/
+    mcp.py
+    cli.py
+  bootstrap.py
+```
+
+This is an ownership map, not a requirement to create one file for every name or
+to move all code at once. Small modules may be combined when the dependency
+rules remain clear.
+
+## Dependency Rules
+
+- Domain imports only standard-library and domain-safe modeling utilities.
+- Application imports domain types and port protocols, not adapter modules.
+- Interfaces and adapters may depend on application contracts.
+- Interfaces never depend directly on one another.
+- Repository APIs return domain/application values, not rows or connections.
+- Mail adapters return typed provider results, not response strings that an
+  application service must parse.
+- Secret values are resolved only immediately before constructing a mail client
+  and are not attached to long-lived account DTOs returned to interfaces.
+- Database transactions never include IMAP, SMTP, keyring, or large filesystem
+  operations.
+- Logging accepts structured identifiers and error codes, not secret values or
+  message content.
+
+## Compatibility Facades
+
+Existing public modules may delegate into the new boundaries while compatibility
+is required:
+
+- `mcp_email_server.app` may continue to export `mcp` and current tool callables;
+- `mcp_email_server.config` may continue to export current models and functions;
+- `mcp_email_server.emails.classic` may continue to export current handlers;
+- `mcp_email_server.cli` remains the console entry point.
+
+The currently published `sse`, `streamable-http`, and Gradio `ui` commands are
+legacy compatibility entry points. They do not use or expand the proposed local
+stdio runtime, and this spec adds no new behavior to them. They remain maintained
+against current published behavior until a separately documented, versioned
+removal or replacement decision updates code, tests, and user documentation.
+
+A facade may preserve response text or legacy mutation behavior. New
+application code must not import back through the facade. Public compatibility
+changes require aligned tests and published documentation even though this spec
+does not prescribe a release phase plan.
+
+## Testing Boundaries
+
+- Domain policy tests use only values.
+- Application service tests use fake ports and assert commands, outcomes, and
+  transaction intent.
+- SQLite tests use temporary real databases and real migrations.
+- Mail adapter tests use deterministic protocol fakes plus the GreenMail E2E
+  baseline where applicable.
+- MCP tests verify discovery schemas, annotations, text and structured results,
+  error mapping, and context bounds.
+- CLI tests verify secret masking, source selection, dry runs, exit codes, and
+  concurrency-safe writes.

--- a/spec/03-configuration-and-credentials.md
+++ b/spec/03-configuration-and-credentials.md
@@ -1,0 +1,461 @@
+# 03. Configuration and Credentials
+
+Status: Proposed
+
+Previous: [`02-application-boundaries.md`](02-application-boundaries.md)
+Next: [`04-mail-workflows-and-consistency.md`](04-mail-workflows-and-consistency.md)
+
+## Purpose
+
+The local Email App needs a managed configuration model without breaking current
+TOML, environment-variable, and keyring users. It also needs one unambiguous
+source of truth for writable account data and a strict boundary between
+non-secret configuration and credentials.
+
+The target supports two explicit base modes:
+
+- **managed mode**: SQLite owns non-secret account and policy configuration;
+- **legacy mode**: the existing TOML model remains the base configuration.
+
+Environment values are a read-only runtime overlay in both modes. They never
+become a second writable source of truth.
+
+## Bootstrap Settings
+
+A small bootstrap model is resolved before SQLite can be opened. It includes
+only values needed to locate and safely initialize the local runtime:
+
+- database path;
+- selected base mode, when explicitly configured;
+- migration and lock timeouts;
+- process-level logging settings;
+- emergency read-only or maintenance flags.
+
+The existing `db_location` value and default location remain compatible inputs.
+An environment or CLI override may select a different database path. Database
+path selection cannot be stored only inside the database it is needed to find.
+
+Bootstrap settings do not contain account passwords or a second copy of the
+managed account catalog.
+
+## Configuration Sources
+
+```mermaid
+flowchart LR
+    BOOT[Bootstrap settings]
+    MODE{Base mode}
+    DB[(Managed SQLite catalog)]
+    TOML[Legacy TOML]
+    ENV[Environment overlay]
+    SOURCE[Attributed effective source]
+    IDENTITY[(OperationalIdentityRepository in SQLite)]
+    SNAPSHOT[Validated account snapshot]
+    SECRETS[SecretStore resolver]
+    RUNTIME[Operation-scoped runtime]
+
+    BOOT --> MODE
+    MODE -->|managed| DB
+    MODE -->|legacy| TOML
+    DB --> SOURCE
+    TOML --> SOURCE
+    ENV --> SOURCE
+    SOURCE -->|managed ID or source key and fingerprint| IDENTITY
+    SOURCE -->|config and policy provenance| SNAPSHOT
+    IDENTITY -->|stable account_id| SNAPSHOT
+    SNAPSHOT --> SECRETS
+    SECRETS --> RUNTIME
+```
+
+The managed catalog and operational identity repository use the same SQLite file
+but are separate logical stores. Managed, legacy, and environment effective
+sources all resolve through the identity repository. Only the managed branch
+supplies writable account configuration to SQLite.
+
+### Managed SQLite catalog
+
+Managed mode stores a managed account row linked to operational identity,
+endpoint settings, enablement, global and account policy, catalog generation,
+revisions, and secret bindings in SQLite. It is the only writable base catalog
+in that mode. Scalar policy and normalized allowlist or approved-root rules have
+explicit schema ownership as defined in
+[`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md).
+
+### Legacy TOML
+
+Legacy mode preserves current file location, path migration, model validation,
+credential mode, and serialization behavior behind a compatibility adapter. The
+adapter distinguishes stored state from the environment-composited effective
+view even when a facade must preserve current whole-view writes.
+
+### Environment overlay
+
+Environment values are captured at process startup and applied after the base
+catalog. Existing account replacement and setting precedence remain compatible.
+Every effective value records its source so CLI diagnostics can show when a
+managed or legacy value is shadowed.
+
+Environment-derived accounts and overrides are:
+
+- read-only;
+- process-scoped;
+- never imported or persisted by an unrelated account update;
+- eligible for mail operations after normal validation;
+- clearly marked as `environment` source in account summaries.
+
+### Operational identity in every mode
+
+The SQLite operational index uses a local `account_id` independently of the base
+configuration source. Legacy and environment accounts create or reuse only an
+`ACCOUNT_IDENTITY` plus a non-secret `ACCOUNT_SOURCE` mapping; they do not create
+`MANAGED_ACCOUNT`, endpoint, policy, or credential-binding rows. Exact source
+key/fingerprint reuse, rename, shadowing, disappearance, and import continuity
+are normative in
+[`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md).
+
+This separation lets legacy mode persist mail metadata and operation evidence
+without copying TOML or environment configuration into a second authoritative
+catalog.
+
+## Mode Selection
+
+Mode selection must be deterministic and must not silently import credentials.
+
+1. An explicit CLI or bootstrap setting wins only when its requested base is
+   valid; requesting managed mode without an `ACTIVE` catalog is an error.
+2. An `ACTIVE` managed catalog selects managed mode; a `MAINTENANCE` catalog
+   selects a management-only runtime and never falls back to legacy mail access.
+3. If neither active nor maintenance catalog exists and a current or legacy TOML
+   file exists, select legacy mode.
+4. If only a valid environment account exists, run a legacy-compatible effective
+   view without creating managed account rows; operational identity and index
+   rows may still be reused.
+5. Otherwise, the runtime is unconfigured and the CLI directs the user to
+   initialize or import configuration.
+
+The presence of an empty SQLite file, operational identity rows, or a `STAGING`
+or `FAILED_IMPORT` catalog does not imply a completed managed import. A managed
+catalog stores lifecycle state, catalog generation, policy version, and
+revision. `ACTIVE` selects the managed base; `MAINTENANCE` deliberately disables
+mail access until another generation transition.
+
+## Explicit Legacy Import
+
+Switching to managed mode is a management action, not an automatic startup side
+effect.
+
+```mermaid
+sequenceDiagram
+    participant U as Local user
+    participant CLI as Management CLI
+    participant L as LegacyConfigReader
+    participant D as SQLite
+    participant S as SecretStore
+
+    U->>CLI: config import-legacy --dry-run
+    CLI->>L: load stored legacy state only
+    L-->>CLI: accounts, policies, secret provenance
+    CLI-->>U: conflicts, identity reuse, secret actions, no writes
+    U->>CLI: confirm import
+    CLI->>D: create STAGING catalog and managed rows
+    CLI->>D: persist candidate bindings and PREPARED changes
+    loop each required secret
+        CLI->>S: verify or write pre-recorded locator/version
+        S-->>CLI: bounded success evidence
+        CLI->>D: advance binding and change state
+    end
+    alt every account and binding valid
+        CLI->>D: atomically set ACTIVE and advance generation
+        D-->>CLI: active catalog revision
+        CLI-->>U: imported accounts and retained legacy path
+    else any failure
+        CLI->>D: retain STAGING or mark FAILED_IMPORT
+        CLI-->>U: legacy remains active, run import repair
+    end
+```
+
+Import rules:
+
+- Dry-run is always available and never resolves or prints secret values.
+- Import reads stored TOML without environment account injection.
+- Account-name conflicts require an explicit resolution; no silent overwrite.
+- Existing keyring entries may be referenced without copying their values.
+- Before any managed secret write, import persists a `STAGING` catalog, reuses or
+  creates the operational identity, inserts the managed account and immutable
+  `CANDIDATE` binding, and creates the `PREPARED` change that references it.
+- Plaintext legacy credentials move to the selected managed secret backend only
+  after explicit confirmation and through the same persisted secret-change saga
+  used by managed rotation.
+- The legacy file is retained until the user explicitly archives or removes it.
+- One final transaction verifies every staged account and binding, changes the
+  catalog to `ACTIVE`, and advances generation. No earlier staging write changes
+  base-mode selection.
+- A failed import leaves legacy mode operational. Its exact candidate locators
+  remain repairable from SQLite without backend enumeration; repair may resume or
+  clean them and mark the catalog `FAILED_IMPORT`.
+
+After managed mode is active, TOML is not also writable as a base catalog.
+Re-import requires a deliberate merge operation with conflict reporting.
+
+### Mode-transition visibility
+
+Activating managed mode increments a durable catalog generation. A stdio process
+selects its base mode at startup and does not hot-swap repositories while calls
+may be in flight. It compares its startup generation when accepting every mail
+operation and again before provider access.
+
+For a mutation, the effect boundary is the linearization point. The SQLite
+transition from `CLAIMED_PRE_EFFECT` to `REMOTE_EFFECT_POSSIBLE`, `SUBMITTING`,
+or the equivalent compound substep verifies the startup generation in the same
+conditional transaction. Catalog activation and that transition therefore have
+a deterministic order:
+
+- if activation commits first, the old process receives `RESTART_REQUIRED` and
+  performs no new provider side effect;
+- if an effect-boundary transition commits first, that provider call may finish
+  and reconcile from its already validated snapshot; every later independent or
+  compound side-effect substep checks generation again;
+- ordinary account and policy revisions within the same mode are visible through
+  repository reads on the next operation;
+- the MCP client must restart the stdio server to construct the new base adapter;
+- read-only diagnostics may report the transition but must not continue using a
+  stale writable base.
+
+An operation may use its original snapshot for local validation before the
+boundary; “already started” does not grant permission to cross the boundary
+after a generation change. This conditional transaction closes the check/call
+TOCTOU window for SMTP and IMAP mutations.
+
+The operational SQLite index is available in both legacy and managed modes. Mode
+selection chooses the writable base account and policy catalog; it does not turn
+the mail index on or off.
+
+## Effective Account Snapshot
+
+For each operation, `EffectiveAccountCatalog` creates an immutable snapshot:
+
+1. resolve the selected effective source to its stable operational `account_id`;
+2. load the selected base account and its revision without copying legacy or
+   environment configuration into managed rows;
+3. load managed global policy and account overrides when applicable;
+4. apply compatible environment replacement or per-field setting overrides;
+5. validate account capability and the fully attributed effective policy;
+6. resolve required secret references only for the requested mail operation;
+7. return an operation-scoped account snapshot;
+8. discard secret values when the mail client/session is closed.
+
+List and diagnostic operations do not resolve secret values unless they perform
+an explicit credential or connectivity check.
+
+## Secret Model
+
+A `SecretRef` identifies a value without containing it:
+
+```text
+SecretRef
+  backend: keyring | environment | plaintext_legacy
+  locator: backend-specific opaque identifier
+  purpose: incoming | outgoing | provider
+  version: immutable managed rotation version when the backend is mutable
+```
+
+The locator is internal and never appears in MCP results. SQLite may store the
+backend, opaque locator, purpose, and lifecycle metadata. It must not store the
+resolved secret in ordinary columns, JSON, operation payloads, or FTS content.
+
+### Mutable keyring backend
+
+The OS keyring is the default managed backend. Before writing a managed value,
+the application generates or reserves a new immutable locator or version and
+persists that candidate identity in SQLite; it never overwrites the active
+locator in place. A backend that cannot allocate an independent candidate may be
+used for managed rotation only if one atomic compare-and-swap API provides a
+durable rollback or version handle keyed by the pre-persisted change ID. That
+handle must remain recoverable after process loss without backend enumeration; a
+receipt returned only to process memory is insufficient. Explicit managed
+keyring mode fails closed when those storage guarantees or secure storage are
+unavailable.
+
+The current compatibility key format based on `account_name:role` is an in-place
+replace model. It remains a legacy adapter contract and cannot be reused as the
+managed rotation algorithm without the stronger rollback behavior above.
+
+### Read-only environment backend
+
+An environment binding references a named process variable and supports resolve
+only. The CLI reports that rotation and deletion must happen outside the app.
+Environment references are useful for ephemeral or externally managed accounts,
+but they are not silently converted into persistent keyring values.
+
+### Plaintext legacy backend
+
+Plaintext behavior remains available for compatibility and explicit local use.
+It preserves owner-only atomic file writes on supported platforms. It is not the
+managed default and never results from an implicit keyring fallback in managed
+mode.
+
+The current `auto`, `keyring`, and `plaintext` semantics remain normative while
+legacy mode is selected. In particular, current `auto` fallback behavior is a
+compatibility contract, not the target default for newly managed accounts.
+
+## Credential Writes
+
+Configuration and secret stores cannot share one transaction. Managed secret
+creation, rotation, and import use a persisted saga rather than an unrecorded
+best-effort sequence:
+
+1. validate the complete proposed non-secret update;
+2. in one transaction guarded by the expected account revision, generate or
+   reserve an immutable candidate locator/version, insert its `CANDIDATE`
+   binding, and create one `PREPARED` `SECRET_CHANGE` that references both the
+   old and candidate binding IDs; only one active change is allowed for an
+   account and purpose;
+3. outside the SQLite transaction, write the secret to exactly that pre-recorded
+   candidate locator/version, then mark the intent `CANDIDATE_WRITTEN`;
+4. in one SQLite compare-and-swap transaction, activate the candidate binding,
+   increment the account revision, retain the old binding as
+   `OLD_DELETE_PENDING`, and mark the change `BINDING_COMMITTED`;
+5. mark the change `CLEANUP_PENDING`, then outside the transaction delete the old
+   locator;
+6. mark or remove the old binding as `DELETED` and mark the change `COMPLETED`;
+7. persist bounded error codes and retry state for every incomplete cleanup.
+
+Account removal uses the `DELETE` change variant after the account is durably
+disabled. It persists `PREPARED` with the old binding and a null candidate, then
+in one revision-checked transaction detaches the active binding, marks it
+`OLD_DELETE_PENDING`, and advances the change to `BINDING_COMMITTED`. It then
+uses the same `CLEANUP_PENDING -> COMPLETED` cleanup path. Deletion never needs a
+candidate and never removes a secret still required by an enabled account.
+
+A failed candidate write leaves the active binding untouched. A crash after the
+external write but before `CANDIDATE_WRITTEN` is recoverable because the
+`PREPARED` row already identifies the candidate; repair can probe, reconcile, or
+delete that exact locator without enumeration. If the binding transaction fails,
+only the independent candidate locator may be deleted. A backend that used the
+qualified atomic compare-and-swap alternative must recover through its durable,
+pre-associated rollback/version handle. Deletion by immutable locator is
+idempotent; a not-found result counts as cleaned only after the committed binding
+state proves that locator is no longer active. The application must never delete
+the locator still referenced by the committed account revision.
+
+`credential repair` scans persisted change and pending-cleanup rows. It does not
+assume that a generic keyring backend can enumerate all application entries.
+Account removal and legacy import use the same saga. No saga row contains a
+resolved secret value.
+
+An update never deletes or overwrites the only known working secret before the
+new account revision is durable. Cleanup uncertainty remains repairable and
+visible across process crashes.
+
+## Account Revisions and Concurrent CLI Writes
+
+Managed accounts have stable IDs and monotonic revisions. CLI updates include
+the revision they inspected. If another process changed the account or has an
+active credential change for the same purpose, the update fails with a conflict
+and shows the new summary rather than overwriting it.
+
+Renaming an account changes its display name, not its stable ID or secret
+binding identity. Environment overlays continue to match the documented
+compatibility key; CLI diagnostics must warn when a rename changes shadowing
+behavior.
+
+`account remove` first soft-deletes and disables the account. The stable ID and
+name remain reserved while secret cleanup or retained operation evidence exists.
+A separate hard purge requires completed secret cleanup, no unresolved or
+unknown operation, retention eligibility, explicit confirmation, and a warning
+that historical idempotency evidence will be lost. It follows the guarded,
+explicit account-graph deletion order in
+[`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md);
+completed child rows do not disappear through an implicit cascade.
+
+## CLI Management Contract
+
+The target CLI management surface includes commands equivalent to:
+
+- `config status`, `config init`, and `config import-legacy --dry-run`;
+- `account list`, `account show`, `account add`, `account update`,
+  `account disable`, `account remove`, `account hard-purge`, and `account test`;
+- `credential status`, `credential set`, `credential migrate`, and
+  `credential repair`;
+- `index status`, `index sync`, `index rebuild`, `index purge`, and explicit
+  operational-identity list/rebind/retire actions for legacy source conflicts;
+- `doctor` for database, migration, source identity, secret, filesystem, IMAP,
+  and SMTP checks.
+
+Exact command spelling may follow existing Typer conventions, but the ownership
+rules are normative:
+
+- secret values are read through masked interactive input or a named external
+  source, never echoed;
+- secret values should not be accepted as ordinary positional arguments;
+- every destructive command supports confirmation and non-interactive explicit
+  consent;
+- imports, migrations, and destructive maintenance support dry-run where a
+  preview is meaningful;
+- output identifies whether values are managed, legacy, environment, or
+  shadowed without exposing secret locators.
+
+## MCP Configuration Boundary
+
+The target MCP catalog does not accept mailbox credentials or manage account
+configuration. `add_email_account` currently exists and is therefore a public
+compatibility concern, but it is not part of the target management design.
+Keeping it temporarily requires an explicit compatibility decision and the same
+security controls; new workflows and documentation must direct account setup to
+the CLI.
+
+Mail tools may return an `UNCONFIGURED` or `ACCOUNT_UNAVAILABLE` error with a
+safe CLI remediation command. They do not request a password through tool input
+or MCP elicitation.
+
+## Compatibility Ledger
+
+Legacy mode preserves, unless a separately documented versioned change says
+otherwise:
+
+- current and legacy default TOML path behavior;
+- import-time path compatibility where public code depends on it;
+- environment account injection and replacement precedence;
+- supported environment flags and allowlists;
+- `auto`, `keyring`, and `plaintext` behavior;
+- keyring sentinel resolution and credential migration semantics;
+- current public Pydantic models and imports at compatibility facades;
+- current reset cleanup behavior.
+
+Managed mode deliberately improves these behaviors:
+
+- stored and effective values are separate;
+- environment values are never persisted accidentally;
+- account identity is stable across rename;
+- secrets are represented by explicit references;
+- new account writes do not silently downgrade from keyring to plaintext.
+
+## Security and Validation
+
+Tests cover:
+
+- deterministic mode selection and database path resolution;
+- current and legacy TOML loading;
+- every documented environment override and replacement rule, including present
+  empty allowlists and durable deny precedence;
+- operational identity reuse and conflict behavior for legacy, environment,
+  shadowed, renamed, disappeared, and imported accounts, including canonical
+  fingerprint versions and upgrades, without managed config duplication;
+- managed account and policy revisions, mandatory global rule-set completeness,
+  account absence/inherit behavior, rule-set merge semantics, complete source
+  attribution, and cross-process conflicts;
+- atomic mode-generation/effect-boundary ordering and `RESTART_REQUIRED` before
+  each independent provider side effect;
+- dry-run, staging lifecycle, failed-import rollback, and candidate repair;
+- each secret backend's explicit capabilities;
+- keyring failure plus secret-change crashes before and after every saga boundary;
+- concurrent rotations proving a failed CAS cannot delete or overwrite the active
+  secret;
+- pending cleanup, account soft removal, explicit guarded hard-purge ordering,
+  orphan reporting limitations, and repair without backend enumeration;
+- no secret values in SQLite, logs, MCP results, exception strings, or test
+  snapshots;
+- atomic owner-only plaintext compatibility writes;
+- managed versus legacy reset and backup behavior.
+
+SQLite tables and constraints are defined in
+[`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md).

--- a/spec/04-mail-workflows-and-consistency.md
+++ b/spec/04-mail-workflows-and-consistency.md
@@ -1,0 +1,400 @@
+# 04. Mail Workflows and Consistency
+
+Status: Proposed
+
+Previous: [`03-configuration-and-credentials.md`](03-configuration-and-credentials.md)
+Next: [`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md)
+
+## Consistency Model
+
+IMAP, SMTP, SQLite, the secret backend, and the local filesystem do not share a
+transaction. Application services distinguish remote truth, local indexed
+state, confirmed outcomes, and uncertain outcomes instead of presenting them as
+one atomic system.
+
+SQLite improves performance and recovery, but it does not make provider side
+effects exactly once. The application never retries an ambiguous send merely
+because a local write failed.
+
+## Command and Query Types
+
+Queries return bounded data and declare freshness and coverage. Commands return
+a typed operation outcome and reconcile known remote effects into SQLite.
+
+Every result that depends on indexed state includes:
+
+- `source`: `indexed`, `refreshed`, or `partial`;
+- the index or refresh timestamp;
+- whether the requested range is fully covered;
+- an opaque continuation when more results are available;
+- warnings when local reconciliation remains pending.
+
+Interface adapters may preserve current response shapes, but internal services
+do not infer success by parsing human-readable strings.
+
+## Message Identity
+
+Every effective managed, legacy, or environment account first resolves to a
+stable local operational `account_id`; this does not make its source
+configuration managed. An external IMAP UID is meaningful only within that
+account, mailbox, and UIDVALIDITY value:
+
+```text
+MessagePlacement = account_id + mailbox_id + uidvalidity + uid
+```
+
+SQLite assigns an opaque internal `message_id` for local references. RFC 5322
+`Message-ID` is searchable metadata, not a unique key: it may be absent,
+duplicated, or reused.
+
+Current MCP inputs use mailbox-scoped `email_id` values. A compatibility mapper
+resolves those values into a `MessagePlacement`. New internal APIs never pass an
+unscoped UID.
+
+## Metadata Search and Refresh
+
+Metadata-first access is the default path.
+
+```mermaid
+sequenceDiagram
+    participant I as MCP adapter
+    participant Q as MailQueryService
+    participant R as MailIndexRepository
+    participant X as IndexService
+    participant G as MailGateway
+
+    I->>Q: SearchMessages(query, cursor, limit, freshness)
+    Q->>R: query indexed metadata and coverage
+    R-->>Q: rows, next cursor, coverage
+    alt index satisfies request
+        Q-->>I: bounded indexed page
+    else refresh allowed and budget remains
+        Q->>X: refresh bounded mailbox range
+        X->>G: discover and fetch metadata
+        G-->>X: provider metadata batch and cursor facts
+        X->>R: atomic upsert and cursor advancement
+        X-->>Q: refreshed coverage
+        Q->>R: repeat indexed query
+        R-->>Q: rows, next cursor, coverage
+        Q-->>I: bounded refreshed page
+    else refresh not requested or budget exhausted
+        Q-->>I: partial page and explicit refresh action
+    end
+```
+
+### Search rules
+
+- The application-level cursor is opaque and tied to account, mailbox set,
+  filters, sort order, and an index snapshot boundary.
+- `limit` has a conservative default and hard maximum.
+- Results use deterministic ordering with a unique tie-breaker.
+- Exact totals are optional and returned only when the index has complete
+  coverage and the query can compute them cheaply.
+- FTS results identify whether only metadata or also cached body text was
+  searched.
+- A provider-side search may be used to extend coverage, but its results are
+  normalized into the same DTO and labeled as refreshed or partial.
+- Sender allowlist filtering occurs before a message is exposed in a result.
+
+The current page-number MCP contract can remain a facade. The application core
+uses cursors because pages are unstable while mail arrives or moves.
+
+## Mailbox Discovery
+
+Mailbox discovery refreshes mailbox names, delimiters, attributes, and
+UIDVALIDITY. Provider-specific archive and sent-folder detection belongs to the
+mail adapter, which returns typed candidates and evidence. Application policy
+selects a configured override or a validated candidate.
+
+Mailbox names are untrusted provider data. SQL, logs, MCP output, and IMAP
+commands use parameterization or protocol-safe encoding rather than string
+interpolation.
+
+## Body Retrieval
+
+```mermaid
+sequenceDiagram
+    participant I as MCP adapter
+    participant Q as MailQueryService
+    participant P as Policy
+    participant R as MailIndexRepository
+    participant G as MailGateway
+
+    I->>Q: GetMessageBody(message ref, section, offset, limit)
+    Q->>R: load placement, metadata, and cached body prefix
+    R-->>Q: indexed message state
+    Q->>P: authorize sender and requested output
+    alt cache satisfies requested window
+        Q-->>I: bounded body and continuation
+    else provider fetch required
+        Q->>G: fetch body section using PEEK
+        G-->>Q: bounded decoded content and source length
+        Q->>R: cache permitted normalized text prefix
+        Q-->>I: bounded body and continuation
+    end
+```
+
+Body rules:
+
+- IMAP PEEK is used by default so reading does not mark a message as seen.
+- Marking as read is a separate explicit command or an explicit option whose
+  partial failure is reported.
+- The service accepts one or a bounded number of message references.
+- The caller selects a body section or normalized text view, an offset, and a
+  maximum size.
+- A truncated result returns `has_more` and the next offset or cursor. A textual
+  truncation marker is compatibility presentation, not the only continuation
+  signal.
+- Persistent body cache is a contiguous normalized-text prefix beginning at
+  offset zero. Arbitrary later windows are sliced from a complete prefix or
+  fetched under byte and decode budgets without being cached as if they were the
+  start of the body.
+- Blocked sender policy is evaluated from safe metadata before fetching a body
+  or attachment whenever possible.
+- HTML is treated as untrusted. The MCP baseline returns normalized text; any
+  future renderer must sanitize HTML and block remote content separately.
+- Body cache policy is explicit. Metadata indexing does not silently enable
+  durable full-body storage.
+
+## Attachment Discovery and Materialization
+
+Attachment metadata is discovered before bytes are transferred. It includes an
+opaque attachment ID, filename, media type, size when known, content ID, and
+message reference.
+
+Materialization then:
+
+1. validates account, sender policy, attachment ID, size, and allowed output
+   root;
+2. fetches the exact MIME part without loading unrelated payloads when the
+   provider and parser permit it;
+3. streams through quota and checksum enforcement;
+4. atomically publishes to a private temporary file or explicitly approved
+   destination;
+5. returns bounded metadata and the approved local path;
+6. schedules temporary output for cleanup according to policy.
+
+Filenames never determine the storage path directly. Raw attachment bytes are
+not stored in SQLite and are not inlined in normal tool results.
+
+## Send and Sent-copy Flow
+
+```mermaid
+sequenceDiagram
+    participant I as MCP or CLI interface
+    participant C as MailCommandService
+    participant O as OperationRepository
+    participant S as MessageSender
+    participant G as MailGateway
+    participant R as MailIndexRepository
+
+    I->>C: SendMessage(command, idempotency key)
+    C->>C: validate account, recipients, body, and attachments
+    C->>O: claim CLAIMED_PRE_EFFECT with fencing token
+    alt known SMTP or unknown outcome exists
+        C->>C: do not submit again
+    else safe new attempt
+        C->>O: CAS generation and persist SUBMITTING
+        C->>S: submit via SMTP
+        alt all recipients accepted
+            S-->>C: per-recipient acceptance evidence
+            C->>O: record SMTP_SUCCEEDED
+        else accepted and rejected recipients
+            S-->>C: per-recipient mixed evidence
+            C->>O: record SMTP_PARTIAL
+        else all recipients definitively rejected
+            S-->>C: per-recipient rejection evidence
+            C->>O: record TERMINAL_FAILED
+        else any recipient outcome unknown
+            S-->>C: per-recipient ambiguous evidence
+            C->>O: record OUTCOME_UNKNOWN
+        end
+    end
+    alt accepted recipients and sent copy requested
+        C->>O: CAS generation and persist SENT_COPY_SUBMITTING
+        C->>G: append private sent copy via IMAP
+        alt append succeeds
+            G-->>C: placement if available
+            C->>R: reconcile sent placement
+            C->>O: record COMPLETED
+        else append definitely rejected
+            C->>O: record SENT_COPY_DEFINITELY_FAILED
+        else append outcome unknown
+            C->>O: record SENT_COPY_OUTCOME_UNKNOWN
+        end
+    end
+    C-->>I: per-recipient delivery and sent-copy outcome
+```
+
+### Send rules
+
+- All To, CC, and BCC addresses are normalized and checked against recipient
+  policy before MIME composition or local file reads.
+- The submitted MIME message contains no `Bcc` header. SMTP still receives BCC
+  addresses as RCPT TO envelope recipients, and the private sent copy may contain
+  BCC metadata, preserving current behavior.
+- `MessageSender` returns accepted, definitively rejected, and unknown status for
+  every envelope recipient plus bounded provider evidence.
+- Mixed acceptance records `SMTP_PARTIAL`. A retry never resubmits to accepted or
+  unknown recipients; retrying rejected recipients is an explicit new operation
+  with a newly reviewed recipient set.
+- SMTP acceptance remains successful for accepted recipients if saving the sent
+  copy fails.
+- A definitely failed sent copy may be retried as that substep only. An unknown
+  APPEND is first reconciled by stable Message-ID and bounded payload evidence;
+  it is never immediately appended again.
+- The operation persists `SUBMITTING` before entering SMTP code. That conditional
+  transaction verifies the attempt token and startup catalog generation; a
+  generation mismatch returns `RESTART_REQUIRED` without submission. A stale
+  `CLAIMED_PRE_EFFECT` claim may be fenced and safely reclaimed, while a stale
+  `SUBMITTING` attempt becomes `OUTCOME_UNKNOWN` and is never automatically
+  resent.
+- An idempotency key is scoped to account, operation kind, and payload hash. The
+  same key with a different payload is rejected.
+- Idempotency reduces known replay; it cannot prove that a provider accepted a
+  message after a lost response.
+- Local attachments are read only from approved roots and are bounded before
+  SMTP submission.
+
+## Save, Mark, Move, Archive, and Delete
+
+Mutation sequence:
+
+1. resolve every external reference to a current placement;
+2. load safe metadata and enforce sender and mutation policy;
+3. validate mailbox capability and command preconditions;
+4. record and claim operation intent when durable resume evidence is useful;
+5. conditionally verify claim token and catalog generation while persisting the
+   remote-effect-possible substep;
+6. perform the remote IMAP command outside SQLite transactions;
+7. persist confirmed outcomes or mark the affected local state stale;
+8. return per-item success, failure, and uncertainty without claiming an entire
+   batch succeeded.
+
+Specific rules:
+
+- Save-to-mailbox works without SMTP and records `APPENDUID` placement when the
+  provider returns it.
+- Mark-as-read changes only the requested flag and preserves unrelated flags.
+- Move uses native MOVE when available and a tested copy/delete fallback
+  otherwise.
+- The fallback records copy and source-delete as separate substeps. After a known
+  copy success it may continue only deletion or reconciliation; it never repeats
+  the copy. An unknown copy result is reconciled before any further side effect.
+- A move retains local message identity only when provider evidence or safe
+  reconciliation supports it; otherwise the destination is discovered on
+  refresh.
+- Archive selection comes from adapter discovery plus application policy, not a
+  hard-coded MCP folder name.
+- Delete semantics remain provider-aware and explicit about expunge behavior.
+- Privacy-preserving blocked mutation behavior remains compatible: blocked IDs
+  appear missing or as no-op success unless reporting is explicitly enabled.
+
+## On-demand Synchronization
+
+No background daemon is required. Synchronization runs through a bounded MCP
+query refresh or an explicit CLI command.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Indexed
+    Indexed --> Discovering: refresh requested
+    Discovering --> Applying: cursor valid and changes found
+    Discovering --> Rebuilding: UIDVALIDITY changed
+    Applying --> Indexed: batch and cursor committed
+    Rebuilding --> Indexed: replacement coverage committed
+    Discovering --> Partial: time or item budget reached
+    Applying --> Partial: time or item budget reached
+    Partial --> Discovering: continuation requested
+    Discovering --> AuthBlocked: credential rejected
+    AuthBlocked --> Discovering: credential updated and retry requested
+```
+
+- Remote fetch happens before the short write transaction.
+- The metadata batch and corresponding cursor advancement commit atomically.
+- Cursor advancement uses a revision check so two local processes cannot move a
+  cursor past data they did not persist.
+- Duplicate concurrent fetches are safe because mailbox and placement upserts
+  are idempotent.
+- UIDVALIDITY change invalidates old UID mappings and starts a controlled rebuild
+  without deleting unrelated account data.
+- Time, item, and byte budgets produce an honest `partial` state and continuation.
+- Authentication failures stop refresh for that invocation and remain visible
+  until credentials change; no hot loop exists.
+
+## Operation States
+
+The minimum durable vocabulary is:
+
+- `PENDING`: validated locally, no remote attempt claimed;
+- `CLAIMED_PRE_EFFECT`: one fenced attempt owns work but has not crossed the
+  persisted remote-effect boundary;
+- `REMOTE_EFFECT_POSSIBLE`: the boundary was persisted before entering provider
+  code; a stale attempt becomes unknown rather than being replayed;
+- `SUBMITTING`: SMTP-specific remote-effect-possible phase;
+- `SMTP_SUCCEEDED`: all envelope recipients were accepted;
+- `SMTP_PARTIAL`: accepted and definitively rejected recipients are both recorded;
+- `REMOTE_SUCCEEDED`: a non-SMTP remote mutation confirmed;
+- `SENT_COPY_SUBMITTING`: sent-copy APPEND may now have an external effect;
+- `SENT_COPY_DEFINITELY_FAILED`: APPEND was definitively rejected and may be
+  retried as a substep;
+- `SENT_COPY_OUTCOME_UNKNOWN`: APPEND may have succeeded and must be reconciled
+  before retry;
+- `OUTCOME_UNKNOWN`: another remote side effect may have occurred but cannot be
+  proven;
+- `RECONCILIATION_REQUIRED`: remote success is known and local projection needs
+  repair;
+- `COMPLETED`: required remote and local steps are reconciled;
+- `RETRYABLE_FAILED`: no ambiguous external effect and a bounded retry is safe;
+- `TERMINAL_FAILED`: validation, policy, or permanent provider failure.
+
+Each attempt has a random owner token and conditional state transitions. The
+pre-effect-to-effect transition is also the mode-generation linearization point:
+it checks the startup generation in the same SQLite transaction. If a catalog
+transition committed first, it returns `RESTART_REQUIRED`; if the attempt
+transition committed first, that provider call may finish with its original
+snapshot. Every later compound-operation side-effect substep performs its own
+generation-checked transition. A stale pre-effect claim can be fenced and
+reclaimed. Claim expiry after `REMOTE_EFFECT_POSSIBLE`, `SUBMITTING`, or
+`SENT_COPY_SUBMITTING` never proves
+that no external effect occurred and therefore transitions to the corresponding
+unknown state.
+
+The database schema and uniqueness rules are defined in
+[`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md).
+
+## Cancellation and Retry
+
+- Every provider call has a timeout and propagates cancellation.
+- Cancellation after a confirmed remote result still attempts to persist minimal
+  outcome evidence before returning.
+- Automatic retry is limited to operations known not to have produced the
+  external effect, or to an explicitly resumable later step.
+- A stale pre-effect claim can be retried after fencing its old token. A stale
+  remote-effect-possible claim cannot.
+- Partial SMTP acceptance and unknown recipient or sent-copy outcomes require
+  reconciliation or a separately reviewed new operation, not payload replay.
+- Backoff is bounded and applies within one explicit operation; there is no
+  background retry scheduler.
+- Authentication and policy failures are not retried automatically.
+- A database-busy error after remote success yields reconciliation-required, not
+  a repeated remote mutation.
+
+## Validation
+
+Tests cover successful and failure boundaries for:
+
+- indexed, refreshed, and partial metadata results;
+- cursor stability, concurrent refresh, and UIDVALIDITY rebuild;
+- PEEK body reads, bounded windows, and cache policy;
+- attachment size, path, and sender-policy controls;
+- SMTP full, partial, rejected, and per-recipient unknown outcomes;
+- crashes before and after the persisted SMTP boundary, fenced stale claims, and
+  proof that post-boundary recovery never automatically resends;
+- definite and unknown sent-copy outcomes plus reconciliation before APPEND
+  retry;
+- BCC MIME-header versus SMTP-envelope handling and idempotency payload mismatch;
+- per-item mutation outcomes, copy/delete fallback substeps, and local
+  reconciliation failure;
+- cancellation before and after remote side effects;
+- compatibility behavior exercised by the GreenMail stdio baseline.

--- a/spec/05-sqlite-persistence-and-data-model.md
+++ b/spec/05-sqlite-persistence-and-data-model.md
@@ -1,0 +1,841 @@
+# 05. SQLite Persistence and Data Model
+
+Status: Proposed
+
+Previous: [`04-mail-workflows-and-consistency.md`](04-mail-workflows-and-consistency.md)
+Next: [`06-mcp-interface-and-client-compatibility.md`](06-mcp-interface-and-client-compatibility.md)
+
+## Purpose
+
+SQLite is the local Email App's managed store. It provides durable non-secret
+configuration, fast metadata search, cross-process reuse, synchronization
+cursors, and operation evidence without introducing a server database.
+
+SQLite is not authoritative for remote mailbox contents and is not a secret
+vault. The schema distinguishes durable local configuration and operation
+evidence from rebuildable mail indexes and caches.
+
+## Storage Classes
+
+| Class                         | Examples                                                  | Rebuildable                    | Default persistence            |
+| ----------------------------- | --------------------------------------------------------- | ------------------------------ | ------------------------------ |
+| Managed configuration         | Accounts, endpoints, policies, secret bindings            | No                             | Yes                            |
+| Operational identity          | Stable IDs and legacy/environment source mappings         | No, when evidence refers to it | Yes in every base mode         |
+| Operation evidence            | SMTP acceptance, uncertain outcome, reconciliation state  | No                             | Yes, bounded retention         |
+| Mail index                    | Mailboxes, message metadata, placements, flags, addresses | Yes, from IMAP                 | Yes                            |
+| Search projection             | FTS subject, addresses, preview, permitted cached text    | Yes                            | Yes when available             |
+| Body cache                    | Normalized plain-text prefixes                            | Yes                            | Bounded and policy-controlled  |
+| Attachment metadata           | Filename, MIME type, part locator, size                   | Yes                            | Yes                            |
+| Raw MIME and attachment bytes | Provider payloads                                         | Yes                            | No by default                  |
+| Temporary artifacts           | Explicit local materialization                            | Yes                            | Private filesystem with expiry |
+
+## Sources of Truth
+
+- Managed account configuration is authoritative in SQLite only after an
+  `ACTIVE` managed catalog has been explicitly initialized.
+- `ACCOUNT_IDENTITY` and `ACCOUNT_SOURCE` are authoritative only for local
+  operational continuity; they never override legacy or environment base
+  configuration.
+- The selected `SecretStore` is authoritative for secret values. SQLite stores
+  `SecretRef` metadata only.
+- IMAP is authoritative for remote mailboxes, placements, flags, bodies, and
+  attachments.
+- SMTP response evidence is authoritative for known delivery acceptance.
+- SQLite operation records are authoritative for what the local application
+  observed and which reconciliation steps remain.
+
+## Logical Schema
+
+```mermaid
+erDiagram
+    ACCOUNT_IDENTITY ||--o{ ACCOUNT_SOURCE : resolves
+    ACCOUNT_IDENTITY ||--o| MANAGED_ACCOUNT : configures
+    MANAGED_CATALOG ||--|| GLOBAL_POLICY : governs
+    MANAGED_CATALOG ||--o{ MANAGED_ACCOUNT : owns
+    MANAGED_CATALOG ||--o{ POLICY_RULE_SET : defines
+    MANAGED_ACCOUNT ||--|| ACCOUNT_POLICY : overrides
+    MANAGED_ACCOUNT o|--o{ POLICY_RULE_SET : scopes
+    POLICY_RULE_SET ||--o{ POLICY_RULE : contains
+    MANAGED_ACCOUNT ||--o{ MAIL_ENDPOINT : configures
+    MANAGED_ACCOUNT ||--o{ CREDENTIAL_BINDING : references
+    MANAGED_ACCOUNT ||--o{ SECRET_CHANGE : changes
+    ACCOUNT_IDENTITY ||--o{ MAILBOX : owns
+    ACCOUNT_IDENTITY ||--o{ MESSAGE : indexes
+    ACCOUNT_IDENTITY ||--o{ OPERATION : records
+    MAILBOX ||--o{ MESSAGE_PLACEMENT : contains
+    MESSAGE ||--o{ MESSAGE_PLACEMENT : placed_as
+    MESSAGE ||--o{ MESSAGE_ADDRESS : addresses
+    MESSAGE ||--o{ MESSAGE_BODY : caches
+    MESSAGE ||--o{ ATTACHMENT : describes
+    MAILBOX ||--o| SYNC_CURSOR : tracks
+    OPERATION ||--o{ OPERATION_ATTEMPT : attempts
+
+    ACCOUNT_IDENTITY {
+        text id PK
+        text display_name
+        text state
+        datetime first_seen_at
+        datetime last_seen_at
+        datetime retired_at
+    }
+    ACCOUNT_SOURCE {
+        text id PK
+        text account_id FK
+        text source_kind
+        text source_namespace
+        text source_key
+        integer fingerprint_version
+        text source_fingerprint
+        text state
+        datetime first_seen_at
+        datetime last_seen_at
+    }
+    MANAGED_CATALOG {
+        text id PK
+        text lifecycle_state
+        integer generation
+        integer revision
+        integer policy_version
+        datetime updated_at
+    }
+    GLOBAL_POLICY {
+        text catalog_id PK, FK
+        integer revision
+        text default_secret_backend
+        text metadata_index_scope
+        integer report_blocked_mutations
+        integer attachment_download_enabled
+        integer metadata_quota_bytes
+        integer body_cache_quota_bytes
+        integer artifact_quota_bytes
+    }
+    MANAGED_ACCOUNT {
+        text account_id PK, FK
+        text catalog_id FK
+        text account_name UK
+        text full_name
+        text email_address
+        text status
+        integer revision
+        datetime deleted_at
+        datetime created_at
+        datetime updated_at
+    }
+    ACCOUNT_POLICY {
+        text account_id PK, FK
+        integer revision
+        text freshness_policy
+        text mutation_policy
+        integer body_cache_enabled
+        datetime updated_at
+    }
+    POLICY_RULE_SET {
+        text id PK
+        text catalog_id FK
+        text account_id FK
+        text kind
+        text mode
+        integer revision
+    }
+    POLICY_RULE {
+        text id PK
+        text rule_set_id FK
+        text normalized_value
+        text effect
+        integer ordinal
+        integer enabled
+    }
+    MAIL_ENDPOINT {
+        text id PK
+        text account_id FK
+        text role
+        text host
+        integer port
+        text tls_mode
+        integer verify_tls
+        text username
+    }
+    CREDENTIAL_BINDING {
+        text id PK
+        text account_id FK
+        text purpose
+        text backend
+        text locator
+        text version
+        text state
+        datetime created_at
+        datetime updated_at
+    }
+    SECRET_CHANGE {
+        text id PK
+        text account_id FK
+        text purpose
+        text kind
+        integer expected_account_revision
+        text old_binding_id FK
+        text candidate_binding_id FK
+        text state
+        text error_code
+        datetime created_at
+        datetime updated_at
+    }
+    MAILBOX {
+        text id PK
+        text account_id FK
+        text remote_name
+        text delimiter
+        text attributes_json
+        integer uidvalidity
+        integer uidnext
+        datetime indexed_at
+    }
+    MESSAGE {
+        text id PK
+        text account_id FK
+        text rfc_message_id
+        text subject
+        datetime sent_at
+        datetime internal_date
+        integer size_bytes
+        text preview
+        datetime last_observed_at
+    }
+    MESSAGE_PLACEMENT {
+        text mailbox_id FK
+        text message_id FK
+        integer uidvalidity
+        integer uid
+        text flags_json
+        integer modseq
+        datetime observed_at
+    }
+    MESSAGE_ADDRESS {
+        text message_id FK
+        text role
+        integer ordinal
+        text display_name
+        text address
+    }
+    MESSAGE_BODY {
+        text message_id FK
+        text body_kind
+        text content_prefix
+        integer source_chars
+        integer prefix_chars
+        text completeness
+        datetime cached_at
+        datetime expires_at
+    }
+    ATTACHMENT {
+        text id PK
+        text message_id FK
+        text part_locator
+        integer ordinal
+        text filename
+        text media_type
+        text content_id
+        integer size_bytes
+        text checksum
+    }
+    SYNC_CURSOR {
+        text mailbox_id PK
+        integer uidvalidity
+        integer highest_uid
+        integer highest_modseq
+        text coverage_state
+        datetime coverage_start
+        integer revision
+        datetime updated_at
+    }
+    OPERATION {
+        text id PK
+        text account_id FK
+        text kind
+        text idempotency_key
+        text payload_hash
+        text state
+        text result_json
+        datetime created_at
+        datetime updated_at
+    }
+    OPERATION_ATTEMPT {
+        text id PK
+        text operation_id FK
+        integer attempt_number
+        text claim_token
+        text phase
+        datetime claim_deadline
+        datetime remote_started_at
+        text outcome
+        text error_code
+        datetime started_at
+        datetime finished_at
+    }
+```
+
+This is a logical schema. Physical migrations may combine narrowly related
+tables or add generated columns when measured query behavior justifies it. They
+must preserve identity, secret, and transaction invariants.
+
+## Operational Account Identity
+
+`ACCOUNT_IDENTITY.id` is the stable local `account_id` used by mailboxes,
+messages, cursors, and operations in every base mode. It contains no endpoint,
+policy, or secret configuration and therefore does not make the database a
+second account-config source in legacy mode. Its `display_name` is diagnostic
+metadata and is never used instead of effective-source resolution. Operational
+identity rows and mail index rows may exist when no managed catalog is active.
+Identity state is `ACTIVE` while any selected source or managed account can use
+it and `RETIRED` when only retained index or evidence refers to it; retirement
+does not itself delete evidence.
+
+`ACCOUNT_SOURCE` maps a non-managed source to that identity. A source mapping is
+unique on `(source_kind, source_namespace, source_key)`:
+
+- for legacy TOML, the namespace is a stable local digest of the logical
+  configuration source and the key is the stored account entry key. The current
+  and legacy default paths are recognized aliases; an explicit custom-path move
+  transfers or rebinds the namespace rather than silently creating identities;
+- for the environment account, the namespace identifies the documented
+  environment slot and the key is its compatibility account name;
+- `source_fingerprint` is a versioned digest of the exact non-secret identity
+  tuple defined below; it detects accidental source-key reuse without storing a
+  copy of source configuration.
+
+For a legacy source, `source_namespace` is encoded as
+`legacy-path-v1:<sha256>`. The recognized current and legacy default paths map to
+the same logical input before hashing. A custom path expands the user directory,
+becomes absolute, resolves existing symlinks, normalizes separators and the
+platform's filesystem case semantics, and then uses a length-prefixed UTF-8 path
+encoding. If the target does not yet exist, the existing parent is resolved and
+the final component retained. `source_key` is the validated stored account key
+after trim and Unicode NFC normalization with case preserved; the environment
+slot uses the same account-name rule. Moving a custom source or retargeting a
+symlink therefore requires the explicit namespace transfer/rebind already
+defined above.
+
+Fingerprint version 1 for an email account is the SHA-256 digest of a
+domain-separated, length-prefixed UTF-8 encoding of:
+
+```text
+("email-v1", normalized_email_address, incoming_host, incoming_port,
+ incoming_username, incoming_tls_mode)
+```
+
+Canonicalization is normative:
+
+- email uses the current compatibility address parser, surrounding whitespace
+  removal, and lowercase normalization;
+- host is trimmed, converted to a lowercase IDNA A-label, and has one terminal
+  DNS dot removed;
+- port is the validated integer encoded in base-10 without leading zeroes;
+- username is trimmed and Unicode NFC-normalized but remains case-sensitive;
+- TLS is the normalized `implicit | starttls | none` enum.
+
+Account/display name, full name, password, secret locator, outgoing endpoint,
+and mutable policy are excluded. Changing an included field is
+identity-affecting and enters the explicit rebind-or-successor conflict flow;
+changing an excluded field does not. Another provider kind must define its own
+versioned stable principal/endpoint tuple before it may persist operational
+identity.
+
+`fingerprint_version` is stored beside the digest. An algorithm upgrade supports
+the old and new versions during migration, re-reads the authoritative source,
+and compare-and-swaps to the new digest only when the old digest, source key, and
+identity mapping all match uniquely. An absent source remains on the old version;
+an ambiguous or unverifiable source remains conflicted. Upgrade code never
+infers equivalence from display name and never persists the canonical tuple or a
+secret in SQLite.
+
+An exact source key, fingerprint version, and digest reuses the identity after
+restart. If a key reappears with a materially different fingerprint, the adapter
+marks a conflict
+and requires an explicit CLI rebind or successor identity; it never silently
+attaches old mail or operation evidence. Before creating a new identity, it also
+checks for the same fingerprint under another key in that source namespace. Such
+a probable out-of-band rename is a conflict and blocks provider-effect operations
+until the user chooses rebind or explicitly accepts a successor identity and the
+associated idempotency-evidence discontinuity.
+
+A source that disappears updates `last_seen_at` and is retired only through
+explicit index maintenance. A CLI-managed legacy rename updates the source
+mapping with the file change; an out-of-band rename follows the conflict flow
+above rather than silently becoming a new account.
+
+An environment account that shadows the same display name as a managed or legacy
+account keeps a distinct source mapping and identity. Name resolution selects the
+attributed effective source, not whichever identity was seen first. Diagnostics
+show both the selected and shadowed identities.
+
+`MANAGED_ACCOUNT.account_id` is both its primary key and a foreign key to
+`ACCOUNT_IDENTITY`. New managed accounts create both rows. A legacy-to-managed
+import reuses the selected legacy identity for its staging managed row whenever
+the source match is unambiguous, preserving index and operation continuity; the
+legacy source mapping remains as provenance and is not a writable managed
+configuration row.
+
+## Managed Configuration
+
+### Catalog lifecycle
+
+`MANAGED_CATALOG.lifecycle_state` is one of `STAGING`, `ACTIVE`, `MAINTENANCE`,
+or `FAILED_IMPORT`. `ACTIVE` selects managed base mode; `MAINTENANCE` selects a
+management-only runtime and must not fall back to legacy mail access. Staging and
+failed imports may coexist with an operational legacy index but are never visible
+as the effective account catalog. At most one catalog is active or in maintenance
+and at most one unfinished staging import exists.
+
+`generation` changes when a process must rebuild its base configuration adapter;
+`revision` changes for ordinary writes within one active catalog. Legacy mode
+with neither an active nor maintenance catalog uses generation zero. Activating a
+staging catalog or entering or leaving maintenance advances generation in the
+same transaction that changes lifecycle state.
+
+For a mutation, the transition from `CLAIMED_PRE_EFFECT` to
+`REMOTE_EFFECT_POSSIBLE` or `SUBMITTING` conditionally verifies the process's
+startup generation in that same SQLite transaction. If it changed, the
+transition fails with `RESTART_REQUIRED` and no provider side effect occurs. A
+provider call that crossed its boundary before the generation transition may
+finish and reconcile from its original snapshot; every later independent or
+compound side-effect substep checks generation again.
+
+### Scalar and rule policy
+
+`GLOBAL_POLICY` owns typed scalar settings, including blocked-mutation reporting,
+attachment enablement, and cache or artifact quotas. `ACCOUNT_POLICY` owns typed
+per-account overrides such as freshness, mutation, and body-cache policy. For
+scalar fields, an explicitly set account value replaces the global value, and a
+supported process environment override replaces that result using current
+compatibility semantics. Every effective scalar carries its final source.
+
+`POLICY_RULE_SET` makes absence, inheritance, unrestricted access, and an
+explicit empty restriction distinguishable. Each global or account scope has at
+most one set per `kind`; its `mode` is:
+
+- `INHERIT`: this scope adds no allow constraint;
+- `UNRESTRICTED`: explicitly no allow constraint at this scope;
+- `RESTRICT`: every request must match an enabled `allow` rule in this scope; a
+  restrictive set with zero allow rows denies all.
+
+Absence has scope-specific, non-ambiguous semantics:
+
+- every `ACTIVE` catalog must materialize exactly one global set for every
+  supported security-sensitive kind; a missing global set is invalid
+  configuration, never implicit unrestricted access;
+- catalog activation and startup validation fail if a required global set is
+  missing, duplicated, has an unknown mode, or uses global `INHERIT`;
+- while invalid, mail/provider operations, indexed content exposure, and
+  filesystem materialization that depend on policy are disabled; read-only
+  `doctor` may identify the missing set and maintenance CLI may repair it;
+- an account-scoped row may be absent, which is implicit `INHERIT`; an explicit
+  account `INHERIT` row has the same authorization result but preserves a
+  revisioned user choice for diagnostics.
+
+Managed catalog initialization materializes these versioned defaults:
+
+| Global kind            | Initial mode and rules                                               |
+| ---------------------- | -------------------------------------------------------------------- |
+| `recipient_address`    | `UNRESTRICTED`, preserving the current empty-recipient-list behavior |
+| `sender_pattern`       | `UNRESTRICTED`, preserving the current empty-sender-list behavior    |
+| `approved_input_root`  | `RESTRICT` to the canonical private import/workspace root            |
+| `approved_output_root` | `RESTRICT` to the canonical private artifact workspace               |
+
+A staging catalog may be incomplete while it is built, but the final activation
+transaction validates the full required set and its canonical root values.
+Migrations that introduce a kind materialize its declared default before the
+catalog can remain `ACTIVE`. Database damage or an unknown future kind fails
+closed rather than being interpreted as `INHERIT` or `UNRESTRICTED`.
+
+`POLICY_RULE` owns the normalized values and `allow` or `deny` effect. Enabled
+deny rules from all durable scopes are unioned and always win. Account allow
+rules cannot override a global deny. When both global and account sets are
+`RESTRICT`, a request must satisfy both sets, so an account can narrow but cannot
+expand global authority.
+
+The initial rule kinds have these complete semantics:
+
+| Rule kind              | Normalized match                                           | Global/account behavior                                              | Environment behavior                                                                                                                                |
+| ---------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `recipient_address`    | Exact normalized envelope address                          | Every restrictive scope must match; any matching deny wins           | Present `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS` replaces durable allow constraints; an empty value means unrestricted, while durable denies still win |
+| `sender_pattern`       | One normalized sender against an anchored case-folded glob | Every restrictive scope must match; malformed/multiple sender fails  | Present `MCP_EMAIL_SERVER_ALLOWED_SENDERS` replaces durable allow constraints; an empty value means unrestricted, while durable denies still win    |
+| `approved_input_root`  | Canonical target is contained by the canonical root        | Every restrictive scope must contain the target; denied subtree wins | No compatibility override; an environment value cannot implicitly add a root                                                                        |
+| `approved_output_root` | Canonical target is contained by the canonical root        | Every restrictive scope must contain the target; denied subtree wins | No compatibility override; an environment value cannot implicitly add a root                                                                        |
+
+The two documented allowlist variables intentionally remain process-global,
+full process-local replacements for every effective account, including their
+existing present-but-empty behavior. This explicit local environment authority
+can expand a managed allow constraint, so account summaries and `doctor` report
+the replacement and its source. It still cannot override a durable deny rule.
+Legacy TOML empty allowlists map to
+`UNRESTRICTED`; managed callers use `INHERIT`, `UNRESTRICTED`, or an empty
+`RESTRICT` set explicitly rather than overloading one empty list.
+
+Rule evaluation never uses first-match wins. `ordinal` preserves deterministic
+CLI display and diagnostics only. An authorization result attributes every
+restrictive set, matching deny, and environment replacement that participated;
+it does not report only one nominal winner. Unsupported kinds, effects, or
+wildcard grammars fail validation, and a new security-sensitive rule kind cannot
+ship until this table defines its merge and environment behavior.
+
+Rule-set and scalar policy writes use expected revisions just like account
+writes. Unique and check constraints prevent duplicate normalized values and
+unsupported effects. A catch-all JSON settings blob must not bypass validation,
+revisions, source attribution, or migrations.
+
+### Accounts and removal
+
+`MANAGED_ACCOUNT.account_id` is an application-generated stable identifier shared
+with its operational identity. `account_name` is a unique user-facing name, not
+the primary identity. Rename increments `revision` and does not re-key messages,
+operations, source mappings, or secret bindings.
+
+`account remove` is a soft-delete workflow:
+
+1. change status to `REMOVED` and set `deleted_at` using the expected revision;
+2. reject new mail operations while retaining the stable ID and minimum
+   non-secret identity;
+3. purge rebuildable mailbox, message, body, attachment, and FTS rows separately;
+4. complete credential cleanup through the persisted secret-change saga;
+5. retain the managed tombstone and operational identity with unresolved or
+   retained operation evidence.
+
+`account_name` is not reusable while the tombstone remains. A separate
+destructive hard purge runs only after explicit confirmation of the backup and
+evidence-loss warning. In one guarded transaction it:
+
+1. rechecks the expected tombstone revision and exclusive maintenance lock;
+2. proves that no active or incomplete secret change, live credential binding,
+   unresolved/unknown operation, or non-retention-eligible evidence remains;
+3. explicitly deletes retention-eligible completed operation attempts and
+   operations;
+4. deletes completed secret-change and deleted-binding metadata after external
+   secret cleanup is proven;
+5. deletes rebuildable index rows, account rule sets and rules, policy,
+   endpoints, and the managed account row in dependency order;
+6. retires or deletes source mappings as requested and deletes the operational
+   identity only when no reference remains;
+7. releases the unique name only with the tombstone deletion.
+
+Every reference is `RESTRICT` by default. The command uses enumerated deletes and
+must not enable a blind cascade over the account graph.
+
+### Endpoints
+
+`MAIL_ENDPOINT.role` is constrained to supported roles such as `incoming` and
+`outgoing`. `(account_id, role)` is unique. TLS behavior is represented as a
+validated enum such as `implicit`, `starttls`, or `none`; contradictory booleans
+are normalized at the adapter boundary.
+
+### Credential bindings and change recovery
+
+`CREDENTIAL_BINDING` contains no resolved value. Its lifecycle is
+`CANDIDATE -> ACTIVE -> OLD_DELETE_PENDING -> DELETED`. A partial unique index
+permits exactly one `ACTIVE` row for `(account_id, purpose)` while retaining the
+independent candidate and cleanup rows. Before the external value write, managed
+mutable backends allocate a unique locator/version and the application persists
+the `CANDIDATE` binding; the active locator is never modified in place.
+
+`SECRET_CHANGE` persists kind, expected account revision, old and candidate
+binding IDs, state, and bounded error code. `SET`, `ROTATE`, and `IMPORT` use
+`PREPARED -> CANDIDATE_WRITTEN -> BINDING_COMMITTED -> CLEANUP_PENDING -> COMPLETED`.
+`DELETE` has a null candidate and, only after the account is durably disabled,
+uses `PREPARED -> BINDING_COMMITTED -> CLEANUP_PENDING -> COMPLETED` while the old
+binding advances to `OLD_DELETE_PENDING`. A partial unique index permits only one
+incomplete change per account and purpose. Candidate creation, binding
+activation, old-secret deletion, account removal, and legacy import all use this
+record for crash recovery. Binding and change states are separate vocabularies;
+`OLD_DELETE_PENDING` is never a `SECRET_CHANGE` state.
+
+The `locator` is sensitive operational metadata even though it is not the secret
+value; it is never exposed through MCP or normal CLI listing. `credential
+repair` operates from binding/change rows and does not require keyring
+enumeration. Secret deletion by immutable locator is idempotent; not-found is
+accepted only when the committed binding state proves the locator is no longer
+active. A database constraint cannot prove that an external value exists, so
+`doctor` and account tests resolve bindings safely without logging values.
+
+### Core constraints and delete behavior
+
+- `ACCOUNT_SOURCE` is unique on `(source_kind, source_namespace, source_key)`;
+  fingerprint version or digest mismatch follows the verified migration or
+  conflict path, never an upsert onto old evidence.
+- `MANAGED_ACCOUNT.account_name` remains unique across active and retained
+  tombstone rows.
+- Operational `MAILBOX`, `MESSAGE`, and `OPERATION` rows reference
+  `ACCOUNT_IDENTITY`, never `MANAGED_CATALOG`.
+- `MAIL_ENDPOINT` is unique on `(account_id, role)`.
+- `ACCOUNT_POLICY` is one-to-one with managed account; global and account policy
+  revisions advance independently.
+- `POLICY_RULE_SET` is unique on `(catalog_id, account_id, kind)`, with null-safe
+  uniqueness for global scope. A composite constraint ensures an account-scoped
+  set references a managed account in the same catalog. `POLICY_RULE` is unique
+  on `(rule_set_id, normalized_value, effect)` and has a deterministic ordinal.
+- Exactly one active credential binding and one incomplete secret change may
+  exist per managed account and purpose.
+- Account removal does not cascade to operation evidence, credential cleanup,
+  operational identity, or the managed tombstone.
+- Rebuildable mailbox, message, body, attachment, and FTS rows may be purged by
+  an explicit index cleanup after soft removal.
+- Every account-graph foreign key uses `RESTRICT` unless a narrow rebuildable
+  child relation documents otherwise. Hard purge follows the enumerated guarded
+  deletion order and never relies on a blind cascade.
+
+## Mail Index
+
+### Mailboxes and placements
+
+A mailbox is unique on `(account_id, remote_name)`. A placement is unique on:
+
+```text
+(mailbox_id, uidvalidity, uid)
+```
+
+`MESSAGE_PLACEMENT` also has an index on `(message_id, mailbox_id)`. When
+UIDVALIDITY changes, old placements for that mailbox become invalid and are
+replaced through controlled rebuild. They are never matched to new UIDs by UID
+alone.
+
+### Messages
+
+`MESSAGE.id` is local and opaque. `rfc_message_id` is nullable and indexed but
+not unique. Message coalescing across mailboxes must use provider evidence or a
+conservative reconciliation rule; matching only the RFC header is insufficient.
+
+Useful indexes include:
+
+- `(account_id, internal_date, id)` for stable recent-mail ordering;
+- `(account_id, rfc_message_id)` for thread and sent-copy reconciliation;
+- `(account_id, subject)` only if query plans justify it;
+- placement indexes for mailbox and UID lookup.
+
+### Addresses
+
+Addresses are normalized into `MESSAGE_ADDRESS` so sender and recipient filters,
+allowlists, and search do not depend on parsing JSON at query time.
+
+- `role` is constrained to `from`, `sender`, `reply_to`, `to`, `cc`, or `bcc` as
+  appropriate to indexed data.
+- `(message_id, role, ordinal)` is unique.
+- normalized `address` is indexed with `role` for common filters.
+- BCC for received remote messages is stored only when it is legitimately
+  present; it is not inferred.
+
+### Body cache
+
+`MESSAGE_BODY` stores decoded, normalized text only under explicit cache policy.
+Raw MIME and binary payloads are excluded. `(message_id, body_kind)` is unique.
+
+The cached text is always a contiguous prefix beginning at normalized character
+offset zero. `prefix_chars` is the exclusive prefix end. `completeness`
+distinguishes `prefix`, `complete`, and `truncated_by_policy`, and
+`source_chars` records full normalized length when known. A non-prefix body
+request may be served from a complete cached prefix; otherwise it is fetched
+without being persisted as a misleading standalone window.
+
+MCP character offsets are applied after bounded MIME decoding. Mail adapters use
+provider byte ranges only when they can map them safely through transfer and
+character encodings; otherwise they enforce an input-byte budget while decoding
+and return `partial` rather than reading an unbounded MIME part.
+
+Body cache may be disabled, limited to recent messages, or capped by bytes and
+age. Metadata indexing remains useful when body cache is disabled.
+
+### Attachments
+
+`ATTACHMENT` stores only metadata and a provider-relative MIME part locator.
+`(message_id, part_locator)` and `(message_id, ordinal)` are unique where the
+provider data supports those constraints. Filenames are display metadata, not
+storage keys.
+
+## Full-text Search
+
+When SQLite FTS5 is available, a derived `message_fts` projection indexes only
+policy-approved fields:
+
+- subject;
+- normalized sender and recipient addresses;
+- preview;
+- cached normalized body text when body indexing is enabled.
+
+The FTS row references `MESSAGE.id`. Repository transactions update the content
+row and search projection together or mark the projection stale for repair.
+FTS content is rebuildable from base index rows.
+
+FTS5 availability is checked at startup. If unavailable, the app remains
+functional with indexed filters and provider search; it reports reduced search
+capability rather than failing the entire runtime.
+
+A search response states whether body text was in the indexed field set. It does
+not imply full-message search when only metadata coverage exists.
+
+## Synchronization Cursors
+
+`SYNC_CURSOR` is mailbox-scoped. It stores UIDVALIDITY, highest observed UID,
+optional highest MODSEQ, coverage state, coverage boundary, and a monotonic
+revision.
+
+A synchronization batch follows this order:
+
+1. read cursor and revision;
+2. perform bounded IMAP discovery outside a transaction;
+3. begin a short write transaction;
+4. verify the cursor revision still matches;
+5. upsert mailboxes, messages, addresses, placements, and attachments;
+6. update search projections;
+7. advance cursor and coverage in the same commit.
+
+If the revision changed, the process re-evaluates or safely repeats idempotent
+upserts. It never commits a cursor that skips metadata it did not persist.
+
+## Operation Journal
+
+The operation journal stores durable local evidence only for workflows where it
+prevents unsafe replay or supports reconciliation.
+
+Required constraints:
+
+- unique `(account_id, kind, idempotency_key)` when a key is present;
+- the same key may be reused only with the same payload hash;
+- unique `(operation_id, attempt_number)`;
+- one active attempt claim per operation, protected by a random claim token,
+  conditional transitions, and a bounded stale deadline;
+- an attempt phase that distinguishes `CLAIMED_PRE_EFFECT` from
+  `REMOTE_EFFECT_POSSIBLE` before any provider side-effect call;
+- the effect-boundary transition conditionally verifies both claim token and
+  startup catalog generation in the same transaction; a mismatch produces
+  `RESTART_REQUIRED` without advancing the attempt;
+- per-recipient SMTP acceptance, rejection, and unknown evidence in bounded
+  typed result data;
+- explicit sent-copy and compound-IMAP substep outcomes;
+- result JSON never contains full bodies, MIME, attachment bytes, or secrets.
+
+A stale `CLAIMED_PRE_EFFECT` attempt may be fenced and reclaimed because it did
+not cross a remote-effect boundary. A stale `REMOTE_EFFECT_POSSIBLE` attempt is
+converted to `OUTCOME_UNKNOWN` and is never automatically replayed. Claim expiry
+is a recovery signal, not proof that the provider did nothing.
+
+`OUTCOME_UNKNOWN`, partial acceptance, pending compound-operation substeps, and
+confirmed remote success records use longer retention than rebuildable cache
+rows. They retain their `ACCOUNT_IDENTITY` foreign key; a removed managed account
+also retains its tombstone until guarded hard purge. Purging evidence requires an
+explicit policy and must not make the application claim stronger idempotency
+guarantees.
+
+## SQLite Runtime Rules
+
+- Enable foreign keys for every connection.
+- Use WAL mode, a bounded busy timeout, and documented synchronous settings.
+- Keep one clear connection ownership strategy per process; do not share a raw
+  connection across unrelated async tasks without serialization.
+- Hide synchronous driver work behind an adapter that does not block the event
+  loop for unbounded periods.
+- Keep write transactions short and deterministic.
+- Never perform IMAP, SMTP, keyring, DNS, or large filesystem work in a
+  transaction.
+- Parameterize every value; mailbox names, search terms, and message data never
+  become SQL fragments.
+- Use explicit projections rather than returning `SELECT *` rows across the
+  repository boundary.
+- Use `PRAGMA integrity_check` or an appropriate bounded check in explicit
+  diagnostics, not on every startup.
+
+## Schema Migrations
+
+A `schema_migrations` table records version, name, checksum, and applied time.
+Migrations are forward-only in normal operation.
+
+- A local lock prevents two processes from migrating the same database.
+- Startup waits only for a bounded period and reports a clear maintenance error.
+- Every migration runs in a transaction when SQLite permits it.
+- Destructive transformations copy and validate data before dropping old
+  structures.
+- A failed migration leaves the last committed schema readable or marks the
+  database as requiring explicit repair.
+- The application refuses to write a newer unsupported schema.
+- Migration tests start from every supported prior schema fixture.
+
+## Files and Permissions
+
+The database and private artifact directory are created with owner-only
+permissions where the platform supports them. Parent directories are private.
+
+SQLite sidecars such as `-wal` and `-shm` receive equivalent directory
+protection. The application does not claim database encryption at rest; users
+who require it rely on operating-system disk encryption unless a separately
+accepted design introduces application-level encryption.
+
+## Retention and Quotas
+
+Independent limits apply to:
+
+- indexed message age or count per account;
+- body cache bytes and age;
+- operation evidence age by state;
+- temporary artifact bytes and expiry;
+- synchronization batch items, bytes, and time.
+
+Default policy principles:
+
+- index metadata by default within a configured local budget;
+- cache bodies only on demand and under an explicit bound;
+- do not cache attachment bytes by default;
+- retain unresolved or uncertain operation evidence until resolved or explicitly
+  acknowledged;
+- purge derived FTS rows with their source cache rows;
+- report partial index coverage after quota eviction.
+
+Concrete numeric defaults remain a product configuration decision and must be
+specified with implementation benchmarks rather than guessed in this proposal.
+
+## Backup, Restore, and Rebuild
+
+A SQLite backup includes managed non-secret configuration, operational account
+identities and source mappings, index state, and operation evidence. It does not
+include keyring secret values or temporary artifacts.
+
+- Use SQLite's online backup API or an equivalent consistent method; copying only
+  the main file while WAL is active is not a supported backup procedure.
+- Restore validates schema version and secret bindings before enabling mail
+  operations.
+- Missing rebuildable index rows trigger refresh.
+- Missing secret bindings disable affected accounts and produce CLI remediation;
+  they do not trigger plaintext fallback.
+- Missing temporary artifacts are reported as expired and can be fetched again.
+- `index rebuild` preserves operational identities, source mappings, managed
+  accounts, credential bindings, and operation evidence while replacing only
+  rebuildable mail data.
+
+## Validation
+
+Persistence tests cover:
+
+- all constraints, indexes, foreign keys, and delete behavior;
+- migration from every supported fixture and migration checksum mismatch;
+- concurrent readers, writer contention, and bounded busy behavior;
+- sync revision conflicts and atomic cursor advancement;
+- UIDVALIDITY invalidation;
+- legacy and environment identity reuse across restart; exact v1 canonical
+  tuples; address, IDNA host, username, TLS, path, case, symlink, and default-path
+  normalization; fingerprint-version migration; conflict behavior; source
+  disappearance/reappearance; rename/rebind; shadowing; and legacy-to-managed
+  import without evidence re-keying;
+- `STAGING`/`FAILED_IMPORT` catalogs never selecting managed mode, atomic `ACTIVE`
+  generation transition, and repair of pre-recorded import candidates;
+- account rename, soft removal, retained operation evidence, and guarded hard
+  purge with explicit completed-child deletion and no blind cascade;
+- required global rule-set completeness at activation and startup; invalid or
+  missing global sets failing closed; account absence as inherit; every policy
+  mode; global/account allow intersections; deny-wins; explicit empty
+  restrictions; current environment full-replacement and empty semantics; root
+  containment; deterministic diagnostics; and source attribution;
+- secret-change crashes at every state, concurrent rotation fencing, pending
+  cleanup repair, and proof that the active locator is never deleted;
+- FTS enabled and unavailable paths;
+- body and artifact quota eviction;
+- operation idempotency, atomic generation/effect-boundary ordering for each
+  compound substep, stale pre-effect claim recovery, stale post-boundary
+  conversion to unknown, partial SMTP acceptance, and uncertain-outcome retention;
+- database, WAL, and artifact permissions;
+- online backup, restore, index rebuild, and missing-secret recovery;
+- proof that resolved secret values never reach database pages through normal
+  application writes.

--- a/spec/06-mcp-interface-and-client-compatibility.md
+++ b/spec/06-mcp-interface-and-client-compatibility.md
@@ -1,0 +1,442 @@
+# 06. MCP Interface and Client Compatibility
+
+Status: Proposed
+
+Previous: [`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md)
+Index: [`README.md`](README.md)
+
+## Scope
+
+The MCP interface is a local stdio adapter over application services. Its design
+must work across current stable VS Code, Cursor, Claude Code, and OpenAI Codex
+clients without assuming that each client implements every optional MCP
+capability in the same way.
+
+The compatibility baseline is deliberately small:
+
+```text
+stdio
+  + a stable tool catalog discovered at initialization
+  + stable tool names and input schemas
+  + complete text results
+  + clear, reviewable arguments for client approval
+```
+
+Resources, prompts, structured content, resource links, and list-change
+notifications may improve capable clients, but no core mail workflow depends on
+them.
+
+## Protocol Baseline
+
+This design was checked on 2026-07-18 against the stable
+[MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25).
+
+Relevant protocol facts:
+
+- Under [stdio](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#stdio),
+  the client launches the server, messages are newline-delimited JSON-RPC, logs
+  may use stderr, and stdout must contain only MCP messages.
+- [Initialization](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
+  negotiates protocol versions and optional capabilities. An advertised feature
+  must be used only when negotiated.
+- [`tools/list`](https://modelcontextprotocol.io/specification/2025-11-25/server/tools#listing-tools)
+  returns full tool names, descriptions, and schemas and supports protocol
+  pagination.
+- A server that advertises tool `listChanged` should send
+  `notifications/tools/list_changed` when the catalog changes.
+- Tool annotations are untrusted hints to clients, not authorization.
+- A tool may return text, `structuredContent`, embedded resources, or resource
+  links. The specification recommends a serialized text copy when returning
+  structured content for compatibility.
+- [Resources](https://modelcontextprotocol.io/specification/2025-11-25/server/resources)
+  and [prompts](https://modelcontextprotocol.io/specification/2025-11-25/server/prompts)
+  have independent discovery and optional list-change behavior.
+
+The protocol has no universal output-size limit and no portable request for one
+individual tool schema. Protocol pagination for `tools/list` also does not
+define application pagination for email results. The server therefore owns
+context bounds and email cursors explicitly.
+
+## Current SDK Baseline
+
+The repository currently declares `mcp[cli]>=1.23.0,<2` and `uv.lock` resolves
+`mcp==1.26.0`.
+
+That SDK can:
+
+- run stdio;
+- attach tool annotations;
+- derive output schemas and structured results from typed returns;
+- register resources and prompts;
+- send tool, resource, and prompt list-change notifications through a server
+  session;
+- include concise server instructions.
+
+The current `VisibilityAwareFastMCP.list_tools()` only filters the returned list.
+It does not emit a list-change notification when configuration changes. This is
+one reason dynamic visibility cannot be a correctness mechanism.
+
+FastMCP remains an adapter. The application core must not depend on SDK content
+blocks, session objects, decorators, or exceptions.
+
+## Verified Client Matrix
+
+`✓` means stable public product documentation or stable release evidence
+confirms the capability. `△` means implementation-only evidence, a partial
+surface, omission from the stable support list, or a known compatibility limit
+that makes the feature unsafe as a baseline. `?` means no sufficient public
+confirmation was found; it does not assert non-support.
+
+| Capability                             | VS Code             | Cursor | Claude Code               | OpenAI Codex                                    |
+| -------------------------------------- | ------------------- | ------ | ------------------------- | ----------------------------------------------- |
+| Local stdio                            | ✓                   | ✓      | ✓                         | ✓                                               |
+| Tools                                  | ✓                   | ✓      | ✓                         | ✓                                               |
+| Resources                              | ✓                   | ✓      | ✓                         | △ current implementation evidence               |
+| Resource templates                     | ✓                   | ?      | ?                         | △ current implementation evidence               |
+| Prompts                                | ✓                   | ✓      | ✓                         | Not supported in current public client evidence |
+| Dynamic tool/list refresh              | ✓ dynamic discovery | ?      | ✓ explicit `list_changed` | Not reliable; open stale-schema behavior        |
+| Structured tool output                 | ✓                   | ?      | ?                         | △ current implementation evidence               |
+| Tool-result resource links             | ✓                   | ?      | ?                         | ?                                               |
+| Per-call or policy-based tool approval | ✓                   | ✓      | ✓                         | ✓                                               |
+
+### VS Code evidence
+
+VS Code documents local stdio and tools, resources, prompts, roots, sampling,
+elicitation, and dynamic tool discovery in its
+[MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp).
+Its [MCP server guide](https://code.visualstudio.com/docs/agent-customization/mcp-servers)
+and [configuration reference](https://code.visualstudio.com/docs/agents/reference/mcp-configuration)
+document resource browsing, prompts, trust, stdio configuration, and cached-tool
+management. Stable
+[VS Code 1.103](https://code.visualstudio.com/updates/v1_103) explicitly added
+structured tool output and resource links.
+
+### Cursor evidence
+
+Cursor's current [MCP documentation](https://cursor.com/docs/mcp) lists stdio,
+tools, prompts, resources, roots, and elicitation. It documents default tool
+approval and MCP allowlists, but does not separately confirm resource templates,
+list-change handling, structured output, or resource links. Those features
+cannot be required even if a particular Cursor build happens to support them.
+
+### Claude Code evidence
+
+Claude Code's [MCP documentation](https://code.claude.com/docs/en/mcp) documents
+stdio, resources through `@` references, prompts as slash commands, and explicit
+refresh of tools, prompts, and resources after `list_changed`. It also documents
+MCP tool search, which defers most tool definitions until needed. Tool search is
+a useful host optimization, not a portable server capability.
+
+### OpenAI Codex evidence
+
+OpenAI's current [Codex MCP documentation](https://developers.openai.com/codex/mcp)
+documents stdio, tools, approvals, allow/deny lists, and server instructions.
+Current official implementation evidence, but not the stable product support
+list, shows resources and structured content. They remain `△` enhancements.
+MCP prompt discovery and reliable tool-list refresh cannot be assumed. Relevant official references include the merged
+[resource support change](https://github.com/openai/codex/pull/5239), the open
+[prompt support request](https://github.com/openai/codex/issues/8342), and the
+open [tool list-change request](https://github.com/openai/codex/issues/10105).
+
+## Design Consequences
+
+### Static catalog
+
+The target catalog is assembled once before MCP initialization and remains
+stable for the stdio session.
+
+- Account addition, removal, send capability, allowlist state, index state, and
+  credential health are returned as data and checked at call time.
+- A tool is not added or removed merely because the CLI changed an account.
+- An unconfigured server still exposes safe discovery tools and returns a clear
+  CLI remediation from mail tools.
+- Breaking a tool name or schema requires an explicit compatibility decision;
+  `list_changed` is not a migration mechanism.
+- Optional list-change notifications may refresh non-core enhancements, but
+  missing client support cannot block a workflow.
+
+The current conditional visibility of `send_email`,
+`list_allowed_recipients`, and `list_allowed_senders` may remain in a
+compatibility facade, but new design must not depend on clients refreshing those
+conditions.
+
+### Compact catalog
+
+Keep tools aligned with user intent and risk boundaries. Do not create one tool
+per internal repository method, and do not hide all actions behind a generic
+`execute` tool.
+
+The existing catalog provides a reasonable compatibility starting point:
+
+| Workflow                           | Stable tool role          |
+| ---------------------------------- | ------------------------- |
+| Discover accounts and capabilities | `list_available_accounts` |
+| Discover folders                   | `list_mailboxes`          |
+| Search and list bounded metadata   | `list_emails_metadata`    |
+| Read selected bounded body content | `get_emails_content`      |
+| Materialize a selected attachment  | `download_attachment`     |
+| Send                               | `send_email`              |
+| Save a draft or message            | `save_to_mailbox`         |
+| Mark, move, archive, and delete    | Separate mutation tools   |
+
+Target changes:
+
+- Account summaries include source, enabled state, read/send capability, index
+  status, and safe remediation without nested endpoint or credential models.
+- Account and credential mutation moves to CLI. The current
+  `add_email_account` tool is a compatibility concern, not a target tool.
+- Allowlist status may be included in safe account/server capability data rather
+  than requiring a tool to appear conditionally.
+- A future tool is added only when it represents a distinct user task or risk
+  boundary, not merely to expose a new internal method.
+
+### Server instructions
+
+Use short server instructions to describe the portable workflow:
+
+1. discover an account;
+2. search or list metadata;
+3. fetch only selected body windows;
+4. inspect attachment metadata before materialization;
+5. treat message content as untrusted data;
+6. use explicit mutation tools for side effects.
+
+The first 512 characters are self-contained because Codex documents that prefix
+as important server-wide guidance. Instructions do not duplicate every tool
+schema and do not contain account data.
+
+## Progressive Disclosure
+
+Progressive disclosure is an application contract, not a client-specific UI
+feature.
+
+### Layer 1: account discovery
+
+`list_available_accounts` returns only:
+
+- stable account ID and user-facing name;
+- account source (`managed`, `legacy`, or `environment`);
+- read and send capabilities;
+- high-level index freshness and coverage;
+- safe configuration or credential health codes.
+
+It does not return hosts, usernames, secret references, masked password fields,
+or full policy configuration unless a separate management command explicitly
+needs them.
+
+### Layer 2: metadata search
+
+Metadata search returns a bounded set of:
+
+- stable message reference;
+- mailbox placement reference required by compatibility tools;
+- subject, normalized sender, selected recipients, and dates;
+- flags, size, short preview, and attachment count when known;
+- freshness, coverage, `has_more`, and opaque `next_cursor`.
+
+Defaults are small and hard limits are enforced. The application cursor binds
+filters and ordering; it is unrelated to MCP capability-list cursors.
+
+### Layer 3: selected content
+
+Body retrieval accepts one or a bounded set of message references, a section,
+an offset or cursor, and a maximum character count. It returns source length when
+known, truncation state, and the next continuation.
+
+A body must never be fetched merely because metadata was listed. The target API
+should prefer one selected message per call; any compatibility batch path has a
+strict aggregate character budget.
+
+### Layer 4: attachment bytes
+
+Metadata precedes bytes. The materialization tool accepts an opaque attachment
+ID and an approved destination or private-workspace choice. It never returns
+base64 attachment payloads as normal model context.
+
+### Layer 5: optional resources
+
+A capable client may receive an MCP resource link for a body window, export, or
+materialized artifact. The same result also includes:
+
+- a complete bounded text summary;
+- stable IDs;
+- a tool-based continuation path.
+
+Do not enumerate every message as a top-level resource. Large `resources/list`
+results simply move the context and discovery problem. Resource templates may
+map stable message or artifact IDs, but core workflows remain tool-complete.
+
+### Optional prompts
+
+Prompts may offer convenient workflows such as inbox triage, but they are
+user-invoked templates, not hidden application commands. Because Codex does not
+provide a reliable prompt baseline, setup, search, read, send, and mutation must
+not require a prompt.
+
+## Tool Schemas
+
+- Names remain short, stable, and task-oriented.
+- Descriptions state when to call the tool, its side effects, required IDs, and
+  the bounded shape of the result.
+- Shared concepts use the same field name and semantics across tools.
+- IDs are opaque strings; descriptions do not teach the model to parse them.
+- List limits have defaults and hard maxima in JSON Schema.
+- Unknown fields are rejected where the SDK and compatibility contract permit.
+- Mutations expose recipients, subject, message IDs, source mailbox, and target
+  mailbox directly so approval dialogs are understandable.
+- Secrets and arbitrary configuration models never appear in schemas.
+- A schema change is additive when possible. Removing or changing a required
+  field is treated as a public compatibility event.
+
+### Account reference compatibility
+
+Current MCP tools continue to accept required `account_name` and resolve it at
+call time through the effective catalog to a stable local operational account ID.
+Rename therefore requires clients to rediscover account summaries; an old name returns a
+bounded `ACCOUNT_NOT_FOUND` or `STALE_ACCOUNT_REFERENCE` result rather than
+silently selecting another row.
+
+Account summaries return the stable local operational `account_id` for every
+effective managed, legacy, or environment account without removing the existing
+name. A future optional `account_id` input is additive. If both ID and name are
+supplied, they must resolve to the same effective source mapping or the call is
+rejected. Environment shadowing resolves the name to the attributed environment
+identity and is reported in discovery; an adapter never uses a shadowed managed
+or legacy ID behind the caller's back. A fingerprint or probable-rename conflict
+is returned as `ACCOUNT_IDENTITY_CONFLICT`; provider-effect tools fail before
+claiming an effect until the CLI resolves it.
+
+Operation records and internal services use stable IDs. Compatibility mapping is
+owned by the MCP adapter, just as mailbox-scoped `email_id` is mapped to a full
+message placement. Replacing `account_name` with a new required field would be a
+versioned public schema change.
+
+## Tool Results
+
+Each result has one typed semantic model. The MCP adapter renders it in two
+forms where supported:
+
+1. complete, bounded text in `content`;
+2. a machine-readable mirror in `structuredContent` that conforms to
+   `outputSchema`.
+
+Text is never a reduced fallback that omits IDs, errors, continuation, or
+partial-success state. Resource links are additional content, not the sole
+carrier of a result.
+
+### Result envelope
+
+Conceptually, results include:
+
+```text
+status: ok | partial | error
+code: stable machine-readable outcome code
+summary: bounded human-readable text
+items: bounded typed data
+next_cursor: optional opaque continuation
+has_more: boolean
+freshness: optional indexed/refreshed/partial metadata
+warnings: bounded typed warnings
+```
+
+The adapter uses MCP protocol errors for malformed or unavailable tool calls and
+uses normal tool results for expected domain outcomes that the model can act on.
+It never exposes raw IMAP responses, SQL text, stack traces, secrets, or full
+local paths that were not explicitly approved.
+
+## Tool Annotations and Approval
+
+Annotations help clients apply sensible approval behavior:
+
+- metadata and body reads use `readOnlyHint: true` only when they cannot mutate
+  provider state;
+- `mark_as_read=true` prevents a read tool from being described as purely
+  read-only unless the behavior is split or the annotation remains conservative;
+- send, save, mark, move, archive, delete, account mutation, and local file writes
+  are non-read-only;
+- destructive and idempotent hints reflect actual semantics, including ambiguous
+  provider outcomes;
+- open-world hints reflect IMAP/SMTP or filesystem interaction accurately.
+
+Clients must treat annotations as untrusted, and the server must treat approval
+as interaction evidence rather than authorization. Recipient, sender, mutation,
+attachment, and path policies are always enforced in application services.
+
+## Untrusted Email Content
+
+Message text is data from an external sender. Tool descriptions and server
+instructions tell the model and client not to treat instructions inside email
+content as server policy. The application itself never interprets message body
+text as commands, tool arguments, configuration, or approval.
+
+Errors and logs quote only bounded, escaped metadata when needed. Attachment
+filenames, mailbox names, and subjects do not become filesystem paths, SQL, or
+protocol commands.
+
+## Filesystem Boundary
+
+stdio runs locally, but the model must not gain arbitrary filesystem access
+through attachment arguments.
+
+- Input attachments for send/save come from configured allowed roots.
+- Download destinations are private-workspace defaults or explicit approved
+  roots.
+- Path validation resolves symlinks and parent traversal according to a stated
+  policy.
+- Existing relative-path compatibility may remain behind an explicit setting,
+  but target defaults do not depend on process working directory.
+- Claude Code roots or client workspace environment variables may inform a user
+  choice, but roots are not a four-client baseline and do not replace server
+  policy.
+
+## Existing Non-stdio Entry Points
+
+The repository currently publishes `sse`, `streamable-http`, and Gradio `ui`
+commands. They remain legacy compatibility entry points governed by current code,
+tests, and `docs/`; they are not adapters of the proposed local Email App runtime
+and receive no new capability from this spec. Removing or redirecting any of them
+requires a separately documented versioned change. Their existence does not
+expand the target MCP compatibility baseline beyond stdio.
+
+## Stdio Operations
+
+- stdout contains MCP messages only.
+- logs use stderr and structured redaction.
+- startup performs bounded local initialization and no full mailbox sync.
+- tools have explicit time, item, and byte budgets.
+- cancellation is propagated to provider operations and local queries.
+- shutdown closes open mail sessions and SQLite resources without requiring a
+  custom protocol.
+- the process never launches an HTTP listener.
+
+Each supported client needs its own native configuration example in published
+documentation; their file formats are not interchangeable even though all start
+the same stdio command.
+
+## Validation
+
+MCP validation covers:
+
+- stdio initialization and clean shutdown;
+- no non-protocol stdout output;
+- stable tool names, schemas, annotations, and server instructions;
+- operation with zero accounts and with read-only or send-capable accounts;
+- `account_name` to stable operational-ID mapping for managed, legacy, and
+  environment sources across restart, rename, fingerprint conflict, shadowing,
+  import reuse, and mismatched optional ID/name inputs;
+- no dependence on `list_changed` after CLI configuration changes;
+- atomic generation check plus effect-boundary transition, including compound
+  substeps, and `RESTART_REQUIRED` before side effects after a base-mode change;
+- complete text semantics with and without structured output;
+- bounded metadata pages, body batches, warnings, and errors;
+- cursor continuity and stale-cursor errors;
+- resource and prompt enhancements disabled without affecting tools;
+- client-approval-visible arguments for every mutation;
+- no credentials, secret references, unapproved paths, SQL, or raw provider
+  errors in results;
+- message-content prompt-injection boundaries;
+- black-box stdio workflows against GreenMail.
+
+Compatibility claims are based on official evidence, not MCP Inspector behavior.
+When client support changes, update this matrix, the owning interface design,
+and published client setup documentation together.

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,222 @@
+# Local Email App Architecture
+
+Status: Proposed
+
+This directory defines the target architecture for evolving `mcp-email-server`
+into a local, single-user Email App. The application exposes email workflows to
+MCP clients over stdio and exposes account, credential, index, cache, and
+diagnostic management through a CLI.
+
+These documents are design proposals. Current behavior remains defined by the
+code, tests, and published documentation under [`docs/`](../docs/).
+
+## Product Decisions
+
+The following decisions apply to every detailed spec:
+
+- The product is local and single-user.
+- stdio is the only target MCP transport.
+- MCP and CLI are peer adapters over the same application services.
+- SQLite is the managed local store for non-secret account configuration,
+  source-mapped operational account identities, mailbox and message metadata,
+  search indexes, sync cursors, operation evidence, and bounded body cache.
+- IMAP remains authoritative for mailbox state; SQLite is a local view, not a
+  replacement mail server.
+- Passwords, OAuth tokens, and provider API keys do not appear in ordinary
+  SQLite tables. A `SecretStore` owns secret values and SQLite stores only
+  opaque references.
+- Existing TOML, environment-variable, and keyring behavior remains available
+  as a compatibility mode and explicit import source.
+- MCP tools use progressive disclosure: account and metadata discovery precede
+  bounded body and attachment retrieval.
+- Static tools plus complete text results form the cross-client compatibility
+  baseline. Resources, prompts, structured output, and change notifications are
+  optional enhancements.
+
+## Explicit Non-goals
+
+The proposal does not design:
+
+- Streamable HTTP, SSE, or any other remote MCP transport;
+- a hosted service, tenant model, remote authentication, or cloud secret store;
+- a profile daemon or implicit background synchronization service;
+- a web application or MCP App user interface;
+- a database portability framework or interchangeable SQL engines;
+- full offline mailbox replication;
+- persistent raw MIME or attachment payloads by default.
+
+The application core must not import FastMCP, which keeps an additional adapter
+possible in principle, but no abstraction may be added solely for a hypothetical
+HTTP or cloud deployment.
+
+## Spec Map
+
+1. [`01-system-context.md`](01-system-context.md) — product boundary, local
+   process model, actors, goals, non-goals, and runtime ownership.
+2. [`02-application-boundaries.md`](02-application-boundaries.md) — domain,
+   application services, ports, adapters, composition, and dependency rules.
+3. [`03-configuration-and-credentials.md`](03-configuration-and-credentials.md)
+   — managed configuration, legacy compatibility, runtime overlays, secret
+   backends, and CLI management contracts.
+4. [`04-mail-workflows-and-consistency.md`](04-mail-workflows-and-consistency.md)
+   — metadata refresh, search, body retrieval, send, mutation, retry, and local
+   reconciliation semantics.
+5. [`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md)
+   — SQLite ownership, logical schema, search indexes, transactions, retention,
+   migrations, and recovery.
+6. [`06-mcp-interface-and-client-compatibility.md`](06-mcp-interface-and-client-compatibility.md)
+   — MCP tool design, progressive disclosure, client capability evidence,
+   output compatibility, annotations, and stdio validation.
+
+There is intentionally no phased migration plan. Each implementation change
+must preserve or explicitly version current public behavior, but sequencing
+belongs in issues and pull requests rather than in the architecture contract.
+
+## Architecture Shape
+
+```mermaid
+flowchart LR
+    USER[Local user]
+    CLIENT[MCP client]
+    SHELL[Shell]
+    MCP[MCP stdio adapter]
+    CLI[Management CLI]
+    APP[Application services]
+    DB[(SQLite)]
+    SECRET[SecretStore]
+    IMAP[IMAP server]
+    SMTP[SMTP server]
+    FILES[Private artifact workspace]
+
+    USER --> CLIENT
+    USER --> SHELL
+    CLIENT --> MCP
+    SHELL --> CLI
+    MCP --> APP
+    CLI --> APP
+    APP --> DB
+    APP --> SECRET
+    APP --> IMAP
+    APP --> SMTP
+    APP --> FILES
+```
+
+MCP owns agent-facing mail workflows. CLI owns local management workflows,
+including secret input. Neither interface owns mail policy, persistence rules,
+or protocol clients.
+
+## Sources of Truth
+
+| Data class                   | Source of truth                      | SQLite role                                                                                              |
+| ---------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| Managed configuration        | SQLite                               | Authoritative non-secret accounts, policies, and rules                                                   |
+| Legacy account configuration | TOML compatibility adapter           | Base config stays in TOML; SQLite stores only non-secret source-to-operational-ID mapping and index data |
+| Environment overrides        | Process environment                  | Read-only runtime config; SQLite may retain only non-secret source identity and index data               |
+| Passwords and tokens         | Selected `SecretStore`               | Opaque backend and locator only                                                                          |
+| Mailbox and message state    | IMAP server                          | Rebuildable local index and cache                                                                        |
+| SMTP delivery acceptance     | SMTP server response                 | Operation evidence and reconciliation state                                                              |
+| Raw MIME and attachments     | IMAP server or explicit local export | Metadata only by default                                                                                 |
+
+## Dependency Direction
+
+```mermaid
+graph TD
+    MCP[MCP interface]
+    CLI[CLI interface]
+    APP[Application services]
+    DOMAIN[Domain models and policies]
+    PORTS[Application ports]
+    SQLITE[SQLite adapters]
+    LEGACY[Legacy config adapters]
+    SECRETS[Secret adapters]
+    MAIL[IMAP, SMTP, and MIME adapters]
+    ARTIFACTS[Local artifact adapter]
+
+    MCP --> APP
+    CLI --> APP
+    APP --> DOMAIN
+    APP --> PORTS
+    SQLITE -. implements .-> PORTS
+    LEGACY -. implements .-> PORTS
+    SECRETS -. implements .-> PORTS
+    MAIL -. implements .-> PORTS
+    ARTIFACTS -. implements .-> PORTS
+```
+
+Outer adapters depend on application contracts. Domain and application code do
+not import FastMCP, Typer, sqlite3, keyring, aioimaplib, or aiosmtplib.
+
+## Cross-cutting Invariants
+
+- Tool and CLI handlers map inputs and outputs; they do not implement email
+  policy or database transactions.
+- One application command or query owns each user action.
+- Network calls and secret-store calls never run inside SQLite transactions.
+- A message placement is identified by account, mailbox, UIDVALIDITY, and UID;
+  an IMAP UID alone is not durable.
+- SMTP results preserve per-recipient acceptance, rejection, and uncertainty;
+  accepted or unknown recipients are never automatically resubmitted.
+- SMTP success is not rolled back when saving the sent copy fails, and an unknown
+  sent-copy APPEND is reconciled before retry.
+- Provider-effect operations atomically verify claim ownership and catalog
+  generation while persisting each effect boundary; a stale post-boundary claim
+  becomes unknown rather than being replayed.
+- Body reads use IMAP PEEK unless the user explicitly requests a read mutation.
+- Legacy and environment accounts may reuse stable SQLite operational identities,
+  but their endpoints, policies, and secrets are never copied into managed
+  configuration by index activity or an unrelated save.
+- Secrets never appear in tool results, structured logs, database rows, or
+  migration diagnostics.
+- Managed credential changes use a persisted saga and a unique candidate locator;
+  they never overwrite or delete the currently committed secret in place.
+- Account removal keeps a tombstone and operational identity while credential
+  cleanup or operation evidence remains; hard purge explicitly deletes eligible
+  children before releasing the name.
+- An active managed catalog materializes every required global security rule set;
+  missing or invalid sets fail closed. Rule sets distinguish inherit,
+  unrestricted, and explicit empty restriction; durable denies win and account
+  rules cannot widen global authority, apart from documented process-local
+  compatibility replacements.
+- The tool catalog is stable for the life of a stdio session. Account capability
+  changes are represented as data and call-time validation, not tool replacement.
+- Every list, body, error, and artifact operation has an explicit size bound.
+
+## Current Implementation Relationship
+
+The current repository already provides stdio, mail workflows, TOML/environment
+composition, keyring support, and bounded body reads. It does not yet provide
+the architecture described here:
+
+- `mcp_email_server/app.py` currently combines MCP registration, settings access,
+  policy checks, handler dispatch, and response mapping.
+- `mcp_email_server/config.py` currently combines stored configuration, runtime
+  composition, resolved secrets, mutation, and a process-global cache.
+- `db_location` exists, but no operational SQLite repository currently uses it.
+- conditional tool visibility filters `tools/list` but does not notify clients
+  when the list changes.
+- the published `sse`, `streamable-http`, and Gradio `ui` commands remain legacy
+  compatibility entry points; they are not part of the proposed runtime and
+  require a separate versioned decision before removal or redirection.
+
+Those statements describe the starting point, not a delivery sequence.
+
+## Status Vocabulary
+
+| Status        | Meaning                                                     |
+| ------------- | ----------------------------------------------------------- |
+| `Proposed`    | Under discussion; no implementation claim is made.          |
+| `Accepted`    | Approved target; implementation may be incomplete.          |
+| `Implemented` | Backed by code, tests, and aligned published documentation. |
+| `Superseded`  | Replaced by a linked decision or spec.                      |
+
+## Research Basis
+
+The MCP interface design was checked on 2026-07-18 against the stable
+[MCP 2025-11-25 specification](https://modelcontextprotocol.io/specification/2025-11-25)
+and current official documentation for
+[VS Code](https://code.visualstudio.com/api/extension-guides/ai/mcp),
+[Cursor](https://cursor.com/docs/mcp),
+[Claude Code](https://code.claude.com/docs/en/mcp), and
+[OpenAI Codex](https://developers.openai.com/codex/mcp).
+Detailed, claim-specific links are kept in
+[`06-mcp-interface-and-client-compatibility.md`](06-mcp-interface-and-client-compatibility.md).

--- a/tests/e2e/test_stdio_greenmail.py
+++ b/tests/e2e/test_stdio_greenmail.py
@@ -10,6 +10,7 @@ import time
 import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass
+from datetime import timedelta
 from email import policy
 from email.message import EmailMessage, Message
 from email.parser import BytesParser
@@ -233,7 +234,11 @@ async def test_current_stdio_server_against_greenmail(tmp_path: Path) -> None:
     )
 
     async with stdio_client(server) as (read_stream, write_stream):
-        async with ClientSession(read_stream, write_stream) as session:
+        async with ClientSession(
+            read_stream,
+            write_stream,
+            read_timeout_seconds=timedelta(seconds=15),
+        ) as session:
             initialized = await session.initialize()
             assert initialized.serverInfo.name == "email"
 

--- a/tests/e2e/test_stdio_greenmail.py
+++ b/tests/e2e/test_stdio_greenmail.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import contextlib
+import imaplib
+import os
+import re
+import smtplib
+import sys
+import time
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from email import policy
+from email.message import EmailMessage, Message
+from email.parser import BytesParser
+from email.utils import make_msgid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.types import TextContent
+
+pytestmark = pytest.mark.e2e
+
+SMTP_HOST = "127.0.0.1"
+SMTP_PORT = int(os.environ.get("MCP_EMAIL_SERVER_E2E_SMTP_PORT", "3025"))
+IMAP_HOST = "127.0.0.1"
+IMAP_PORT = int(os.environ.get("MCP_EMAIL_SERVER_E2E_IMAP_PORT", "3143"))
+ALICE = ("alice@example.test", "alice-password")
+BOB = ("bob@example.test", "bob-password")
+
+CONFIG_TEMPLATE = f"""credential_storage = "plaintext"
+enable_attachment_download = true
+
+[[emails]]
+account_name = "alice"
+full_name = "Alice Example"
+email_address = "alice@example.test"
+save_to_sent = true
+sent_folder_name = "Sent"
+
+[emails.incoming]
+user_name = "alice@example.test"
+password = "alice-password"
+host = "127.0.0.1"
+port = {IMAP_PORT}
+use_ssl = false
+start_ssl = false
+verify_ssl = true
+
+[emails.outgoing]
+user_name = "alice@example.test"
+password = "alice-password"
+host = "127.0.0.1"
+port = {SMTP_PORT}
+use_ssl = false
+start_ssl = false
+verify_ssl = true
+
+[[emails]]
+account_name = "bob"
+full_name = "Bob Example"
+email_address = "bob@example.test"
+save_to_sent = false
+
+[emails.incoming]
+user_name = "bob@example.test"
+password = "bob-password"
+host = "127.0.0.1"
+port = {IMAP_PORT}
+use_ssl = false
+start_ssl = false
+verify_ssl = true
+"""
+
+
+@dataclass(frozen=True)
+class ObservedMessage:
+    uid: str
+    message: Message
+    flags: set[str]
+
+
+@contextlib.contextmanager
+def _imap_session(credentials: tuple[str, str]) -> Iterator[imaplib.IMAP4]:
+    client = imaplib.IMAP4(IMAP_HOST, IMAP_PORT, timeout=5)
+    try:
+        status, _ = client.login(*credentials)
+        assert status == "OK"
+        yield client
+    finally:
+        with contextlib.suppress(Exception):
+            client.logout()
+
+
+def _wait_until_ready(timeout: float = 15) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=2) as smtp:
+                smtp.login(*ALICE)
+            with _imap_session(BOB):
+                pass
+            return
+        except (OSError, smtplib.SMTPException, imaplib.IMAP4.error, AssertionError) as exc:
+            last_error = exc
+            time.sleep(0.25)
+    pytest.fail(f"GreenMail is not ready on SMTP {SMTP_PORT}/IMAP {IMAP_PORT}: {last_error}")
+
+
+def _ensure_empty_mailboxes(credentials: tuple[str, str], mailboxes: list[str]) -> None:
+    with _imap_session(credentials) as client:
+        for mailbox in mailboxes:
+            if mailbox != "INBOX":
+                status, _ = client.create(mailbox)
+                assert status in {"OK", "NO"}
+            status, _ = client.select(mailbox)
+            assert status == "OK"
+            status, data = client.uid("search", None, "ALL")
+            assert status == "OK"
+            for uid in (data[0] or b"").split():
+                status, _ = client.uid("store", uid, "+FLAGS.SILENT", r"(\Deleted)")
+                assert status == "OK"
+            status, _ = client.expunge()
+            assert status == "OK"
+
+
+def _find_message(credentials: tuple[str, str], mailbox: str, subject: str) -> ObservedMessage | None:
+    with _imap_session(credentials) as client:
+        status, _ = client.select(mailbox, readonly=True)
+        assert status == "OK"
+        status, data = client.uid("search", None, "ALL")
+        assert status == "OK"
+        for uid in reversed((data[0] or b"").split()):
+            status, fetched = client.uid("fetch", uid, "(BODY.PEEK[] FLAGS)")
+            assert status == "OK"
+            response = next((item for item in fetched if isinstance(item, tuple)), None)
+            assert response is not None
+            metadata, raw_message = response
+            message = BytesParser(policy=policy.default).parsebytes(raw_message)
+            if str(message.get("Subject", "")) != subject:
+                continue
+            flag_match = re.search(rb"FLAGS \(([^)]*)\)", metadata)
+            flags = set(flag_match.group(1).decode().split()) if flag_match else set()
+            return ObservedMessage(uid.decode(), message, flags)
+    return None
+
+
+def _wait_for_message(credentials: tuple[str, str], mailbox: str, subject: str, timeout: float = 5) -> ObservedMessage:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        observed = _find_message(credentials, mailbox, subject)
+        if observed is not None:
+            return observed
+        time.sleep(0.1)
+    pytest.fail(f"Message {subject!r} did not arrive in {mailbox!r}")
+
+
+def _seed_message(subject: str, body: str) -> None:
+    message = EmailMessage()
+    message["From"] = ALICE[0]
+    message["To"] = BOB[0]
+    message["Subject"] = subject
+    message["Message-ID"] = make_msgid(domain="example.test")
+    message.set_content(body)
+    with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=5) as smtp:
+        smtp.login(*ALICE)
+        smtp.send_message(message)
+
+
+def _text_content(result: Any) -> str:
+    return "\n".join(item.text for item in result.content if isinstance(item, TextContent))
+
+
+async def _call_tool(session: ClientSession, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    result = await session.call_tool(name, arguments=arguments)
+    assert result.isError is not True, f"{name} failed: {_text_content(result)}"
+    assert result.structuredContent is not None, f"{name} returned no structured content"
+    return result.structuredContent
+
+
+async def _metadata_for_subject_in_mailbox(
+    session: ClientSession, account_name: str, mailbox: str, subject: str
+) -> dict[str, Any]:
+    payload = await _call_tool(
+        session,
+        "list_emails_metadata",
+        {"account_name": account_name, "mailbox": mailbox, "subject": subject, "page_size": 50},
+    )
+    matches = [email for email in payload["emails"] if email["subject"] == subject]
+    assert len(matches) == 1, payload
+    return matches[0]
+
+
+async def _metadata_for_subject(session: ClientSession, account_name: str, subject: str) -> dict[str, Any]:
+    return await _metadata_for_subject_in_mailbox(session, account_name, "INBOX", subject)
+
+
+@pytest.mark.asyncio
+async def test_current_stdio_server_against_greenmail(tmp_path: Path) -> None:
+    """Exercise the current public MCP/CLI/config boundary against real mail sockets."""
+    _wait_until_ready()
+    _ensure_empty_mailboxes(ALICE, ["INBOX", "Sent", "Drafts", "Archive"])
+    _ensure_empty_mailboxes(BOB, ["INBOX", "Drafts", "Archive"])
+
+    run_id = uuid.uuid4().hex
+    sent_subject = f"mcp-e2e-send-{run_id}"
+    sent_body = f"Body produced through MCP stdio {run_id}"
+    attachment_bytes = b"greenmail attachment roundtrip\x00\xff\n"
+    attachment_source = tmp_path / "roundtrip.bin"
+    attachment_source.write_bytes(attachment_bytes)
+    attachment_download = tmp_path / "downloaded.bin"
+
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(CONFIG_TEMPLATE)
+    config_path.chmod(0o600)
+    server_env = {key: value for key, value in os.environ.items() if not key.startswith("MCP_EMAIL_SERVER_")}
+    server_env.update({
+        "MCP_EMAIL_SERVER_CONFIG_PATH": str(config_path),
+        "MCP_EMAIL_SERVER_CREDENTIAL_STORAGE": "plaintext",
+        "MCP_EMAIL_SERVER_LOG_LEVEL": "WARNING",
+    })
+    console_script = Path(sys.executable).with_name("mcp-email-server")
+    assert console_script.is_file(), f"Installed console script not found: {console_script}"
+    server = StdioServerParameters(
+        command=str(console_script),
+        args=["stdio"],
+        env=server_env,
+        cwd=Path.cwd(),
+    )
+
+    async with stdio_client(server) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            initialized = await session.initialize()
+            assert initialized.serverInfo.name == "email"
+
+            tools = await session.list_tools()
+            tool_names = {tool.name for tool in tools.tools}
+            assert {
+                "list_available_accounts",
+                "list_emails_metadata",
+                "get_emails_content",
+                "send_email",
+                "save_to_mailbox",
+                "delete_emails",
+                "mark_emails_as_read",
+                "move_emails",
+                "archive_emails",
+                "list_mailboxes",
+                "download_attachment",
+            } <= tool_names
+
+            accounts = await _call_tool(session, "list_available_accounts", {})
+            assert {account["account_name"] for account in accounts["result"]} == {"alice", "bob"}
+
+            send_result = await _call_tool(
+                session,
+                "send_email",
+                {
+                    "account_name": "alice",
+                    "recipients": [BOB[0]],
+                    "subject": sent_subject,
+                    "body": sent_body,
+                    "attachments": [str(attachment_source)],
+                },
+            )
+            assert send_result["result"] == f"Email sent successfully to {BOB[0]} with 1 attachment(s)"
+
+            delivered = _wait_for_message(BOB, "INBOX", sent_subject)
+            assert sent_body in (delivered.message.get_body(preferencelist=("plain",)).get_content())
+            delivered_attachments = list(delivered.message.iter_attachments())
+            assert len(delivered_attachments) == 1
+            assert delivered_attachments[0].get_filename() == attachment_source.name
+            assert delivered_attachments[0].get_payload(decode=True) == attachment_bytes
+
+            sent_copy = _wait_for_message(ALICE, "Sent", sent_subject)
+            assert sent_body in sent_copy.message.get_body(preferencelist=("plain",)).get_content()
+
+            sent_metadata = await _metadata_for_subject(session, "bob", sent_subject)
+            assert sent_metadata["sender"].endswith("<alice@example.test>") or sent_metadata["sender"] == ALICE[0]
+            assert BOB[0] in sent_metadata["recipients"]
+            # Metadata intentionally fetches headers only; attachment names are populated by the content path.
+            assert sent_metadata["attachments"] == []
+
+            content = await _call_tool(
+                session,
+                "get_emails_content",
+                {"account_name": "bob", "email_ids": [sent_metadata["email_id"]]},
+            )
+            assert content["requested_count"] == 1
+            assert content["retrieved_count"] == 1
+            assert content["failed_ids"] == []
+            assert content["emails"][0]["attachments"] == [attachment_source.name]
+            assert sent_body in content["emails"][0]["body"]
+
+            mark_result = await _call_tool(
+                session,
+                "mark_emails_as_read",
+                {"account_name": "bob", "email_ids": [sent_metadata["email_id"]]},
+            )
+            assert mark_result["result"] == "Successfully marked 1 email(s) as read"
+            assert r"\Seen" in _wait_for_message(BOB, "INBOX", sent_subject).flags
+
+            download = await _call_tool(
+                session,
+                "download_attachment",
+                {
+                    "account_name": "bob",
+                    "email_id": sent_metadata["email_id"],
+                    "attachment_name": attachment_source.name,
+                    "save_path": str(attachment_download),
+                },
+            )
+            assert download["attachment_name"] == attachment_source.name
+            assert download["size"] == len(attachment_bytes)
+            assert Path(download["saved_path"]) == attachment_download
+            assert attachment_download.read_bytes() == attachment_bytes
+
+            move_result = await _call_tool(
+                session,
+                "move_emails",
+                {
+                    "account_name": "bob",
+                    "email_ids": [sent_metadata["email_id"]],
+                    "source_mailbox": "INBOX",
+                    "destination_mailbox": "Archive",
+                },
+            )
+            assert move_result["result"] == "Successfully moved 1 email(s) to Archive"
+            assert _find_message(BOB, "INBOX", sent_subject) is None
+            _wait_for_message(BOB, "Archive", sent_subject)
+
+            archive_subject = f"mcp-e2e-archive-{run_id}"
+            _seed_message(archive_subject, "Archive this message")
+            _wait_for_message(BOB, "INBOX", archive_subject)
+            archive_metadata = await _metadata_for_subject(session, "bob", archive_subject)
+            archive_result = await _call_tool(
+                session,
+                "archive_emails",
+                {"account_name": "bob", "email_ids": [archive_metadata["email_id"]]},
+            )
+            assert archive_result["result"] == "Successfully archived 1 email(s) to Archive"
+            assert _find_message(BOB, "INBOX", archive_subject) is None
+            _wait_for_message(BOB, "Archive", archive_subject)
+
+            draft_subject = f"mcp-e2e-draft-{run_id}"
+            draft_body = "Draft body created through MCP"
+            save_result = await _call_tool(
+                session,
+                "save_to_mailbox",
+                {
+                    "account_name": "alice",
+                    "recipients": [BOB[0]],
+                    "subject": draft_subject,
+                    "body": draft_body,
+                    "mailbox": "Drafts",
+                },
+            )
+            assert "Email saved to 'Drafts' successfully" in save_result["result"]
+            draft = _wait_for_message(ALICE, "Drafts", draft_subject)
+            assert draft_body in draft.message.get_body(preferencelist=("plain",)).get_content()
+            assert {r"\Draft", r"\Seen"} <= draft.flags
+
+            draft_metadata = await _metadata_for_subject_in_mailbox(session, "alice", "Drafts", draft_subject)
+            delete_draft = await _call_tool(
+                session,
+                "delete_emails",
+                {
+                    "account_name": "alice",
+                    "email_ids": [draft_metadata["email_id"]],
+                    "mailbox": "Drafts",
+                },
+            )
+            assert delete_draft["result"] == "Successfully deleted 1 email(s)"
+            assert _find_message(ALICE, "Drafts", draft_subject) is None
+
+            mailboxes = await _call_tool(session, "list_mailboxes", {"account_name": "alice"})
+            mailbox_names = {mailbox["name"] for mailbox in mailboxes["result"]}
+            assert {"INBOX", "Sent", "Drafts", "Archive"} <= mailbox_names


### PR DESCRIPTION
Document the stdio-only local Email App target, including SQLite-backed
operational identity, managed configuration, consistency, and MCP client
compatibility contracts.

Add an isolated GreenMail black-box E2E runner and validation guide to preserve
current stdio, SMTP, and IMAP behavior while the architecture evolves.

Follow-up hardening bounds MCP response waits and removes the unpinned npm
bootstrap command from contributor guidance.
