### PR TITLE
ci: run GreenMail E2E in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,22 @@ jobs:
       - name: Run checks
         run: make check
 
+  greenmail-e2e:
+    name: GreenMail E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+
+      - name: Set up the environment
+        uses: ./.github/actions/setup-python-env
+
+      - name: Run GreenMail E2E baseline
+        run: make test-e2e
+
   tests-and-type-check:
     runs-on: ubuntu-latest
     strategy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ anycap feedback --type feature -m "describe the use case"
 
 - Add or update tests for every behavior change and regression fix.
 - Keep unit tests deterministic and independent of live IMAP, SMTP, or keyring services.
-- Run `make test-e2e` for changes to IMAP, SMTP, MCP stdio, configuration loading, attachment handling, or mailbox mutations. This uses synthetic accounts on a loopback-only GreenMail container.
+- Run `make test-e2e` for changes to IMAP, SMTP, MCP stdio, configuration loading, attachment handling, or mailbox mutations. This uses synthetic accounts on a loopback-only GreenMail container, and CI runs it once on the default Python version.
 - Cover both successful operations and security or failure boundaries.
 - When changing configuration, test TOML loading, supported environment overrides, persistence, and migration behavior as applicable.
 - When changing MCP tools, test schemas, responses, conditional visibility, and account-specific error paths.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,9 +109,10 @@ to loopback, and removes it after the test. See the
 [validation guide](https://mcp-email-server.wh1isper.top/validation/) for the
 covered flows and limitations.
 
-The CI pipeline runs the unit test suite against every supported Python version.
-The GreenMail baseline is currently an explicit local check rather than a
-required CI job.
+The CI pipeline runs the unit test suite against every supported Python version
+and runs the GreenMail baseline once on Python 3.13 for pull requests and pushes
+to `main`. Relevant changes should still run `make test-e2e` locally before they
+are pushed so failures can be diagnosed without waiting for CI.
 
 9. Commit your changes and push your branch to GitHub:
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -32,6 +32,17 @@ Docker:
 make test
 ```
 
+## Continuous integration
+
+The main GitHub Actions workflow runs `make test-e2e` once on `ubuntu-latest`
+with Python 3.13 for every pull request and push to `main`. The job has a
+10-minute outer timeout in addition to the per-request MCP deadline. The regular
+Python 3.11-3.14 test matrix continues to exclude the `e2e` marker, so GreenMail
+is not repeated for every interpreter version.
+
+Run the baseline locally before pushing relevant mail or stdio changes; the
+shared CI check is not a replacement for local diagnosis.
+
 ## Tested boundary
 
 ```mermaid


### PR DESCRIPTION
Run the stdio SMTP/IMAP black-box baseline once on Python 3.13 for pull requests
and main pushes. Bound the job to ten minutes, restrict its token to read-only
contents access, and document the shared CI behavior.

Assisted-by: YAAI <261597362+yaai-bot@users.noreply.github.com>
