### PR TITLE
docs(spec): refine local email app architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ tests/config.toml
 local/
 config.toml
 .worktrees/
+local-reference/

--- a/research/ui-delivery-strategy.md
+++ b/research/ui-delivery-strategy.md
@@ -1,0 +1,987 @@
+# UI Delivery Strategy for the Local Email App
+
+Status: Research recommendation, not an accepted architecture specification
+
+Research date: 2026-07-18
+
+## Executive Summary
+
+The product should not choose between a local web UI and MCP Apps as if they
+were interchangeable. They serve different trust boundaries and different user
+jobs.
+
+The recommended product shape is:
+
+1. **An embedded React local Web UI is the primary graphical management
+   surface.** It is started explicitly with
+   `uvx mcp-email-server@latest webui`, binds only to a loopback address, uses an
+   ephemeral port, one-time browser bootstrap, and process session, and exits
+   with its CLI process. It
+   manages accounts, credentials, policy, migration, diagnostics, index state,
+   and cache state by calling the same application services as the CLI.
+2. **The CLI remains the headless, recovery, and automation surface.** Secret
+   prompts remain available in the terminal even if a browser or Web UI is
+   unavailable.
+3. **MCP Apps is an optional agent-facing enhancement, not the management
+   plane.** It can improve mailbox exploration, review, selection, and other
+   non-secret interactions inside capable hosts. Core tools must retain complete
+   bounded text results for every other host.
+4. **The current Gradio UI remains a compatibility bridge, not the target UI
+   architecture.** A React/Vite frontend can be built during release, packaged
+   into the Python wheel, and run by `uvx` without requiring Node.js on the
+   user's machine.
+
+One frontend workspace can serve both graphical surfaces, but it should produce
+**two entry points and two bundles**. Shared React components, view models,
+validation, and design tokens are reusable. The MCP host bridge, loopback HTTP
+client, session security, credential handling, and authorization adapters must
+remain separate.
+
+This recommendation preserves the existing product constraints: local,
+single-user, no daemon, no hosted service, and stdio as the only target MCP
+transport. The Web UI is a temporary local management listener; it is not an MCP
+HTTP transport or a remotely supported API.
+
+## Research Questions
+
+This report evaluates:
+
+- the official status and wire model of MCP Apps;
+- stdio compatibility and Python SDK maturity;
+- support in VS Code, Cursor, Claude, Claude Code, and OpenAI Codex;
+- whether an MCP App can safely manage email credentials;
+- the current Gradio implementation and `uvx` experience;
+- an embedded React distribution model;
+- local Web UI security requirements;
+- the best division of product responsibilities;
+- file-level changes that would be needed in the current architecture proposal.
+
+## Current Repository Baseline
+
+### Existing user experience
+
+The project already documents and supports:
+
+```bash
+uvx mcp-email-server@latest ui
+```
+
+The command imports `mcp_email_server.ui`, constructs a Gradio `Blocks`
+application, and calls `launch(inbrowser=True)`. It currently provides:
+
+- account listing;
+- account creation for common IMAP and optional SMTP configurations;
+- account deletion;
+- operating-system keyring integration through the current settings facade;
+- Claude Desktop installation and removal controls.
+
+This proves that a browser-based configuration flow distributed through `uvx`
+is viable. It does not prove that the current UI is the right target adapter.
+
+### Architectural gaps in the current Gradio UI
+
+The current `mcp_email_server/ui.py` is a 523-line nested callback module that
+calls global configuration functions and Claude Desktop installer helpers
+directly. It does not use the proposed `create_runtime()` composition root or
+`AccountManagementService`. It therefore cannot naturally inherit the proposed
+managed SQLite catalog, persisted secret-change saga, source attribution,
+connectivity testing, policy management, index maintenance, or cache management.
+
+Other material gaps are:
+
+- no account edit flow;
+- no managed/legacy/environment source distinction;
+- no import, migration, repair, or catalog-generation workflow;
+- no connectivity test before or after save;
+- no index, cache, policy, or diagnostic management;
+- no typed interface boundary between callbacks and application services;
+- no UI tests; `mcp_email_server/ui.py` is explicitly omitted from coverage;
+- no reusable frontend code for an MCP App;
+- implicit Gradio launch policy rather than an application-owned local security
+  contract.
+
+Gradio 6 defaults to `127.0.0.1` and strict CORS, which are useful defaults, but
+`server_name`, `server_port`, and `share` can also be influenced by Gradio
+environment variables when the application does not pass explicit values. In
+particular, Gradio documents that `GRADIO_SERVER_NAME` can change the bind
+address and `GRADIO_SHARE=True` can request a public tunnel. A target management
+surface should own and enforce its loopback-only policy rather than inherit
+framework environment behavior. See the
+[Gradio `Blocks.launch` reference](https://www.gradio.app/docs/gradio/blocks#launch).
+
+The dependency cost is also disproportionate to this product's needs. In the
+current lock graph, Gradio brings in pandas, NumPy, Pillow, Hugging Face Hub,
+audio helpers, and other general-purpose UI dependencies. An embedded static
+frontend can use the ASGI components already required by the MCP Python stack,
+with direct dependency declarations for anything imported by the Web UI
+adapter.
+
+### `uvx` properties
+
+`uvx` is an alias for `uv tool run`. It executes a package-provided command in
+an isolated environment and caches that environment as disposable state. An
+`@latest` suffix explicitly refreshes resolution. A persistent
+`uv tool install` environment is also available when a stable executable path is
+important. These behaviors are documented in the official
+[uv tools documentation](https://docs.astral.sh/uv/concepts/tools/).
+
+This gives the desired product experience without a permanent installation:
+
+```bash
+uvx mcp-email-server@latest webui
+```
+
+It also preserves an existing caveat: disposable or refreshed executable paths
+can trigger new operating-system keyring approval behavior on platforms such as
+macOS. Documentation should recommend `uv tool install mcp-email-server` when a
+stable executable identity is preferred.
+
+## MCP Apps: Verified Protocol Model
+
+### Status and naming
+
+MCP Apps is the official successor and standardization path for earlier MCP-UI
+and vendor-specific app patterns. [SEP-1865](https://modelcontextprotocol.io/seps/1865-mcp-apps-interactive-user-interfaces-for-mcp)
+is **Final** on the Extensions Track. The extension identifier is
+`io.modelcontextprotocol/ui`.
+
+The term **MCP Apps** should be used in product and specification text. MCP-UI
+remains relevant as a community SDK and host framework, but it is not the name
+of the official extension.
+
+### Two protocol objects
+
+An MCP App always has two server-side parts:
+
+1. a normal MCP tool with `_meta.ui.resourceUri`;
+2. a `ui://` resource containing HTML with MIME type
+   `text/html;profile=mcp-app`.
+
+A supporting host discovers the tool metadata, reads the resource through
+`resources/read`, renders it in a sandboxed iframe, and delivers tool input and
+results to the view. The official
+[MCP Apps overview](https://modelcontextprotocol.io/extensions/apps/overview),
+[versioned specification](https://github.com/modelcontextprotocol/ext-apps/blob/2ca6a59d2f493b227a83a2e3ce0396db4705621a/specification/2026-01-26/apps.mdx),
+and [Python SDK guide](https://py.sdk.modelcontextprotocol.io/v2/advanced/apps/)
+all describe this model.
+
+### Stdio compatibility
+
+MCP Apps does not require the MCP server to expose HTTP. There are two separate
+communication paths:
+
+```mermaid
+sequenceDiagram
+    participant V as App iframe
+    participant H as MCP host
+    participant S as Local stdio server
+
+    H->>S: initialize with Apps extension capability
+    S-->>H: tools and resources capabilities
+    H->>S: tools/list
+    S-->>H: tool with _meta.ui.resourceUri
+    H->>S: resources/read ui://...
+    S-->>H: bundled HTML resource
+    H->>V: render sandboxed HTML
+    V->>H: ui/initialize over postMessage
+    H-->>V: host context and capabilities
+    H->>S: tools/call
+    S-->>H: bounded text and structured result
+    H-->>V: ui/notifications/tool-result
+```
+
+Host-to-server traffic continues over stdio. View-to-host traffic uses JSON-RPC
+2.0 over `postMessage`. The host proxies permitted standard messages such as
+`tools/call` to the server. The official React example includes a
+[local stdio configuration](https://github.com/modelcontextprotocol/ext-apps/tree/2ca6a59d2f493b227a83a2e3ce0396db4705621a/examples/basic-server-react).
+
+This fits the Local Email App's stdio-only MCP decision. Adding an MCP App does
+not justify restoring Streamable HTTP or SSE to the target architecture.
+
+### Negotiation and fallback
+
+Apps is an optional extension. A host advertises
+`io.modelcontextprotocol/ui` and supported MIME types during initialization.
+The Apps specification requires UI-enabled tools to return meaningful `content`;
+this product additionally requires that content to be bounded. The iframe is for
+the human, while text remains useful to the model and to hosts without Apps.
+
+For this project, the compatibility contract remains:
+
+```text
+static tools + complete bounded text results
+```
+
+MCP Apps adds a negotiated rendering path. It does not replace tools, text,
+server-side policy, or application pagination.
+
+### Sandbox and host mediation
+
+The specification treats the view as potentially hostile. Its threat model
+includes malicious HTML, sandbox escape, unauthorized tool execution, sensitive
+host-data exfiltration, phishing, and resource exhaustion. Required or
+recommended controls include:
+
+- sandboxed iframes;
+- a different-origin sandbox proxy for web hosts;
+- deny-by-default CSP built from declared resource metadata;
+- predeclared and reviewable resources;
+- validated and auditable JSON-RPC messages;
+- host control over proxied calls;
+- optional user approval for view-initiated actions;
+- resource limits and visible UI boundaries.
+
+`_meta.ui.visibility: ["app"]` means that a conforming host must exclude the
+tool from the model's tool list while allowing a same-server app to call it. The
+host must also reject app calls to tools whose visibility excludes `app`. This
+is **not authentication**, proof of local-user intent, or authority to mutate
+the SecretStore.
+
+### Credential implication
+
+The Apps specification does not contain a blanket sentence that forbids a
+password form. Its data path nevertheless makes the product decision clear:
+
+- the iframe sends tool arguments through a host-controlled `postMessage`
+  bridge;
+- the host validates, may log, may approve, and proxies `tools/call`;
+- the server receives the call only after the host;
+- tool input and result notifications can be delivered back to the view;
+- the view is explicitly inside the untrusted-content threat model.
+
+Therefore email passwords, OAuth refresh tokens, provider API keys, candidate
+secret values, and SecretStore mutation payloads must not pass through an MCP
+App. An app-only tool reduces model exposure, but it does not remove the host
+from the secret path.
+
+MCP Apps may report safe credential health such as `missing`, `expired`, or
+`repair_required`, and may tell the user to run the local Web UI or CLI. It must
+not receive a masked secret, raw secret, secret locator, or reusable token.
+
+## Client Support Matrix
+
+The table distinguishes an MCP host's general tool/resource support from actual
+MCP Apps rendering. Evidence was checked on 2026-07-18.
+
+| Host surface                | Local stdio MCP               | MCP Apps rendering                                                | Product decision                                          |
+| --------------------------- | ----------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------- |
+| VS Code with GitHub Copilot | Yes                           | Supported in current official documentation                       | Valid optional Apps target                                |
+| Cursor desktop              | Yes                           | Supported since Cursor 2.6 and in current docs                    | Valid optional Apps target; test release regressions      |
+| Claude Desktop chat         | Yes                           | Officially supported                                              | Valid optional Apps target                                |
+| Claude web/mobile           | Not the same local stdio path | Officially supported for connectors                               | Not a local-product baseline                              |
+| Claude Code terminal        | Yes                           | No public inline Apps renderer is documented                      | Text tools only for baseline                              |
+| OpenAI Codex CLI/TUI        | Yes                           | No inline HTML surface is documented                              | Text tools only for baseline                              |
+| OpenAI Codex IDE extension  | Yes                           | No stable public Apps support is documented                       | Text tools only for baseline                              |
+| OpenAI Codex desktop app    | Yes                           | Under-development evidence exists, but an open regression remains | Experimental; do not claim support                        |
+| ChatGPT hosted Apps         | Remote MCP-backed app path    | Supported                                                         | Useful portability evidence, not the local stdio baseline |
+
+### Evidence by host
+
+- **VS Code:** the current
+  [MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp)
+  lists MCP Apps among supported features. The
+  [January 2026 announcement](https://code.visualstudio.com/blogs/2026/01/26/mcp-apps-support)
+  introduced full support in Insiders and announced the following stable
+  rollout.
+- **Cursor:** current
+  [Cursor MCP documentation](https://cursor.com/docs/mcp#protocol-and-extension-support)
+  lists Apps as supported and describes progressive enhancement. The
+  [Cursor 2.6 changelog](https://cursor.com/changelog/2-6) records the shipped
+  feature.
+- **Claude:** Anthropic's
+  [interactive connectors announcement](https://claude.com/blog/interactive-tools-in-claude)
+  states that MCP Apps are available in Claude mobile, web, and desktop. The
+  official MCP Apps overview separately lists Claude Desktop. This evidence is
+  for Claude product surfaces, not automatically for the Claude Code terminal.
+- **Claude Code:** its extensive
+  [MCP documentation](https://code.claude.com/docs/en/mcp) documents stdio,
+  tools, resources, prompts, elicitation, refresh, approval, and OAuth, but does
+  not document an MCP Apps iframe renderer. Absence is reported as no public
+  confirmation, not proof that no private or future build can render Apps.
+- **Codex:** current
+  [Codex MCP documentation](https://learn.chatgpt.com/docs/extend/mcp) documents
+  stdio, Streamable HTTP, server instructions, tool controls, and approvals but
+  does not list Apps as a supported server feature. The open
+  [Codex issue #21019](https://github.com/openai/codex/issues/21019) records an
+  under-development feature path and continuing desktop rendering regressions.
+  It is implementation evidence, not a stable product contract.
+- **ChatGPT:** OpenAI documents
+  [MCP Apps compatibility in ChatGPT](https://developers.openai.com/apps-sdk/mcp-apps-in-chatgpt),
+  including the standard iframe bridge. ChatGPT-specific APIs remain optional
+  vendor extensions and should not enter the portable bundle.
+
+### Compatibility conclusion
+
+MCP Apps has meaningful adoption, but it still cannot be the only UI. A user who
+runs Claude Code or Codex must not lose graphical account management merely
+because that MCP host does not render the optional extension. A normal local Web
+UI works independently of the MCP host and is therefore the only portable
+primary graphical surface.
+
+## Python SDK Maturity
+
+The repository currently resolves `mcp==1.26.0` under `mcp>=1.23.0,<2`. The
+installed FastMCP APIs can attach arbitrary tool and resource metadata, but the
+installed package has no `mcp.server.apps` module or first-class Apps extension
+negotiation API.
+
+As of the research date:
+
+- PyPI's latest stable MCP Python SDK is 1.28.1;
+- MCP Python SDK 2.0 has beta releases;
+- the official v2 guide contains the first-class `Apps`, `APP_MIME_TYPE`,
+  `client_supports_apps`, resource CSP, permissions, and visibility APIs.
+
+See [MCP on PyPI](https://pypi.org/project/mcp/) and the
+[official v2 Apps guide](https://py.sdk.modelcontextprotocol.io/v2/advanced/apps/).
+
+A local React Web UI does not depend on MCP Apps SDK maturity and can proceed
+against application services. The MCP App adapter should wait for either:
+
+1. a stable Python SDK 2 release with tested FastMCP or low-level server
+   integration; or
+2. a deliberately maintained thin protocol adapter with conformance tests.
+
+Shipping production behavior on a beta SDK solely to obtain Apps support is not
+recommended. Manually emitting pre-GA compatibility aliases is also not a sound
+cross-host contract.
+
+## Embedded React Is Feasible
+
+### Distribution model
+
+The official MCP Apps React example uses React, Vite,
+`@vitejs/plugin-react`, and `vite-plugin-singlefile`. It compiles the UI into one
+`dist/mcp-app.html`, which the server reads and returns as an MCP resource. See
+the official
+[React example](https://github.com/modelcontextprotocol/ext-apps/tree/2ca6a59d2f493b227a83a2e3ce0396db4705621a/examples/basic-server-react),
+[`vite.config.ts`](https://github.com/modelcontextprotocol/ext-apps/blob/2ca6a59d2f493b227a83a2e3ce0396db4705621a/examples/basic-server-react/vite.config.ts),
+and
+[`server.ts`](https://github.com/modelcontextprotocol/ext-apps/blob/2ca6a59d2f493b227a83a2e3ce0396db4705621a/examples/basic-server-react/server.ts).
+
+For this Python project:
+
+1. Node.js and npm are maintainer and release-build dependencies only.
+2. CI builds each frontend surface selected for the release before building the
+   Python source distribution and wheel.
+3. Built assets and required third-party license material are copied into the
+   `mcp_email_server` package under explicit Hatch sdist and wheel inclusion
+   rules.
+4. Python reads packaged assets through `importlib.resources`.
+5. Both published artifacts are self-contained: a wheel rebuilt from the sdist
+   in an environment without Node.js must contain the same assets and run
+   normally under `uvx`.
+
+Python's standard
+[`importlib.resources`](https://docs.python.org/3/library/importlib.resources.html)
+API supports text and binary resources stored inside packages, including
+non-filesystem package loaders.
+
+### One workspace, two entry points
+
+The target should not use one bundle that guesses whether a parent MCP host
+exists. That makes bootstrap, authorization, CSP, error handling, and secret
+code harder to audit.
+
+Use one frontend workspace that can grow explicit entry points. The following
+is the eventual layout after an MCP App use case and SDK adoption are accepted:
+
+```text
+frontend/
+  src/
+    shared/
+      components/
+      forms/
+      view-models/
+      validation/
+      design-tokens/
+    adapters/
+      loopback-web/
+      mcp-app/
+    webui.tsx
+    mcp-app.tsx
+  webui.html
+  mcp-app.html
+  vite.config.ts
+  package.json
+  package-lock.json
+```
+
+Eventual build outputs:
+
+```text
+mcp_email_server/
+  static/
+    webui/
+      index.html
+      assets/...
+    mcp-app/
+      mcp-app.html
+```
+
+The first implementation should create and package only `webui`. Add the MCP
+entry point, browser SDK dependency, single-file bundle, and wheel assertion
+when the read-only MCP App prototype starts and its actual shared DTOs and
+components are known. At that point the MCP App should normally be a
+self-contained single HTML resource. The local Web UI may use a conventional
+hashed static asset directory because it is served same-origin by its own
+loopback process.
+
+### Safe reuse boundary
+
+Share:
+
+- presentational React components;
+- non-secret account summary and health view models;
+- form layout and non-secret validation;
+- loading, error, and operation-state components;
+- accessibility primitives;
+- design tokens and a theme abstraction;
+- generated TypeScript DTO types for public interface payloads.
+
+Do not share as one implementation:
+
+- MCP `postMessage` bridge and loopback HTTP client;
+- MCP capability negotiation and local Web UI session bootstrap;
+- host display modes and browser routing;
+- app-tool visibility and management authorization;
+- secret input and SecretStore mutation;
+- MCP resource CSP and Web UI HTTP response headers;
+- host-mediated tool approvals and local management confirmations;
+- transport-specific error mapping and retry behavior.
+
+This is an adapter split, not duplicated business logic. Both Python interfaces
+call the same application services.
+
+## Product Surface Ownership
+
+| User job                         | CLI                   | Local Web UI                        | MCP App                                             |
+| -------------------------------- | --------------------- | ----------------------------------- | --------------------------------------------------- |
+| Initialize managed mode          | Primary fallback      | Primary graphical flow              | Not allowed                                         |
+| Add/edit/remove account          | Supported             | Primary graphical flow              | Not allowed                                         |
+| Enter/rotate/delete secret       | Masked prompt         | Primary graphical flow              | Not allowed                                         |
+| Import or repair legacy config   | Supported             | Guided flow                         | Status and remediation only                         |
+| Configure allowlists and roots   | Supported             | Primary graphical flow              | Read-only summary at most                           |
+| Test connectivity                | Supported             | Primary graphical flow              | Safe status only                                    |
+| Manage index/cache               | Supported             | Primary graphical flow              | Bounded status or refresh action later              |
+| Discover account capability      | Supported             | Supported                           | Supported                                           |
+| Explore message metadata         | Optional diagnostics  | Optional                            | Strong Apps use case                                |
+| Select messages for review       | Not optimized         | Possible                            | Strong Apps use case                                |
+| Read message text                | Supported diagnostics | Possible, escaped                   | Optional, bounded plain text only initially         |
+| Send/move/delete mail            | Supported             | Possible with explicit confirmation | Later, only through normal policy and host approval |
+| Recovery when browser/host fails | Primary               | Unavailable                         | Unavailable                                         |
+
+The first MCP App should be read-oriented: account health and bounded metadata
+exploration. Sending, moving, deleting, attachment materialization, and rendered
+email HTML should not be the initial Apps scope.
+
+## Recommended Runtime Architecture
+
+```mermaid
+flowchart LR
+    USER[Local user]
+    BROWSER[Default browser]
+    HOST[MCP host]
+    CLI[CLI adapter]
+    WEB[Loopback Web UI adapter]
+    MCP[MCP stdio adapter]
+    APPUI[MCP App iframe]
+    SERVICES[Application services]
+    DB[(SQLite)]
+    SECRETS[SecretStore]
+    MAIL[IMAP and SMTP]
+
+    USER --> CLI
+    USER --> BROWSER
+    USER --> HOST
+    BROWSER -->|ephemeral authenticated loopback session| WEB
+    HOST -->|stdio| MCP
+    HOST -->|sandbox and postMessage| APPUI
+    APPUI -->|host-mediated non-secret tools/call| HOST
+    CLI --> SERVICES
+    WEB --> SERVICES
+    MCP --> SERVICES
+    SERVICES --> DB
+    SERVICES --> SECRETS
+    SERVICES --> MAIL
+```
+
+There is deliberately no edge from the MCP App iframe to the local Web UI.
+Adding `http://127.0.0.1:*` to an MCP App's `connectDomains` would merge an
+untrusted host iframe into the management API's CORS, CSRF, and authorization
+boundary. The MCP App should use host-mediated non-secret tools only. If
+management is required, it displays the `webui` or CLI command.
+
+## Local Web UI Security Contract
+
+A loopback listener is local, but it is still reachable by the user's browser
+while the browser visits attacker-controlled sites. The MCP specification's
+[Streamable HTTP security warning](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning)
+normatively requires Origin validation for that MCP transport and recommends
+loopback-only binding and authentication. The Web UI is not an MCP transport,
+so those statements are not directly normative for it. The DNS-rebinding and
+cross-origin attack class still applies, and the controls below are this
+product's threat analysis and deliberately strong local-management policy.
+
+### Required launch behavior
+
+- Bind exactly to `127.0.0.1` by default, not `0.0.0.0` and not an inferred
+  network interface.
+- Let the OS choose an ephemeral port by default.
+- Generate a cryptographically random, one-time bootstrap capability plus
+  process-local browser session and CSRF material.
+- Open the browser only after the socket is listening.
+- Put the one-time bootstrap capability in the URL fragment, not the path or
+  query: `http://127.0.0.1:<port>/#bootstrap=<one-time-token>`.
+- Have the SPA submit it once in an authorization header to a same-origin
+  bootstrap endpoint, clear the fragment with `history.replaceState`, and never
+  render management data before the exchange succeeds.
+- Invalidate the bootstrap capability atomically and establish a process-scoped,
+  `HttpOnly`, `SameSite=Strict` browser session with a process-unique cookie name
+  and narrow server-generated path. Move the browser to that path and return
+  separate CSRF material through the authenticated response.
+- On reload, let the session cookie authenticate a safe session-bootstrap GET
+  that returns fresh CSRF material. The session ends on explicit logout or when
+  the foreground process exits; it has no independent persisted TTL.
+- Stop on Ctrl-C and close runtime resources. Do not detach, register a service,
+  or become an implicit daemon.
+- Never provide a share link or non-loopback bind option in the supported
+  product command.
+
+### Required request checks
+
+- Validate `Host` against the exact loopback origin and active port.
+- Validate the bootstrap request's `Origin` and require an exact same-origin
+  `Origin` plus CSRF header for every state-changing request.
+- Do not enable CORS. Reject wildcard, `null`, missing, or unexpected origins
+  where an Origin is required.
+- Permit only safe, non-mutating GET routes without an Origin; they still require
+  a valid `SameSite=Strict` process session. Every mutation requires JSON so a
+  cross-site HTML form cannot be interpreted as an API call.
+- Make the fragment capability single-use and reject replay. Keep browser
+  sessions and CSRF material process-local; never persist them in SQLite.
+- Rate-limit authentication failures and make secret comparisons timing-safe.
+- Return bounded typed errors without stack traces, secret values, SQL, or raw
+  provider failures.
+
+### Management revision contract
+
+A long-lived browser tab is a concurrent management adapter, not an exclusive
+editor. Every mutable Web request must carry the account, catalog, policy,
+credential-binding, or other expected revision represented by the form it
+rendered. The application service performs the same compare-and-swap contract
+for CLI and Web UI writes.
+
+A stale request returns a typed conflict with a bounded current summary. The Web
+adapter must not silently merge or automatically replay a whole-form account,
+policy, import, or credential change. The user reviews the new state and submits
+a new explicit command. MCP operations and background refreshes continue to use
+their existing generation and effect-boundary rules.
+
+### Required browser policy
+
+At minimum, send:
+
+```text
+Cache-Control: no-store
+Content-Security-Policy: default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self'; script-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'
+Referrer-Policy: no-referrer
+X-Content-Type-Options: nosniff
+```
+
+Do not use CDN scripts, remote fonts, third-party analytics, service workers, or
+`dangerouslySetInnerHTML`. Account names, mailbox names, subjects, provider
+errors, and email-derived values are untrusted text and must remain escaped.
+
+### Secret form behavior
+
+- Send secret values only in authenticated JSON request bodies.
+- Do not echo them in responses, validation errors, telemetry, or browser state.
+- Keep them out of URLs, local storage, session storage, IndexedDB, and service
+  workers.
+- Clear component state after success or cancellation.
+- Resolve and store them only through `AccountManagementService` and
+  `SecretStore` saga contracts.
+- Keep the CLI masked prompt as a lower-exposure alternative for users who do
+  not want to enter secrets in a browser.
+
+### Local adversary assumptions
+
+The Python package, built frontend assets, current operating-system account, and
+selected browser profile are trusted. A malicious process already running as
+that same user, a malicious browser extension in that profile, or an observer
+that can read terminal recordings or browser-launch process arguments is out of
+scope; such an actor can usually inspect process state, configuration, or
+keyring access by other means. The launch capability is nevertheless one-time so
+exposure through the launch channel does not reveal the process-long session.
+
+Remote web origins, MCP views and content, email-derived data, and local users or
+processes that have not obtained the one-time capability are untrusted.
+Loopback TCP is machine-local rather than user-isolated, so the capability is
+still required on a multi-user machine; this design does not claim strong
+isolation from a privileged local adversary. Users with an untrusted same-user
+environment should use the masked CLI flow or stronger operating-system
+isolation.
+
+HTTPS with a self-signed local certificate would add substantial trust and
+installation friction without changing that same-user trust assumption. An
+optional future platform integration may revisit local TLS, but it is not
+required for the first local product.
+
+### OAuth
+
+If managed accounts later support OAuth, launch authorization in the system
+browser and use a narrowly scoped loopback callback with single-use `state`,
+PKCE, an ephemeral port, and a bounded callback lifetime. RFC 8252 recommends
+external user agents and documents loopback redirects for native apps. See
+[OAuth 2.0 for Native Apps](https://www.rfc-editor.org/rfc/rfc8252).
+
+The callback handler must suppress or redact access logging of the request query
+because it contains the authorization code and state. Provider and token-exchange
+failures must also be redacted. OAuth refresh tokens terminate in `SecretStore`;
+they do not return to React or an MCP App after the callback completes.
+
+## Command Experience
+
+Recommended canonical command:
+
+```bash
+uvx mcp-email-server@latest webui
+```
+
+Recommended options:
+
+```text
+--no-open       Start without opening a browser.
+--port INTEGER  Bind a chosen loopback port; default 0 means ephemeral.
+```
+
+Do not expose `--host`, `--share`, or remote authentication options. Those
+options would turn a local adapter into a network product and contradict the
+current product direction.
+
+Expected terminal flow:
+
+```text
+Starting the local Email App management UI...
+Listening on http://127.0.0.1:54321/
+The browser session is temporary. Press Ctrl-C to stop.
+```
+
+The browser receives a one-time bootstrap capability through the automatically
+opened fragment URL; automatic mode prints only the sanitized base URL. If
+`--no-open` is used, the terminal may print the full one-time URL with a warning
+that whoever uses it first can establish the browser session. A normal reload
+continues through the process-scoped session cookie. If that cookie is cleared,
+the user restarts the foreground command to obtain a new bootstrap capability.
+
+Keep `mcp-email-server ui` as a compatibility alias during migration. Once the
+new adapter reaches feature parity, `ui` can delegate to `webui`; removal or
+semantic redirection must follow the project's versioned compatibility and
+published-documentation rules.
+
+## Route Comparison
+
+| Route                              | Coverage                                     | Secret suitability               | UX                                   | Implementation fit                     | Recommendation             |
+| ---------------------------------- | -------------------------------------------- | -------------------------------- | ------------------------------------ | -------------------------------------- | -------------------------- |
+| CLI only                           | Universal local                              | Strong                           | Weak for discovery and complex forms | Already aligned                        | Keep as mandatory fallback |
+| Expand current Gradio              | Browser universal                            | Acceptable if hardened           | Moderate                             | Poor reuse and current direct coupling | Compatibility only         |
+| Embedded React local Web UI        | Browser universal                            | Strong within local threat model | Strong                               | Clean peer adapter over services       | Primary graphical surface  |
+| MCP Apps only                      | Host-dependent                               | Unsuitable for raw secrets       | Excellent when rendered              | SDK and host gaps                      | Reject as management plane |
+| React Web UI plus optional MCP App | Universal management plus rich capable hosts | Correctly separated              | Strongest overall                    | Two thin adapters, shared components   | Recommended target         |
+
+The hybrid route has more frontend integration work than one UI, but it avoids
+building two unrelated frontends. The additional code is concentrated in two
+small transport/trust adapters, which is appropriate because the boundaries are
+materially different.
+
+## Implementation Direction
+
+This is not an implementation plan or an accepted spec change. If the direction
+is accepted, a low-risk sequence is:
+
+1. Complete the application service and composition-root boundaries already
+   proposed. Do not let a new UI grow against global `Settings`.
+2. Create a minimal React workspace with only the Web UI entry point and a locked
+   dependency graph.
+3. Implement the loopback Web UI adapter and security contract.
+4. Package the built Web UI in both sdist and wheel, then add from-sdist,
+   isolated-wheel, and `uvx` smoke tests that run without Node.js.
+5. Redirect the legacy `ui` command only after account-management parity and
+   migration documentation exist.
+6. After the Python SDK Apps API is stable and a read-only workflow is accepted,
+   add the MCP App entry point, browser SDK dependency, single-file bundle, and
+   host-specific validation for current VS Code, Cursor, and Claude Desktop.
+7. Keep complete text fallback behavior and never make the MCP App a setup
+   prerequisite.
+
+### Suggested Python ownership
+
+```text
+mcp_email_server/
+  interfaces/
+    cli.py
+    mcp.py
+    webui/
+      app.py
+      auth.py
+      routes.py
+      schemas.py
+  static/
+    webui/
+    mcp-app/  # added only when the optional MCP App ships
+```
+
+The Web UI adapter may use a small ASGI stack such as Starlette and Uvicorn.
+Any directly imported runtime package should be declared directly even if it is
+already transitive through `mcp`. The adapter should not expose OpenAPI,
+framework debug endpoints, filesystem browsing, or a generic RPC method unless
+the product needs them.
+
+### Build and release requirements
+
+- Pin the Node package manager and commit its lockfile.
+- Build currently shipped production assets before creating release artifacts.
+- Declare generated assets and required third-party license material explicitly
+  in Hatch sdist and wheel inclusion rules; fail release creation if a required
+  artifact is missing.
+- Inspect both sdist and wheel contents. The sdist must carry the prebuilt assets
+  so its PEP 517 build does not require Node.js.
+- In an environment without Node.js, build a wheel from the sdist, inspect it,
+  install it in isolation, and start `webui`.
+- Assert only the frontend outputs shipped by that release. Add the MCP App HTML
+  assertion and verify its single-resource/CSP contract when the optional App
+  adapter is introduced.
+- Treat frontend dependency changes like Python dependency changes: review,
+  lock, scan, update, and preserve notices together.
+
+## Testing Requirements
+
+### Web UI backend
+
+- exact loopback bind and no wildcard bind;
+- ephemeral and fixed loopback ports;
+- Host and Origin rejection, including DNS rebinding cases;
+- missing, invalid, valid, and replayed one-time bootstrap capabilities;
+- session establishment, normal reload, logout, and process termination;
+- CSRF rejection and no CORS or public/share mode;
+- security response headers;
+- bounded error redaction;
+- stale account form, concurrent policy edit, and concurrent credential-change
+  revision conflicts with no automatic replay;
+- clean shutdown and concurrent SQLite access;
+- application-service calls rather than direct config/database access;
+- if OAuth enters scope, single-use state and absence of callback query values
+  from access logs, diagnostics, and provider-error output.
+
+### React Web UI
+
+- account create, edit, disable, remove, connectivity test, and secret rotation
+  against fake application ports;
+- secret values absent from URLs, storage, logs, and rendered success state;
+- untrusted strings rendered as text;
+- keyboard and screen-reader behavior;
+- management confirmation, typed revision-conflict review, and error-recovery
+  states;
+- frontend route/client tests without live email services.
+
+### Packaging
+
+- frontend build reproducibility;
+- explicit sdist and wheel content assertions, including license material;
+- wheel construction from the sdist in an environment without Node.js;
+- isolated installation of that rebuilt wheel;
+- `uvx` or equivalent tool-run smoke test with `--no-open`;
+- browser bootstrap, reload, and authenticated health request;
+- no Node executable required by either published artifact at consumer build or
+  runtime.
+
+### MCP App
+
+- extension negotiation and MIME type;
+- tool-to-resource linkage;
+- meaningful complete text with Apps disabled;
+- bundled resource loading through stdio;
+- no external CSP domains by default;
+- app-only tool filtering and server-side policy;
+- no credential fields or secret references in schemas, tool input, results, or
+  app state;
+- bounded structured results;
+- manual compatibility evidence for each claimed host release.
+
+MCP Inspector proves protocol shape, not host rendering compatibility. Product
+claims still require host-specific evidence.
+
+## Proposed Specification Changes
+
+No spec files are changed by this research report. If the recommendation is
+accepted, update the owning specifications before implementation.
+
+### `spec/README.md`
+
+- Add the explicitly started loopback Web UI as a peer management adapter.
+- Keep stdio as the only MCP transport.
+- Replace “web application or MCP App user interface” as a blanket non-goal with
+  narrower non-goals: remote Web UI, hosted UI, and a UI daemon.
+- State the surface split: CLI and Web UI own management; MCP Apps is an optional
+  agent-facing enhancement. Summarize the secret boundary and cross-reference
+  `07` as its normative UI-surface owner.
+- Add a new owning UI/security spec to the map.
+- Update the architecture diagram with Browser, Web UI adapter, and optional MCP
+  App view.
+
+### `spec/01-system-context.md`
+
+- Add Browser and MCP App view actors.
+- Add an explicit Web UI process model: user-started, loopback-only, temporary,
+  no daemon.
+- Extend trust boundaries for hostile web origins, DNS rebinding, CSRF, iframe
+  content, and browser-delivered untrusted email data.
+- Keep the local operating-system user as the only product principal.
+- Change secret-bearing management from “CLI only” to “CLI or authenticated
+  local Web UI”; continue excluding MCP.
+
+### `spec/02-application-boundaries.md`
+
+- Add `WebManagementAdapter` as a peer of CLI and MCP.
+- Add the MCP App resource/metadata mapping as part of the MCP adapter, not a new
+  application service.
+- Add web route schemas and React assets to interface ownership.
+- Keep browser bootstrap, session, and CSRF state process-local to the adapter;
+  do not add it to domain models or SQLite repositories.
+- Preserve the rule that interfaces do not depend on one another. The MCP App
+  must not call the Web UI adapter.
+- Update the target package ownership and interface tests.
+
+### `spec/03-configuration-and-credentials.md`
+
+- Own the definition and lifecycle of secret material, including passwords,
+  tokens, `SecretRef`s, candidate bindings, and the persisted secret-change
+  saga.
+- Define CLI and local Web UI as management adapters that invoke that saga;
+  cross-reference the UI authorization and forbidden-path contract in `07`.
+- Generalize “Account Revisions and Concurrent CLI Writes” to all management
+  adapters. Every mutable request carries its inspected revision; stale Web
+  forms return a typed current summary and are never replayed automatically.
+- Own SecretStore behavior for OAuth results if OAuth enters scope, while
+  cross-referencing `07` for browser callback security and logging.
+- Extend import, repair, and rotation sequences to say “management adapter”
+  where they currently say only CLI, while retaining masked CLI recovery.
+
+### `spec/04-mail-workflows-and-consistency.md`
+
+- State that UI actions map to the same commands and preserve the same provider
+  effect fencing and reconciliation semantics.
+- Do not create UI-specific send, move, or delete consistency rules.
+- Require explicit confirmation rendering for compound or ambiguous outcomes.
+
+### `spec/05-sqlite-persistence-and-data-model.md`
+
+- State that Web UI bootstrap capabilities, browser sessions, CSRF material, and
+  view state are process-local and never persisted.
+- No application schema change should be needed solely to add a UI adapter.
+
+### `spec/06-mcp-interface-and-client-compatibility.md`
+
+- Add MCP Apps as a negotiated optional extension.
+- Add the Apps-specific host matrix while retaining the existing core MCP
+  matrix.
+- Define meaningful text fallback as required by Apps and retain the product's
+  stricter bounded, complete text contract.
+- Define the initial read-only Apps scope. Cross-reference `03` for secret
+  classification and `07` for the prohibition on secret-bearing UI paths rather
+  than restating either contract.
+- Own `ui://`, `text/html;profile=mcp-app`, resource CSP, tool visibility,
+  negotiation, and host-mediated calls.
+- Record Python SDK maturity and the condition for adopting the official Apps
+  API.
+- Update the “Existing Non-stdio Entry Points” section to distinguish the new
+  local management Web UI from MCP network transports.
+
+### New `spec/07-local-ui-surfaces-and-security.md`
+
+This should own contracts that would otherwise be scattered:
+
+- user jobs and surface ownership;
+- explicit Web UI lifecycle, one-time bootstrap exchange, process session,
+  reload, logout, and shutdown;
+- loopback bind, Host/Origin/CSRF checks, browser headers, and local-adversary
+  assumptions;
+- embedded frontend and sdist/wheel packaging;
+- staged React entry points and their reuse boundary;
+- UI surface authorization and threat model, including the single owning
+  prohibition on secret-bearing MCP App paths;
+- OAuth browser callback constraints if OAuth enters scope;
+- UI, concurrency, and packaging validation.
+
+It should be an architecture contract, not a screen-by-screen design or release
+plan.
+
+## Open Decisions Before Spec Acceptance
+
+1. Whether `webui` becomes canonical immediately or after the first React parity
+   release. The recommendation is canonical `webui` with `ui` retained as an
+   alias.
+2. The exact ASGI implementation. The recommendation is a small explicit
+   Starlette/Uvicorn adapter, not a generic network API framework.
+3. Whether the first Web UI release includes only account and credential
+   management or also index/cache diagnostics. Account parity and secure secret
+   handling are the minimum useful release.
+4. The first MCP App workflow. The recommendation is bounded account health and
+   metadata exploration, not compose/send or raw HTML mail rendering.
+5. The Python SDK adoption threshold. The recommendation is stable v2 plus host
+   conformance tests, rather than beta adoption.
+
+## Limitations
+
+- This is a source and architecture review, not a working React/Web UI prototype
+  or a usability study with email users.
+- Host compatibility is based on public product documentation, release evidence,
+  and clearly labeled implementation issues. It was not re-tested in every
+  current proprietary host build, and host regressions can change the matrix.
+- The proposed loopback controls have not yet received implementation-level
+  penetration testing. The final adapter needs security tests against its exact
+  HTTP framework and browser bootstrap code.
+- Python SDK 2 is still pre-release as of the research date. Its API and FastMCP
+  integration may change before the project adopts it.
+- The local threat model assumes the operating-system user, selected browser,
+  Python package, and built frontend assets are trusted. It does not attempt to
+  isolate the app from a malicious process already running as that same user.
+
+## Final Recommendation
+
+Adopt the following product decision:
+
+> The Local Email App provides a CLI and an explicitly started, loopback-only
+> embedded React Web UI as trusted local management adapters over shared
+> application services. It may additionally expose negotiated MCP Apps for
+> non-secret agent-facing workflows over the existing stdio MCP connection.
+> MCP Apps never own account credentials or replace complete text tool results.
+
+This gives users a first-class graphical product through the command they
+already know how to run with `uvx`, while using MCP Apps where they are strongest:
+in-context interaction inside capable hosts. It also avoids turning optional
+host support into a setup dependency or weakening the credential boundary.
+
+## Sources
+
+1. [MCP Apps overview](https://modelcontextprotocol.io/extensions/apps/overview) — protocol pattern, security model, frameworks, and supported clients.
+2. [SEP-1865](https://modelcontextprotocol.io/seps/1865-mcp-apps-interactive-user-interfaces-for-mcp) — Final extension status, rationale, and security implications.
+3. [MCP Apps specification at the reviewed commit](https://github.com/modelcontextprotocol/ext-apps/blob/2ca6a59d2f493b227a83a2e3ce0396db4705621a/specification/2026-01-26/apps.mdx) — normative resource, bridge, lifecycle, visibility, CSP, negotiation, and threat-model details.
+4. [MCP Apps build guide](https://modelcontextprotocol.io/extensions/apps/build) — Vite single-file build and server/resource pattern.
+5. [Official MCP Apps React example](https://github.com/modelcontextprotocol/ext-apps/tree/2ca6a59d2f493b227a83a2e3ce0396db4705621a/examples/basic-server-react) — React entry point, stdio server, and single-file bundle.
+6. [MCP Python SDK v2 Apps guide](https://py.sdk.modelcontextprotocol.io/v2/advanced/apps/) — Python APIs, graceful degradation, visibility, CSP, and packaged file resources.
+7. [VS Code MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp) — current supported MCP features including Apps.
+8. [VS Code MCP Apps announcement](https://code.visualstudio.com/blogs/2026/01/26/mcp-apps-support) — release evidence and product behavior.
+9. [Cursor MCP documentation](https://cursor.com/docs/mcp#protocol-and-extension-support) — current Apps and stdio support.
+10. [Cursor 2.6 changelog](https://cursor.com/changelog/2-6) — shipped Apps release evidence.
+11. [Claude interactive connectors announcement](https://claude.com/blog/interactive-tools-in-claude) — Claude surface support.
+12. [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp) — documented Claude Code MCP surface and current evidence boundary.
+13. [Codex MCP documentation](https://learn.chatgpt.com/docs/extend/mcp) — documented Codex MCP transports and features.
+14. [Open Codex Apps rendering issue #21019](https://github.com/openai/codex/issues/21019) — under-development and regression evidence; not a stable support claim.
+15. [MCP Apps compatibility in ChatGPT](https://developers.openai.com/apps-sdk/mcp-apps-in-chatgpt) — standard bridge compatibility and optional vendor extensions.
+16. [uv tools documentation](https://docs.astral.sh/uv/concepts/tools/) — `uvx` execution, caching, versions, and persistent tool installation.
+17. [Python `importlib.resources`](https://docs.python.org/3/library/importlib.resources.html) — reading packaged static resources.
+18. [MCP transport security](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning) — loopback binding, Origin validation, authentication, and DNS rebinding.
+19. [RFC 8252](https://www.rfc-editor.org/rfc/rfc8252) — external browser and loopback redirect best practices for native-app OAuth.
+20. [Gradio `Blocks.launch`](https://www.gradio.app/docs/gradio/blocks#launch) — current launch, bind, share, and strict-CORS behavior.

--- a/research/ui-delivery-strategy.md
+++ b/research/ui-delivery-strategy.md
@@ -14,7 +14,7 @@ The recommended product shape is:
 
 1. **An embedded React local Web UI is the primary graphical management
    surface.** It is started explicitly with
-   `uvx mcp-email-server@latest webui`, binds only to a loopback address, uses an
+   `uvx mcp-email-server@latest ui`, binds only to a loopback address, uses an
    ephemeral port, one-time browser bootstrap, and process session, and exits
    with its CLI process. It
    manages accounts, credentials, policy, migration, diagnostics, index state,
@@ -26,10 +26,12 @@ The recommended product shape is:
    plane.** It can improve mailbox exploration, review, selection, and other
    non-secret interactions inside capable hosts. Core tools must retain complete
    bounded text results for every other host.
-4. **The current Gradio UI remains a compatibility bridge, not the target UI
-   architecture.** A React/Vite frontend can be built during release, packaged
-   into the Python wheel, and run by `uvx` without requiring Node.js on the
-   user's machine.
+4. **The current Gradio implementation remains a compatibility bridge, not the
+   target UI architecture.** The existing `ui` command remains the sole public
+   graphical entry point and switches to the React implementation only after the
+   replacement reaches its release gate. No separate `webui` command is added.
+   The React/Vite frontend is built during release, packaged into the Python
+   wheel, and runs through `uvx` without requiring Node.js on the user's machine.
 
 One frontend workspace can serve both graphical surfaces, but it should produce
 **two entry points and two bundles**. Shared React components, view models,
@@ -128,7 +130,7 @@ important. These behaviors are documented in the official
 This gives the desired product experience without a permanent installation:
 
 ```bash
-uvx mcp-email-server@latest webui
+uvx mcp-email-server@latest ui
 ```
 
 It also preserves an existing caveat: disposable or refreshed executable paths
@@ -398,9 +400,9 @@ frontend/
     adapters/
       loopback-web/
       mcp-app/
-    webui.tsx
+    ui.tsx
     mcp-app.tsx
-  webui.html
+  ui.html
   mcp-app.html
   vite.config.ts
   package.json
@@ -412,15 +414,16 @@ Eventual build outputs:
 ```text
 mcp_email_server/
   static/
-    webui/
+    ui/
       index.html
       assets/...
     mcp-app/
       mcp-app.html
 ```
 
-The first implementation should create and package only `webui`. Add the MCP
-entry point, browser SDK dependency, single-file bundle, and wheel assertion
+The first implementation should create and package only the local `ui` frontend
+entry point. Add the MCP entry point, browser SDK dependency, single-file bundle,
+and wheel assertion
 when the read-only MCP App prototype starts and its actual shared DTOs and
 components are known. At that point the MCP App should normally be a
 self-contained single HTML resource. The local Web UI may use a conventional
@@ -510,7 +513,7 @@ There is deliberately no edge from the MCP App iframe to the local Web UI.
 Adding `http://127.0.0.1:*` to an MCP App's `connectDomains` would merge an
 untrusted host iframe into the management API's CORS, CSRF, and authorization
 boundary. The MCP App should use host-mediated non-secret tools only. If
-management is required, it displays the `webui` or CLI command.
+management is required, it displays the `ui` or CLI command.
 
 ## Local Web UI Security Contract
 
@@ -646,7 +649,7 @@ they do not return to React or an MCP App after the callback completes.
 Recommended canonical command:
 
 ```bash
-uvx mcp-email-server@latest webui
+uvx mcp-email-server@latest ui
 ```
 
 Recommended options:
@@ -675,10 +678,12 @@ that whoever uses it first can establish the browser session. A normal reload
 continues through the process-scoped session cookie. If that cookie is cleared,
 the user restarts the foreground command to obtain a new bootstrap capability.
 
-Keep `mcp-email-server ui` as a compatibility alias during migration. Once the
-new adapter reaches feature parity, `ui` can delegate to `webui`; removal or
-semantic redirection must follow the project's versioned compatibility and
-published-documentation rules.
+`mcp-email-server ui` remains the sole canonical graphical command throughout
+the migration. Before the replacement release it starts Gradio; once the React
+adapter reaches the accepted parity, security, packaging, and documentation
+gates, the same command starts React instead. The project does not add a
+`webui` command. This semantic replacement still follows the project's versioned
+compatibility and published-documentation rules.
 
 ## Route Comparison
 
@@ -707,8 +712,8 @@ is accepted, a low-risk sequence is:
 3. Implement the loopback Web UI adapter and security contract.
 4. Package the built Web UI in both sdist and wheel, then add from-sdist,
    isolated-wheel, and `uvx` smoke tests that run without Node.js.
-5. Redirect the legacy `ui` command only after account-management parity and
-   migration documentation exist.
+5. Switch the implementation behind the existing `ui` command only after
+   account-management parity and migration documentation exist.
 6. After the Python SDK Apps API is stable and a read-only workflow is accepted,
    add the MCP App entry point, browser SDK dependency, single-file bundle, and
    host-specific validation for current VS Code, Cursor, and Claude Desktop.
@@ -722,13 +727,13 @@ mcp_email_server/
   interfaces/
     cli.py
     mcp.py
-    webui/
+    ui/
       app.py
       auth.py
       routes.py
       schemas.py
   static/
-    webui/
+    ui/
     mcp-app/  # added only when the optional MCP App ships
 ```
 
@@ -748,7 +753,7 @@ the product needs them.
 - Inspect both sdist and wheel contents. The sdist must carry the prebuilt assets
   so its PEP 517 build does not require Node.js.
 - In an environment without Node.js, build a wheel from the sdist, inspect it,
-  install it in isolation, and start `webui`.
+  install it in isolation, and start `ui`.
 - Assert only the frontend outputs shipped by that release. Add the MCP App HTML
   assertion and verify its single-resource/CSP contract when the optional App
   adapter is introduced.
@@ -917,19 +922,24 @@ This should own contracts that would otherwise be scattered:
 It should be an architecture contract, not a screen-by-screen design or release
 plan.
 
+## Product Decision: Canonical UI Command
+
+The existing `ui` command remains the sole public graphical management command.
+The React implementation replaces Gradio behind that command after the accepted
+release gates; the product does not add a `webui` command. If the UI direction is
+accepted, the owning specifications must record this command contract before the
+replacement ships.
+
 ## Open Decisions Before Spec Acceptance
 
-1. Whether `webui` becomes canonical immediately or after the first React parity
-   release. The recommendation is canonical `webui` with `ui` retained as an
-   alias.
-2. The exact ASGI implementation. The recommendation is a small explicit
+1. The exact ASGI implementation. The recommendation is a small explicit
    Starlette/Uvicorn adapter, not a generic network API framework.
-3. Whether the first Web UI release includes only account and credential
+2. Whether the first Web UI release includes only account and credential
    management or also index/cache diagnostics. Account parity and secure secret
    handling are the minimum useful release.
-4. The first MCP App workflow. The recommendation is bounded account health and
+3. The first MCP App workflow. The recommendation is bounded account health and
    metadata exploration, not compose/send or raw HTML mail rendering.
-5. The Python SDK adoption threshold. The recommendation is stable v2 plus host
+4. The Python SDK adoption threshold. The recommendation is stable v2 plus host
    conformance tests, rather than beta adoption.
 
 ## Limitations
@@ -957,6 +967,8 @@ Adopt the following product decision:
 > application services. It may additionally expose negotiated MCP Apps for
 > non-secret agent-facing workflows over the existing stdio MCP connection.
 > MCP Apps never own account credentials or replace complete text tool results.
+> The existing `ui` command is the sole graphical management entry point and the
+> React implementation replaces Gradio behind it.
 
 This gives users a first-class graphical product through the command they
 already know how to run with `uvx`, while using MCP Apps where they are strongest:

--- a/spec/01-system-context.md
+++ b/spec/01-system-context.md
@@ -184,7 +184,9 @@ SQLite is shared by local processes, not by tenants or remote users.
 - IMAP, SMTP, keyring, and large filesystem operations occur outside database
   transactions.
 - Synchronization writes use idempotent upserts and compare the cursor revision
-  before advancing it.
+  before advancing it. Placement-scoped effect boundaries advance the same
+  revision before provider access so an older refresh cannot resurrect
+  pre-effect state.
 - A stale or conflicting refresh may discard its cursor advancement and retry
   reconciliation; it does not hold a database lock during network access.
 - Provider-effect operations use fenced attempt records. The conditional effect
@@ -208,6 +210,10 @@ The app supports three explicit data states:
 
 A local result never silently claims complete mailbox coverage when only a
 partial index exists. Exact counts are returned only when they are known.
+Metadata coverage, recent addition synchronization, flag synchronization, and
+complete mailbox-membership reconciliation are reported independently: finding
+recent additions does not refresh flags or prove that every older indexed
+placement still exists.
 
 ## Trust Boundaries
 
@@ -238,6 +244,22 @@ showed an approval dialog. Detailed tool and file controls are defined in
   backend.
 - Mail reads do not mutate remote state unless the operation explicitly requests
   a mutation.
+- An indexed placement is last-observed state. Only explicit provider removal
+  evidence or a complete UID-set reconciliation under unchanged UIDVALIDITY may
+  remove it by absence; partial refresh performs upserts only.
+- A message-scoped operation never uses bare mailbox-wide EXPUNGE. Flag projection
+  uncertainty is tracked independently from mailbox membership so an unknown
+  STORE neither hides the message nor supports exact flag-derived results. A
+  confirmed flag projection always contains a complete provider-observed set, not
+  a locally inferred delta result.
+- An effect-boundary target fence survives rebuildable index compaction and full
+  index rebuild. A mailbox identity referenced by an unreleased fence is retained
+  or evidence-backed rebound without changing its local ID. Matching provider
+  rediscovery reconstructs operation-owned uncertainty, and a competing mutation
+  is rejected until reconciliation or explicit unknown acknowledgment.
+- External removals are eventually consistent because no daemon is present.
+  Confirmed-removed and stale placements are excluded from normal search, and
+  cached body content is purged by default when no active placement remains.
 - Every response reports whether it came from indexed, refreshed, or partial
   state when that distinction affects correctness.
 

--- a/spec/02-application-boundaries.md
+++ b/spec/02-application-boundaries.md
@@ -111,7 +111,8 @@ Used by MCP read tools and optional CLI diagnostics:
 - refresh a bounded metadata range when requested;
 - read bounded message body sections;
 - list attachment metadata;
-- report freshness and index coverage.
+- report metadata coverage, addition freshness, flag freshness, and
+  complete-membership freshness independently.
 
 #### `MailCommandService`
 
@@ -120,6 +121,10 @@ Owns externally visible mutations:
 - send a message;
 - save a draft or message to a mailbox;
 - mark, move, archive, and delete messages;
+- revalidate placement identity and mailbox revision at each remote-effect
+  boundary;
+- require a target-scoped delete primitive or return a non-expunged partial or
+  policy rejection; never escalate a scoped command to bare mailbox-wide EXPUNGE;
 - reconcile confirmed remote outcomes into SQLite;
 - distinguish complete, partial, uncertain, and failed outcomes.
 
@@ -127,12 +132,17 @@ Owns externally visible mutations:
 
 Owns explicit and on-demand metadata maintenance:
 
-- discover mailbox changes;
+- discover additions, flag changes, and membership changes with independent
+  freshness evidence;
 - upsert metadata and placements;
-- advance cursors transactionally;
+- apply QRESYNC/VANISHED evidence or complete UID-set membership reconciliation;
+- ensure partial observations never infer removal by absence;
+- advance metadata and membership cursor evidence transactionally;
 - invalidate a mailbox on UIDVALIDITY change;
+- fence older refreshes when a placement-scoped operation crosses its effect
+  boundary;
 - rebuild FTS projections;
-- purge expired body cache and stale metadata.
+- purge expired body cache, orphaned message data, and stale metadata.
 
 #### `ArtifactService`
 
@@ -183,11 +193,14 @@ Ports are narrow and use application or domain types.
   settings, revisions, and tombstones.
 - `CredentialChangeRepository`: active, candidate, and pending-cleanup bindings
   plus persisted secret-change saga states.
-- `MailIndexRepository`: mailboxes, messages, placements, addresses, body cache,
-  attachments, search projections, and sync cursors.
-- `OperationRepository`: durable per-recipient and compound-step evidence plus
-  fenced pre-effect and remote-effect-possible attempt transitions for send and
-  other mutations.
+- `MailIndexRepository`: stable mailbox identity shells required by operation
+  fences plus rebuildable mailbox metadata, messages, placements, addresses, body
+  cache, attachments, search projections, and sync cursors.
+- `OperationRepository`: durable per-recipient, target, and compound-step
+  evidence; target fences that remain enforceable across mail-index compaction;
+  fenced pre-effect and remote-effect-possible transitions; explicit unknown
+  acknowledgment; and base-mode-independent evidence-capacity accounting for send
+  and other mutations.
 - `UnitOfWork`: one short SQLite transaction across repositories when an
   application invariant requires atomic local state.
 

--- a/spec/03-configuration-and-credentials.md
+++ b/spec/03-configuration-and-credentials.md
@@ -29,7 +29,19 @@ only values needed to locate and safely initialize the local runtime:
 - selected base mode, when explicitly configured;
 - migration and lock timeouts;
 - process-level logging settings;
+- base-mode-independent hard ceilings for operation-evidence bytes and unresolved
+  operation count;
 - emergency read-only or maintenance flags.
+
+The operation-evidence ceilings have documented built-in defaults and are
+available before opening SQLite or selecting managed, legacy, or environment-only
+configuration. An implementation-level maximum bounds those defaults and any
+local bootstrap override. Managed policy, legacy TOML policy, and process
+environment values may only tighten the effective ceiling; they cannot raise it.
+A source requesting a higher value is invalid and is reported with attribution
+rather than silently widening or clipping policy. The claim transaction uses the
+minimum applicable valid limit and therefore has a non-optional admission bound
+in every base mode.
 
 The existing `db_location` value and default location remain compatible inputs.
 An environment or CLI override may select a different database path. Database
@@ -61,6 +73,7 @@ flowchart LR
     ENV --> SOURCE
     SOURCE -->|managed ID or source key and fingerprint| IDENTITY
     SOURCE -->|config and policy provenance| SNAPSHOT
+    BOOT -->|hard capacity ceilings| SNAPSHOT
     IDENTITY -->|stable account_id| SNAPSHOT
     SNAPSHOT --> SECRETS
     SECRETS --> RUNTIME
@@ -85,7 +98,9 @@ explicit schema ownership as defined in
 Legacy mode preserves current file location, path migration, model validation,
 credential mode, and serialization behavior behind a compatibility adapter. The
 adapter distinguishes stored state from the environment-composited effective
-view even when a facade must preserve current whole-view writes.
+view even when a facade must preserve current whole-view writes. A supported
+legacy operation-evidence policy may set lower byte or unresolved-count limits;
+absence inherits the bootstrap ceiling rather than making capacity unlimited.
 
 ### Environment overlay
 
@@ -101,6 +116,11 @@ Environment-derived accounts and overrides are:
 - never imported or persisted by an unrelated account update;
 - eligible for mail operations after normal validation;
 - clearly marked as `environment` source in account summaries.
+
+A documented process environment override for operation-evidence capacity may
+only lower the applicable bootstrap, managed, or legacy limit. Environment-only
+account operation therefore retains the same finite admission and backpressure
+contract as every other mode.
 
 ### Operational identity in every mode
 
@@ -137,6 +157,21 @@ or `FAILED_IMPORT` catalog does not imply a completed managed import. A managed
 catalog stores lifecycle state, catalog generation, policy version, and
 revision. `ACTIVE` selects the managed base; `MAINTENANCE` deliberately disables
 mail access until another generation transition.
+
+### Open decision: durable managed selection after storage loss
+
+The current mode-selection order cannot distinguish a never-activated install
+from one whose previously active managed database is missing, corrupt, replaced,
+or reached through the wrong path. In the latter cases, selecting retained TOML
+would violate the rule that managed mode never silently falls back to legacy.
+
+Before this proposal can be accepted or managed activation implemented, it must
+define a durable selection signal outside the database being located and a
+crash-safe activation sequence for updating that signal and the catalog. An
+explicit required bootstrap mode or a small fail-closed activation marker are
+possible designs, but neither is selected here. Once managed selection has been
+committed, missing or invalid managed storage must enter maintenance or return a
+configuration error rather than selecting legacy mail access.
 
 ## Explicit Legacy Import
 
@@ -195,6 +230,12 @@ Import rules:
 
 After managed mode is active, TOML is not also writable as a base catalog.
 Re-import requires a deliberate merge operation with conflict reporting.
+Retained legacy mutators, including whole-file credential migration, reset,
+Gradio callbacks, and MCP account mutation, must either route through managed
+application services under an explicit compatibility decision or fail before
+changing TOML or keyring state. An explicit legacy-source maintenance operation
+must prove that no active or pending managed binding references a locator before
+deleting it.
 
 ### Mode-transition visibility
 
@@ -378,8 +419,10 @@ The target CLI management surface includes commands equivalent to:
   `credential repair`;
 - `index status`, `index sync`, `index rebuild`, `index purge`, and explicit
   operational-identity list/rebind/retire actions for legacy source conflicts;
+- `operation list`, `operation reconcile`, and `operation acknowledge` for
+  unresolved provider effects and evidence-capacity recovery;
 - `doctor` for database, migration, source identity, secret, filesystem, IMAP,
-  and SMTP checks.
+  SMTP, and operation-evidence capacity checks.
 
 Exact command spelling may follow existing Typer conventions, but the ownership
 rules are normative:
@@ -391,6 +434,9 @@ rules are normative:
   consent;
 - imports, migrations, and destructive maintenance support dry-run where a
   preview is meaningful;
+- operation acknowledgment requires the exact operation identity and explicit
+  confirmation that the remote outcome remains unknown; it never reports success
+  or failure, authorizes replay, or suppresses the retained warning silently;
 - output identifies whether values are managed, legacy, environment, or
   shadowed without exposing secret locators.
 
@@ -433,7 +479,12 @@ Managed mode deliberately improves these behaviors:
 
 Tests cover:
 
-- deterministic mode selection and database path resolution;
+- deterministic mode selection and database path resolution, including the
+  accepted durable-selection mechanism, activation crash points, and fail-closed
+  behavior for missing, corrupt, replaced, or misresolved managed storage;
+- finite bootstrap operation-evidence ceilings and managed, legacy, and
+  environment-only admission/backpressure, including proof that every override
+  can only tighten the applicable byte and unresolved-count limits;
 - current and legacy TOML loading;
 - every documented environment override and replacement rule, including present
   empty allowlists and durable deny precedence;
@@ -443,8 +494,10 @@ Tests cover:
 - managed account and policy revisions, mandatory global rule-set completeness,
   account absence/inherit behavior, rule-set merge semantics, complete source
   attribution, and cross-process conflicts;
-- atomic mode-generation/effect-boundary ordering and `RESTART_REQUIRED` before
-  each independent provider side effect;
+- generation rejection at admission for every stale-process mail read or command,
+  again before provider or filesystem access, and atomic
+  mode-generation/effect-boundary ordering before each independent provider side
+  effect;
 - dry-run, staging lifecycle, failed-import rollback, and candidate repair;
 - each secret backend's explicit capabilities;
 - keyring failure plus secret-change crashes before and after every saga boundary;
@@ -452,10 +505,15 @@ Tests cover:
   secret;
 - pending cleanup, account soft removal, explicit guarded hard-purge ordering,
   orphan reporting limitations, and repair without backend enumeration;
+- operation listing, reconciliation, evidence-capacity diagnostics, and explicit
+  unknown acknowledgment without outcome invention or replay authorization;
 - no secret values in SQLite, logs, MCP results, exception strings, or test
   snapshots;
 - atomic owner-only plaintext compatibility writes;
-- managed versus legacy reset and backup behavior.
+- managed versus legacy reset and backup behavior;
+- retained legacy credential/configuration mutators in managed and maintenance
+  modes, proving that they fail before TOML/keyring writes or route through the
+  managed saga and never delete a locator referenced by a managed binding.
 
 SQLite tables and constraints are defined in
 [`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md).

--- a/spec/04-mail-workflows-and-consistency.md
+++ b/spec/04-mail-workflows-and-consistency.md
@@ -12,6 +12,12 @@ transaction. Application services distinguish remote truth, local indexed
 state, confirmed outcomes, and uncertain outcomes instead of presenting them as
 one atomic system.
 
+IMAP is authoritative for remote mailbox membership, flags, bodies, and
+attachments. An indexed placement proves only that the application observed it
+at a stated time; it does not prove that the placement still exists remotely.
+SQLite is a rebuildable, freshness-qualified projection for those data classes,
+not a competing mailbox source of truth.
+
 SQLite improves performance and recovery, but it does not make provider side
 effects exactly once. The application never retries an ambiguous send merely
 because a local write failed.
@@ -24,8 +30,10 @@ a typed operation outcome and reconcile known remote effects into SQLite.
 Every result that depends on indexed state includes:
 
 - `source`: `indexed`, `refreshed`, or `partial`;
-- the index or refresh timestamp;
-- whether the requested range is fully covered;
+- the metadata observation or refresh timestamp;
+- relevant mailbox addition-sync, flag-sync, and
+  complete-membership-reconciliation timestamps;
+- whether the requested metadata range and mailbox membership are fully covered;
 - an opaque continuation when more results are available;
 - warnings when local reconciliation remains pending.
 
@@ -42,6 +50,14 @@ account, mailbox, and UIDVALIDITY value:
 ```text
 MessagePlacement = account_id + mailbox_id + uidvalidity + uid
 ```
+
+`mailbox_id` is an opaque local operational identity, not a disposable row ID
+while an unreleased operation fence refers to it. Index compaction and full
+rebuild retain its identity shell and reuse the same ID when rediscovering the
+same canonical remote mailbox. An evidence-backed mailbox rename rebinds the
+remote name without changing the ID; uncertain rename continuity blocks provider
+effects until explicit reconciliation or rebind rather than silently assigning a
+fenced target a new identity.
 
 SQLite assigns an opaque internal `message_id` for local references. RFC 5322
 `Message-ID` is searchable metadata, not a unique key: it may be absent,
@@ -88,8 +104,10 @@ sequenceDiagram
   filters, sort order, and an index snapshot boundary.
 - `limit` has a conservative default and hard maximum.
 - Results use deterministic ordering with a unique tie-breaker.
-- Exact totals are optional and returned only when the index has complete
-  coverage and the query can compute them cheaply.
+- Exact totals are optional and returned only when metadata and membership
+  coverage are complete within the declared freshness policy, no relevant stale
+  placement, stale flag projection, or reconciliation remains, and the query can
+  compute them cheaply.
 - FTS results identify whether only metadata or also cached body text was
   searched.
 - A provider-side search may be used to extend coverage, but its results are
@@ -263,11 +281,20 @@ Mutation sequence:
 1. resolve every external reference to a current placement;
 2. load safe metadata and enforce sender and mutation policy;
 3. validate mailbox capability and command preconditions;
-4. record and claim operation intent when durable resume evidence is useful;
+4. record and claim operation intent, atomically reserving required evidence
+   capacity before any provider effect when durable resume evidence is useful;
 5. conditionally verify claim token and catalog generation while persisting the
-   remote-effect-possible substep;
+   remote-effect-possible substep; for a placement-scoped command, the same
+   transaction also verifies the expected placement is `ACTIVE` under the same
+   UIDVALIDITY and mailbox cursor revision, proves that no other unresolved
+   operation target fence matches the account, mailbox, UIDVALIDITY, and UID, and
+   advances the corresponding mailbox revision; a membership-affecting command
+   additionally marks each source target `STALE` with the attempt as owner, while
+   a flag-only command verifies the flag projection is `CONFIRMED` and marks only
+   that projection stale with ownership;
 6. perform the remote IMAP command outside SQLite transactions;
-7. persist confirmed outcomes or mark the affected local state stale;
+7. reconcile confirmed outcomes, conditionally restore a definitely unaffected
+   placement, or leave an uncertain placement stale;
 8. return per-item success, failure, and uncertainty without claiming an entire
    batch succeeded.
 
@@ -278,15 +305,55 @@ Specific rules:
 - Mark-as-read changes only the requested flag and preserves unrelated flags.
 - Move uses native MOVE when available and a tested copy/delete fallback
   otherwise.
-- The fallback records copy and source-delete as separate substeps. After a known
-  copy success it may continue only deletion or reconciliation; it never repeats
+- The fallback preflights target-scoped source-deletion capability and policy
+  before COPY. If the request requires a completed move and policy does not allow
+  a source-delete-pending result, it rejects before copying. Otherwise it records
+  copy and source-delete as separate substeps. After a known copy success it may
+  continue only target-scoped source deletion or reconciliation; it never repeats
   the copy. An unknown copy result is reconciled before any further side effect.
+- A placement-scoped delete or move fallback never issues bare mailbox-wide
+  `EXPUNGE`. It may use UID EXPUNGE when UIDPLUS is available or another provider
+  primitive proven to remove only the approved targets. Without a safe scoped
+  primitive, it either leaves only those targets marked `\Deleted` and reports
+  `DELETED_NOT_EXPUNGED` or `SOURCE_DELETE_PENDING`, or rejects a requested hard
+  delete before that step according to explicit policy.
+- Bare `EXPUNGE` is a separately modeled mailbox-wide destructive operation, not
+  an implementation detail of a message-ID-scoped command. If any interface
+  exposes it, the request and approval surface identify the mailbox-wide scope;
+  the target MCP catalog does not implicitly escalate a scoped delete into it.
 - A move retains local message identity only when provider evidence or safe
   reconciliation supports it; otherwise the destination is discovered on
   refresh.
 - Archive selection comes from adapter discovery plus application policy, not a
   hard-coded MCP folder name.
-- Delete semantics remain provider-aware and explicit about expunge behavior.
+- Delete semantics remain provider-aware and explicit about `\Deleted`, UID
+  EXPUNGE, provider auto-expunge, and the absence of safe hard-delete support.
+- A membership-affecting effect boundary marks each source target stale with the
+  attempt as owner before provider access. Confirmed delete or source removal
+  then removes the placement; definitive no-effect failure may restore it only
+  while the
+  attempt token and stale ownership marker match and no newer contradictory
+  provider evidence exists. An ambiguous result preserves ownership for
+  operation-aware reconciliation and never treats replay as a safe way to
+  discover the outcome.
+- A flag-only mutation still revalidates the placement and advances the mailbox
+  revision at its effect boundary, but it does not mark mailbox membership stale,
+  hide the message, or purge its body cache. It requires a `CONFIRMED` flag
+  projection and marks that projection stale with attempt ownership before
+  provider access. The provider command changes only the requested flags and
+  preserves unrelated flags. The projection returns to `CONFIRMED` only from a
+  canonical complete resulting flag set explicitly returned by the provider or a
+  complete follow-up FETCH observed after the mutation interval. A delta response
+  or prior cached flags plus the requested delta is insufficient because another
+  client may concurrently change an unrelated flag. Known remote success without
+  that complete observation leaves the flag projection stale and requires
+  reconciliation. Definitive no-effect may restore the prior confirmed projection
+  under the ownership checks, and unknown outcome leaves flags stale.
+- A stale flag projection remains visible as uncertainty on the message, but its
+  last known `flags_json` is not a definitive match for flag-dependent filters,
+  sorting, or exact counts. Such queries return partial or
+  reconciliation-pending state until a provider observation confirms the flags;
+  flag-independent metadata queries may still return the message.
 - Privacy-preserving blocked mutation behavior remains compatible: blocked IDs
   appear missing or as no-op success unless reporting is explicitly enabled.
 
@@ -299,11 +366,14 @@ query refresh or an explicit CLI command.
 stateDiagram-v2
     [*] --> Indexed
     Indexed --> Discovering: refresh requested
-    Discovering --> Applying: cursor valid and changes found
+    Discovering --> Applying: cursor valid and deltas found
+    Discovering --> ReconcilingMembership: complete UID set required
     Discovering --> Rebuilding: UIDVALIDITY changed
+    ReconcilingMembership --> Applying: complete UID set acquired
     Applying --> Indexed: batch and cursor committed
     Rebuilding --> Indexed: replacement coverage committed
     Discovering --> Partial: time or item budget reached
+    ReconcilingMembership --> Partial: response budget reached
     Applying --> Partial: time or item budget reached
     Partial --> Discovering: continuation requested
     Discovering --> AuthBlocked: credential rejected
@@ -321,6 +391,97 @@ stateDiagram-v2
 - Time, item, and byte budgets produce an honest `partial` state and continuation.
 - Authentication failures stop refresh for that invocation and remain visible
   until credentials change; no hot loop exists.
+
+## Remote Disappearance and Expunge Reconciliation
+
+Discovering additions and proving removals are different operations. `UIDNEXT`
+and the highest observed UID can discover likely additions, but they cannot show
+that an older UID was expunged. A message-count comparison is also insufficient:
+one deletion and one arrival can leave the count unchanged.
+
+```mermaid
+flowchart TD
+    LOAD[Load cursor, revision, and known placements]
+    DISCOVER[Select mailbox and discover UIDVALIDITY and capabilities]
+    UID_CHANGED{UIDVALIDITY changed?}
+    REBUILD[Invalidate old placements and begin bounded rebuild]
+    QRESYNC{QRESYNC usable within bounds?}
+    APPLY_QRESYNC[Apply changed metadata, VANISHED removals, and cursor]
+    COMPLETE_REQUESTED{Complete membership reconciliation requested?}
+    SEARCH_ALL[Run UID SEARCH ALL under response budgets]
+    COMPLETE_SET{UID set complete and fully parsed?}
+    DIFF[Diff placements and advance membership evidence]
+    UPSERT_ONLY[Upsert observations only and retain prior placements]
+    DELTA[Fetch bounded new or changed range]
+
+    LOAD --> DISCOVER --> UID_CHANGED
+    UID_CHANGED -->|yes| REBUILD
+    UID_CHANGED -->|no| QRESYNC
+    QRESYNC -->|yes| APPLY_QRESYNC
+    QRESYNC -->|no| COMPLETE_REQUESTED
+    COMPLETE_REQUESTED -->|yes| SEARCH_ALL --> COMPLETE_SET
+    COMPLETE_SET -->|yes| DIFF
+    COMPLETE_SET -->|no| UPSERT_ONLY
+    COMPLETE_REQUESTED -->|no| DELTA --> UPSERT_ONLY
+```
+
+The normative rules are:
+
+- When QRESYNC is supported and the adapter can encode the known UID state within
+  protocol and application bounds, matching-UIDVALIDITY `VANISHED` data is
+  authoritative removal evidence. CONDSTORE or a changed message count alone is
+  not removal evidence.
+- Otherwise, removal by absence requires one successful, completely parsed
+  mailbox UID-set reconciliation, such as bounded `UID SEARCH ALL`, under the
+  same UIDVALIDITY. A timeout, truncated response, parse failure, cancellation,
+  or item/byte budget exhaustion makes the membership result incomplete.
+- A bounded metadata or recent-UID refresh may add or update placements but must
+  never remove a placement merely because that placement was not observed.
+- Metadata coverage and membership reconciliation are independent. A complete
+  UID set can prove membership while headers remain partially indexed; a recent
+  metadata refresh does not refresh the complete-membership timestamp.
+- Confirmed provider evidence from this application's own target-scoped UID
+  EXPUNGE, MOVE, or equivalent operation may remove the affected source placement
+  immediately. Bare mailbox-wide `EXPUNGE` is never used to complete a scoped
+  operation because it can remove unrelated messages already carrying
+  `\Deleted`.
+  An uncertain provider result leaves the operation-owned placement stale until
+  operation-aware reconciliation resolves it. Ordinary sync does not clear that
+  ownership while the attempt may still be in flight or unknown; authoritative
+  existence or removal evidence it observes is persisted for the owning
+  operation rather than discarded.
+- Provider observations from separate connections are not ordered merely by
+  local response-completion time. Evidence whose observation interval overlaps a
+  remote-effect interval cannot restore or remove an owned stale placement by
+  itself; conflicting evidence requires a new post-attempt observation.
+- Remote disappearance removes a mailbox placement, not necessarily the logical
+  message. External moves, label changes, and another surviving mailbox
+  placement may leave the message remotely available. A destination placement
+  is discovered normally and is coalesced only with provider evidence or a
+  conservative reconciliation rule, never by RFC `Message-ID` alone.
+- Confirmed-removed and stale placements are excluded from ordinary indexed
+  search as soon as their state is known. A query scope containing unresolved
+  stale placements reports partial or reconciliation-pending state and does not
+  return an exact total even after a complete UID-set observation. When no
+  confirmed placement remains,
+  cached body text and its FTS projection are purged by default; any minimum
+  metadata needed for bounded operation reconciliation is not user-visible.
+- A body or attachment request whose provider lookup proves the indexed
+  placement is gone reconciles it and returns `STALE_MESSAGE_REFERENCE` or
+  `MESSAGE_NOT_FOUND`, not empty content. For a mutation, the remote-effect
+  transition atomically rechecks the expected `ACTIVE` placement, UIDVALIDITY,
+  and mailbox cursor revision and advances that revision before provider access.
+  A membership-affecting transition also marks each source target stale with
+  attempt ownership; a mismatch produces a stale-reference outcome without a
+  provider call.
+- A cache-satisfied read may return data observed within the declared freshness
+  policy and reports that age. A caller that requires current remote existence
+  requests fresh validation before cached content is served.
+- With no daemon, external removal detection is eventually consistent. The app
+  does not claim immediate awareness of changes made by another mail client.
+
+The persistence evidence, atomic diff, and cleanup rules are owned by
+[`05-sqlite-persistence-and-data-model.md`](05-sqlite-persistence-and-data-model.md).
 
 ## Operation States
 
@@ -342,21 +503,49 @@ The minimum durable vocabulary is:
   before retry;
 - `OUTCOME_UNKNOWN`: another remote side effect may have occurred but cannot be
   proven;
+- `ACKNOWLEDGED_UNKNOWN`: the user explicitly accepted that the historical remote
+  outcome remains unknown; this is not success or failure and never permits
+  automatic replay;
 - `RECONCILIATION_REQUIRED`: remote success is known and local projection needs
   repair;
 - `COMPLETED`: required remote and local steps are reconciled;
 - `RETRYABLE_FAILED`: no ambiguous external effect and a bounded retry is safe;
 - `TERMINAL_FAILED`: validation, policy, or permanent provider failure.
 
-Each attempt has a random owner token and conditional state transitions. The
-pre-effect-to-effect transition is also the mode-generation linearization point:
-it checks the startup generation in the same SQLite transaction. If a catalog
-transition committed first, it returns `RESTART_REQUIRED`; if the attempt
-transition committed first, that provider call may finish with its original
-snapshot. Every later compound-operation side-effect substep performs its own
-generation-checked transition. A stale pre-effect claim can be fenced and
-reclaimed. Claim expiry after `REMOTE_EFFECT_POSSIBLE`, `SUBMITTING`, or
-`SENT_COPY_SUBMITTING` never proves
+Each attempt has a random owner token and conditional state transitions. A
+placement target fence becomes active in the effect-boundary transaction and
+remains active while the provider call is in flight, its outcome is unknown, a
+compound substep is pending, or a known remote effect still requires local
+reconciliation. Definite no-effect, completed reconciliation, or eligible
+explicit unknown acknowledgment releases it; ordinary retention and sync do not.
+The pre-effect-to-effect transition is also the mode-generation linearization
+point:
+it checks the startup generation in the same SQLite transaction. A
+placement-scoped transition additionally compares the expected mailbox cursor
+revision, confirms that every target placement is still `ACTIVE` under the same
+UIDVALIDITY, rejects a match in another unresolved operation's durable target
+fence, and advances the mailbox revision. This fence is checked in the same
+transaction and remains enforceable even when rebuildable placement metadata has
+been compacted. A membership-affecting transition also marks source targets
+`STALE` with attempt ownership. A flag-only transition
+requires the current flag projection to be `CONFIRMED`, then marks it stale with
+attempt ownership while leaving membership active. This serializes competing
+effects and fences older refreshes without hiding a message for a flag-only
+change. Ordinary sync may update unrelated projections but cannot clear an
+operation-owned membership or flag stale marker while that attempt is active or
+unknown; relevant provider evidence is handed to the owning operation for
+reconciliation. If compaction removed the physical placement, rediscovery of an
+identity covered by an unresolved target fence reconstructs the applicable
+operation-owned membership or flag uncertainty instead of inserting an ordinary
+fully active projection. Only operation-aware reconciliation or explicit
+acknowledgment releases that fence. A mismatch returns a stale-reference or
+reconciliation outcome without entering provider code. If a catalog transition
+committed first, it
+returns `RESTART_REQUIRED`; if the attempt transition committed first, that
+provider call may finish with its original snapshot. Every later compound-operation
+side-effect substep performs its own generation and relevant-placement check. A
+stale pre-effect claim can be fenced and reclaimed. Claim expiry after
+`REMOTE_EFFECT_POSSIBLE`, `SUBMITTING`, or `SENT_COPY_SUBMITTING` never proves
 that no external effect occurred and therefore transitions to the corresponding
 unknown state.
 
@@ -376,16 +565,40 @@ The database schema and uniqueness rules are defined in
   reconciliation or a separately reviewed new operation, not payload replay.
 - Backoff is bounded and applies within one explicit operation; there is no
   background retry scheduler.
-- Authentication and policy failures are not retried automatically.
+- Authentication, policy, and operation-evidence-capacity failures are not
+  retried automatically; capacity failure occurs before the remote-effect
+  boundary and directs the user to reconciliation or acknowledgment.
 - A database-busy error after remote success yields reconciliation-required, not
   a repeated remote mutation.
+- Explicit acknowledgment records unresolved history as `ACKNOWLEDGED_UNKNOWN`,
+  releases operation-owned projection markers through the persistence rules, and
+  never converts uncertainty into permission to replay the original effect.
 
 ## Validation
 
 Tests cover successful and failure boundaries for:
 
 - indexed, refreshed, and partial metadata results;
-- cursor stability, concurrent refresh, and UIDVALIDITY rebuild;
+- cursor stability, concurrent refresh, UIDVALIDITY rebuild, and successful empty
+  or no-change addition/flag checks advancing only their applicable freshness;
+- QRESYNC/VANISHED removal, complete UID-set fallback, and proof that partial,
+  interrupted, or budget-exhausted refreshes never infer deletion by absence;
+- a scoped delete or move fallback with an unrelated pre-existing `\Deleted` UID,
+  proving bare EXPUNGE is never issued and the unrelated UID survives;
+- confirmed scoped expunge, no-safe-expunge partial outcome, hard-move rejection
+  before COPY, ambiguous deletion, overlapping sync/effect evidence, external
+  move, stale references, stale-placement suppression of exact totals despite
+  complete membership, and
+  orphaned body/FTS cleanup;
+- unknown STORE outcome followed by flag-independent search, flag-dependent
+  filtering, and exact-count calculation;
+- mark-as-read racing another client's unrelated flag change, proving that a
+  delta or cached-flags-plus-delta result remains stale until a complete
+  post-mutation flag set is observed;
+- unresolved membership mutation followed by projection compaction or full index
+  rebuild, provider rediscovery, and a competing mutation, proving the mailbox ID
+  remains bound, rediscovery remains operation-owned stale, and the durable target
+  fence rejects the competing effect before provider access;
 - PEEK body reads, bounded windows, and cache policy;
 - attachment size, path, and sender-policy controls;
 - SMTP full, partial, rejected, and per-recipient unknown outcomes;

--- a/spec/05-sqlite-persistence-and-data-model.md
+++ b/spec/05-sqlite-persistence-and-data-model.md
@@ -17,17 +17,17 @@ evidence from rebuildable mail indexes and caches.
 
 ## Storage Classes
 
-| Class                         | Examples                                                  | Rebuildable                    | Default persistence            |
-| ----------------------------- | --------------------------------------------------------- | ------------------------------ | ------------------------------ |
-| Managed configuration         | Accounts, endpoints, policies, secret bindings            | No                             | Yes                            |
-| Operational identity          | Stable IDs and legacy/environment source mappings         | No, when evidence refers to it | Yes in every base mode         |
-| Operation evidence            | SMTP acceptance, uncertain outcome, reconciliation state  | No                             | Yes, bounded retention         |
-| Mail index                    | Mailboxes, message metadata, placements, flags, addresses | Yes, from IMAP                 | Yes                            |
-| Search projection             | FTS subject, addresses, preview, permitted cached text    | Yes                            | Yes when available             |
-| Body cache                    | Normalized plain-text prefixes                            | Yes                            | Bounded and policy-controlled  |
-| Attachment metadata           | Filename, MIME type, part locator, size                   | Yes                            | Yes                            |
-| Raw MIME and attachment bytes | Provider payloads                                         | Yes                            | No by default                  |
-| Temporary artifacts           | Explicit local materialization                            | Yes                            | Private filesystem with expiry |
+| Class                         | Examples                                                 | Rebuildable                                 | Default persistence                                   |
+| ----------------------------- | -------------------------------------------------------- | ------------------------------------------- | ----------------------------------------------------- |
+| Managed configuration         | Accounts, endpoints, policies, secret bindings           | No                                          | Yes                                                   |
+| Operational identity          | Stable IDs and legacy/environment source mappings        | No, when evidence refers to it              | Yes in every base mode                                |
+| Operation evidence            | SMTP acceptance, uncertain outcome, reconciliation state | No                                          | Yes; unresolved is capacity-bounded with backpressure |
+| Mail index                    | Mailbox identity/metadata, messages, placements, flags   | Yes, except a fenced mailbox identity shell | Yes                                                   |
+| Search projection             | FTS subject, addresses, preview, permitted cached text   | Yes                                         | Yes when available                                    |
+| Body cache                    | Normalized plain-text prefixes                           | Yes                                         | Bounded and policy-controlled                         |
+| Attachment metadata           | Filename, MIME type, part locator, size                  | Yes                                         | Yes                                                   |
+| Raw MIME and attachment bytes | Provider payloads                                        | Yes                                         | No by default                                         |
+| Temporary artifacts           | Explicit local materialization                           | Yes                                         | Private filesystem with expiry                        |
 
 ## Sources of Truth
 
@@ -39,7 +39,8 @@ evidence from rebuildable mail indexes and caches.
 - The selected `SecretStore` is authoritative for secret values. SQLite stores
   `SecretRef` metadata only.
 - IMAP is authoritative for remote mailboxes, placements, flags, bodies, and
-  attachments.
+  attachments. An index row is a timestamped observation, not proof of current
+  remote existence.
 - SMTP response evidence is authoritative for known delivery acceptance.
 - SQLite operation records are authoritative for what the local application
   observed and which reconciliation steps remain.
@@ -64,6 +65,7 @@ erDiagram
     ACCOUNT_IDENTITY ||--o{ OPERATION : records
     MAILBOX ||--o{ MESSAGE_PLACEMENT : contains
     MESSAGE ||--o{ MESSAGE_PLACEMENT : placed_as
+    OPERATION_ATTEMPT o|--o{ MESSAGE_PLACEMENT : fences
     MESSAGE ||--o{ MESSAGE_ADDRESS : addresses
     MESSAGE ||--o{ MESSAGE_BODY : caches
     MESSAGE ||--o{ ATTACHMENT : describes
@@ -107,6 +109,8 @@ erDiagram
         integer attachment_download_enabled
         integer metadata_quota_bytes
         integer body_cache_quota_bytes
+        integer operation_evidence_quota_bytes
+        integer unresolved_operation_limit
         integer artifact_quota_bytes
     }
     MANAGED_ACCOUNT {
@@ -205,9 +209,17 @@ erDiagram
         text message_id FK
         integer uidvalidity
         integer uid
+        text membership_state
         text flags_json
+        text flags_state
         integer modseq
-        datetime observed_at
+        datetime flags_confirmed_at
+        datetime flags_stale_at
+        text flags_stale_attempt_id FK
+        datetime last_confirmed_at
+        datetime stale_at
+        text stale_reason
+        text stale_attempt_id FK
     }
     MESSAGE_ADDRESS {
         text message_id FK
@@ -242,8 +254,12 @@ erDiagram
         integer uidvalidity
         integer highest_uid
         integer highest_modseq
-        text coverage_state
-        datetime coverage_start
+        text metadata_coverage_state
+        datetime metadata_coverage_start
+        text membership_coverage_state
+        datetime last_addition_sync_at
+        datetime last_flag_sync_at
+        datetime last_complete_membership_at
         integer revision
         datetime updated_at
     }
@@ -254,6 +270,7 @@ erDiagram
         text idempotency_key
         text payload_hash
         text state
+        text target_json
         text result_json
         datetime created_at
         datetime updated_at
@@ -402,11 +419,22 @@ compound side-effect substep checks generation again.
 ### Scalar and rule policy
 
 `GLOBAL_POLICY` owns typed scalar settings, including blocked-mutation reporting,
-attachment enablement, and cache or artifact quotas. `ACCOUNT_POLICY` owns typed
-per-account overrides such as freshness, mutation, and body-cache policy. For
-scalar fields, an explicitly set account value replaces the global value, and a
+attachment enablement, and cache or artifact quotas. Its operation-evidence quota
+and unresolved-operation limit are managed-mode operating thresholds, not the
+sole safety limit. Base-mode-independent hard byte and unresolved-count ceilings
+are resolved from documented built-in and bootstrap settings before SQLite opens.
+Managed policy may tighten those ceilings; legacy TOML may supply lower operating
+thresholds; an environment override may only tighten the result. A configured
+value above its parent ceiling is invalid and reported with source attribution;
+it is not silently clipped or treated as permission to widen capacity. The
+effective admission limit in every mode is the minimum applicable valid value and
+can never be unbounded or exceed the bootstrap ceiling. `ACCOUNT_POLICY` owns
+typed per-account overrides such as freshness, mutation, and body-cache policy.
+For ordinary scalar
+fields, an explicitly set account value replaces the global value, and a
 supported process environment override replaces that result using current
-compatibility semantics. Every effective scalar carries its final source.
+compatibility semantics. Capacity limits are the narrowing-only exception. Every
+effective scalar carries its final source.
 
 `POLICY_RULE_SET` makes absence, inheritance, unrestricted access, and an
 explicit empty restriction distinguishable. Each global or account scope has at
@@ -574,8 +602,27 @@ active. A database constraint cannot prove that an external value exists, so
   exist per managed account and purpose.
 - Account removal does not cascade to operation evidence, credential cleanup,
   operational identity, or the managed tombstone.
-- Rebuildable mailbox, message, body, attachment, and FTS rows may be purged by
-  an explicit index cleanup after soft removal.
+- Rebuildable mailbox metadata, message, placement, body, attachment, and FTS rows
+  may be purged by explicit index cleanup after soft removal. A `MAILBOX` identity
+  shell and its local ID cannot be purged or re-keyed while an unreleased
+  operation target fence refers to it.
+- Placement membership state is constrained to `ACTIVE` or `STALE`; `ACTIVE`
+  requires a non-null `last_confirmed_at` and null membership-stale fields, while
+  `STALE` requires non-null `stale_at` and `stale_reason`. An operation-owned
+  stale row also requires the owning `stale_attempt_id`. Confirmed disappearance
+  uses explicit removal rather than a user-visible deleted-mail row.
+- Flag projection state is independently constrained to `CONFIRMED` or `STALE`;
+  `CONFIRMED` requires non-null `flags_confirmed_at`, non-null canonical
+  `flags_json` containing the complete provider-observed flag set, and null
+  flag-stale fields. `STALE` requires non-null `flags_stale_at`; an
+  operation-owned stale flag projection also requires
+  `flags_stale_attempt_id`. The last known `flags_json` may remain stored but is
+  not authoritative while flags are stale. A requested delta, or prior cached
+  set plus that delta, cannot satisfy the `CONFIRMED` constraint.
+- `COMPLETE` membership coverage requires a non-null
+  `last_complete_membership_at`. A later incomplete observation or continuity
+  gap downgrades coverage without erasing the timestamp of the last successful
+  complete reconciliation.
 - Every account-graph foreign key uses `RESTRICT` unless a narrow rebuildable
   child relation documents otherwise. Hard purge follows the enumerated guarded
   deletion order and never relies on a blind cascade.
@@ -584,22 +631,111 @@ active. A database constraint cannot prove that an external value exists, so
 
 ### Mailboxes and placements
 
-A mailbox is unique on `(account_id, remote_name)`. A placement is unique on:
+A mailbox is unique on `(account_id, remote_name)`. Its `id` is an opaque local
+operational identity. Full index rebuild may clear its attributes, cursor, and
+placements, but it retains an identity shell and ID while an unreleased operation
+target fence refers to that ID. Rediscovery of the same canonical remote name
+reuses the shell. A rename backed by provider identity evidence updates
+`remote_name` without changing `id`; when continuity cannot be proven, the
+adapter records a mailbox-identity conflict and blocks affected provider effects
+until operation reconciliation, acknowledgment, or explicit rebind. It never
+silently attaches a fenced ID to a merely similar mailbox.
+
+A placement is unique on:
 
 ```text
 (mailbox_id, uidvalidity, uid)
 ```
 
-`MESSAGE_PLACEMENT` also has an index on `(message_id, mailbox_id)`. When
-UIDVALIDITY changes, old placements for that mailbox become invalid and are
-replaced through controlled rebuild. They are never matched to new UIDs by UID
-alone.
+`MESSAGE_PLACEMENT` also has an index on `(message_id, mailbox_id)`. Its
+`membership_state` is `ACTIVE` or `STALE`. `ACTIVE` means the provider last
+confirmed the placement at
+`last_confirmed_at`; it does not claim that no later remote change occurred.
+`STALE` means an ambiguous operation or provider result requires reconciliation,
+and `stale_at` records when that uncertainty began. Stale placements are excluded
+from ordinary indexed results and cannot authorize a mutation.
+
+Confirmed disappearance physically removes the placement in the same short
+transaction that updates the applicable mailbox cursor state. A durable
+placement tombstone is unnecessary because a UID is not reused within one
+UIDVALIDITY namespace; operation evidence that must survive owns its own bounded
+identifiers. Every placement-scoped provider-effect transition conditionally
+verifies its expected `ACTIVE` placement, UIDVALIDITY, and mailbox cursor revision,
+checks that no other unresolved operation has a matching durable target fence,
+and advances the affected mailbox revision in the same transaction that crosses
+the effect boundary. The fence match uses account, mailbox, UIDVALIDITY, and UID
+from schema-validated `target_json`, so it remains enforceable after rebuildable
+placement metadata is compacted. A membership-affecting transition additionally
+marks each source target `STALE` with the attempt as owner before provider access,
+without pretending one mutation was a complete membership scan. This serializes
+competing membership effects and prevents an older refresh from committing and
+resurrecting pre-effect state.
+
+A flag-only transition does not change placement membership state or trigger
+orphan cache cleanup. It requires `flags_state = CONFIRMED`, then marks it
+`STALE` with `flags_stale_attempt_id` before provider access. The provider command
+changes only the requested flags. Confirmed remote success returns the projection
+to `CONFIRMED` only when the response explicitly contains the canonical complete
+resulting flag set or a complete follow-up FETCH observes it after the mutation
+interval. A STORE delta or prior `flags_json` plus the requested delta is not a
+complete observation and leaves the projection stale for reconciliation, because
+a concurrent client may have changed unrelated flags. A definitive no-effect
+result may conditionally restore the prior confirmed projection; unknown outcome
+leaves the flags operation-owned and stale. Flag-independent queries may retain
+the placement, but flag-dependent filters, sorting, and exact totals treat the
+projection as unresolved and expose bounded reconciliation warnings.
+
+A normal sync may observe an operation-owned stale membership or flag projection
+but does not resolve it while its attempt may still be in flight or unknown. It
+may reconcile unrelated projections and advance the mailbox revision.
+Authoritative existence, removal, or flag evidence for an owned projection is
+persisted as bounded reconciliation evidence on the owning operation rather than
+discarded. Confirmed provider success removes or updates the owned projection. A
+definitive no-effect result may restore its prior confirmed state only with a
+conditional write that verifies the attempt token, ownership marker, and absence
+of newer contradictory provider evidence; it does not require an unchanged
+mailbox revision and therefore tolerates unrelated synchronization. Unknown
+outcome keeps the ownership marker until an operation-aware reconciliation
+resolves it. If quota maintenance compacted the placement itself, ordinary sync
+must consult unresolved target fences before applying rediscovery. A matching
+rediscovered identity reconstructs the applicable membership or flag projection
+as operation-owned `STALE`, linked to the retained attempt, rather than creating
+an ordinary fully active and confirmed target. Only operation-aware
+reconciliation or explicit acknowledgment releases the durable fence; ordinary
+sync cannot do so.
+
+Reconciliation evidence records its bounded provider-observation interval. Local
+response-completion order across separate connections is not a remote
+linearization order. Evidence overlapping the attempt's effect interval cannot
+resolve ownership by itself; conflicting evidence requires a new post-attempt
+observation.
+
+When UIDVALIDITY changes, all placements in the old namespace become invalid and
+are replaced through controlled rebuild. They are never matched to new UIDs by
+UID alone. Old rows are excluded immediately and may be deleted as the rebuild
+commits; unrelated mailboxes are unaffected.
+
+Removal by absence is legal only for a complete provider UID set under matching
+UIDVALIDITY. QRESYNC `VANISHED` evidence and confirmed local provider operations
+may remove specifically identified placements. A partial, interrupted, bounded,
+or failed scan performs upserts only. These behavior rules are defined in
+[`04-mail-workflows-and-consistency.md`](04-mail-workflows-and-consistency.md).
 
 ### Messages
 
 `MESSAGE.id` is local and opaque. `rfc_message_id` is nullable and indexed but
 not unique. Message coalescing across mailboxes must use provider evidence or a
 conservative reconciliation rule; matching only the RFC header is insufficient.
+A placement disappearing from one mailbox does not prove that the logical
+message was globally deleted or identify a destination placement.
+
+When a message has no `ACTIVE` membership placement, it is excluded from ordinary
+search. A stale flag projection alone does not hide it. If only stale membership
+placements remain, its cached body and body-derived FTS content are
+purged by default while reconciliation proceeds. When no placement remains, its
+addresses, attachment metadata, remaining FTS rows, and message row are deleted
+unless bounded unresolved operation evidence independently retains the minimum
+facts it needs. The target defines no implicit local deleted-mail archive.
 
 Useful indexes include:
 
@@ -671,21 +807,77 @@ not imply full-message search when only metadata coverage exists.
 ## Synchronization Cursors
 
 `SYNC_CURSOR` is mailbox-scoped. It stores UIDVALIDITY, highest observed UID,
-optional highest MODSEQ, coverage state, coverage boundary, and a monotonic
-revision.
+optional highest MODSEQ, independent metadata and membership coverage state,
+separate synchronization timestamps, and a monotonic revision.
+
+The fields have distinct meanings:
+
+- `metadata_coverage_state` is `NONE`, `PARTIAL`, or `COMPLETE` for indexed
+  metadata, and `metadata_coverage_start` identifies the oldest covered boundary
+  when coverage is range-based;
+- `membership_coverage_state` is `UNKNOWN`, `PARTIAL`, or `COMPLETE` for the most
+  recent remote UID-set observation. `COMPLETE` does not make the observation
+  timeless; freshness policy still evaluates its timestamp;
+- `last_addition_sync_at` advances after a successful, completely processed
+  addition-discovery check over its declared mailbox scope, including a valid
+  empty or no-change result. It says nothing by itself about flag changes or older
+  UID removal;
+- `last_flag_sync_at` advances after a successful, completely processed flag
+  delta check over its declared mailbox scope, including a valid no-change
+  result. An additions-only UID check never advances it;
+- partial, interrupted, cancelled, truncated, or budget-exhausted checks advance
+  neither applicable timestamp;
+- `last_complete_membership_at` advances only after a completely parsed UID-set
+  reconciliation, or after a continuous QRESYNC baseline and all subsequent
+  changes have been committed without a gap;
+- `revision` fences concurrent sync and placement-scoped effect boundaries.
 
 A synchronization batch follows this order:
 
-1. read cursor and revision;
-2. perform bounded IMAP discovery outside a transaction;
-3. begin a short write transaction;
-4. verify the cursor revision still matches;
-5. upsert mailboxes, messages, addresses, placements, and attachments;
-6. update search projections;
-7. advance cursor and coverage in the same commit.
+1. read the cursor, revision, known placements, and current coverage;
+2. select the mailbox and obtain UIDVALIDITY and capabilities;
+3. perform bounded IMAP discovery outside a transaction and classify each result
+   by covered scope: addition discovery, flag delta, QRESYNC-continuous change
+   set, complete membership snapshot, or incomplete observation;
+4. begin a short write transaction and verify both cursor revision and
+   UIDVALIDITY still match;
+5. upsert observed mailboxes, messages, addresses, placements, and attachments;
+6. apply specifically identified `VANISHED` removals, or diff local placements
+   against the remote UID set only when the membership snapshot is complete;
+7. resolve ordinary stale membership and flag projections from the new evidence,
+   attach relevant evidence for operation-owned projections to their owning
+   operation, remove other confirmed placements, and apply orphan cache/index
+   cleanup;
+8. update search projections and only the timestamps and coverage fields whose
+   declared scopes completed successfully, even when their valid result was empty;
+9. advance the cursor revision in the same commit.
 
-If the revision changed, the process re-evaluates or safely repeats idempotent
-upserts. It never commits a cursor that skips metadata it did not persist.
+A complete UID set may be compared through a bounded in-memory representation or
+a connection-local temporary table; it is not interpolated into one unbounded
+SQL statement. The set is trusted for absence only when the IMAP command
+completed, the full response was parsed within declared time/item/byte budgets,
+and UIDVALIDITY matches. Otherwise the transaction performs observed upserts but
+no absence-based delete and does not advance `last_complete_membership_at` or any
+addition/flag timestamp whose declared check did not complete.
+
+QRESYNC may remove specifically known placements from matching-UIDVALIDITY
+`VANISHED` evidence even when overall metadata coverage is partial. A completely
+processed continuity-preserving QRESYNC check advances both addition and flag
+freshness even when it reports no changes; it advances complete membership
+evidence only when the prior baseline was complete and no MODSEQ or known-UID
+continuity gap exists. A complete CONDSTORE flag check may advance flag freshness
+but not addition or membership freshness. UIDNEXT/highest-UID discovery may
+advance addition freshness but not flag or complete-membership freshness. A
+message count alone advances none of them. Complete
+membership evidence does not clear operation-owned stale rows or make their
+user-visible projection complete; affected queries remain partial or
+reconciliation-pending until the owning operation is resolved.
+
+If the cursor revision changed, the process re-evaluates the provider evidence
+against the new local state or safely repeats idempotent discovery. It never
+commits a cursor that skips metadata it did not persist, applies absence against
+partial coverage, or resurrects a placement removed by a concurrent confirmed
+mutation.
 
 ## Operation Journal
 
@@ -697,17 +889,53 @@ Required constraints:
 - unique `(account_id, kind, idempotency_key)` when a key is present;
 - the same key may be reused only with the same payload hash;
 - unique `(operation_id, attempt_number)`;
+- bounded, schema-validated `target_json` persists every placement identity,
+  uncertainty scope, and expected revision needed for crash recovery without
+  depending on rebuildable placement or message rows; it contains no body, MIME,
+  attachment bytes, or secret. Its `mailbox_id` remains reserved by a minimal
+  identity shell until the fence is released. From the effect-boundary transition
+  through in-flight,
+  unknown, pending-compound-substep, or known-but-unreconciled states, it is also
+  a durable target fence over account, mailbox, UIDVALIDITY, and UID, not merely
+  diagnostic evidence. Definite no-effect, completed reconciliation, or eligible
+  explicit unknown acknowledgment releases the fence;
 - one active attempt claim per operation, protected by a random claim token,
   conditional transitions, and a bounded stale deadline;
+- creating a new journaled operation atomically reserves its bounded target and
+  evidence capacity and checks the unresolved-operation count in the claim
+  transaction; `OPERATION_EVIDENCE_CAPACITY` fails before any effect boundary;
 - an attempt phase that distinguishes `CLAIMED_PRE_EFFECT` from
   `REMOTE_EFFECT_POSSIBLE` before any provider side-effect call;
 - the effect-boundary transition conditionally verifies both claim token and
   startup catalog generation in the same transaction; a mismatch produces
   `RESTART_REQUIRED` without advancing the attempt;
+- a placement-scoped effect boundary also receives the expected mailbox revision
+  and full placement identities, verifies that each remains `ACTIVE` under the
+  same UIDVALIDITY, rejects any identity matching another effect-possible
+  unresolved operation's target fence, and advances affected mailbox revisions
+  in that transaction; this target-fence check and the other preconditions are
+  one atomic query/update boundary and therefore survive index compaction. A
+  membership-affecting boundary additionally marks each source target `STALE`
+  with that attempt as owner; a flag-only boundary leaves membership active but
+  requires `flags_state = CONFIRMED` and marks that projection stale with the
+  attempt as owner. A mismatch produces a stale-reference or reconciliation
+  result before provider access;
+- definite no-effect restoration verifies the attempt token, applicable stale
+  ownership marker, and absence of newer contradictory provider evidence;
+  confirmed effects reconcile owned membership or flag projections, while unknown
+  outcomes preserve ownership and bounded provider evidence for operation-aware
+  reconciliation;
+- an attempt referenced by an operation-owned membership or flag-stale marker
+  cannot be purged. Safe compaction may remove the rebuildable marker only after
+  the unresolved operation, attempt, uncertainty scope, and durable target fence
+  are retained; neither operation nor attempt becomes purge-eligible while that
+  fence remains. Reconciliation or acknowledgment releases the fence before
+  normal attempt retention applies;
 - per-recipient SMTP acceptance, rejection, and unknown evidence in bounded
   typed result data;
 - explicit sent-copy and compound-IMAP substep outcomes;
-- result JSON never contains full bodies, MIME, attachment bytes, or secrets.
+- target and result JSON never contain full bodies, MIME, attachment bytes, or
+  secrets.
 
 A stale `CLAIMED_PRE_EFFECT` attempt may be fenced and reclaimed because it did
 not cross a remote-effect boundary. A stale `REMOTE_EFFECT_POSSIBLE` attempt is
@@ -720,6 +948,16 @@ rows. They retain their `ACCOUNT_IDENTITY` foreign key; a removed managed accoun
 also retains its tombstone until guarded hard purge. Purging evidence requires an
 explicit policy and must not make the application claim stronger idempotency
 guarantees.
+
+Explicit acknowledgment may transition only an eligible unknown state, such as
+`OUTCOME_UNKNOWN` or `SENT_COPY_OUTCOME_UNKNOWN`, to `ACKNOWLEDGED_UNKNOWN`. It
+records acknowledgment time and the warning shown, releases operation ownership
+without promoting an uncertain membership or flag
+projection to confirmed state, and makes rebuildable target metadata
+purge-eligible. Bounded `target_json` and idempotency evidence remain for the
+configured evidence-retention period. Acknowledgment never records remote success
+or failure, enables replay, or interprets later rediscovery as retroactive proof
+of the historical outcome.
 
 ## SQLite Runtime Rules
 
@@ -770,7 +1008,8 @@ Independent limits apply to:
 
 - indexed message age or count per account;
 - body cache bytes and age;
-- operation evidence age by state;
+- operation evidence bytes, count, and age by state;
+- unresolved or operation-owned evidence count;
 - temporary artifact bytes and expiry;
 - synchronization batch items, bytes, and time.
 
@@ -780,12 +1019,37 @@ Default policy principles:
 - cache bodies only on demand and under an explicit bound;
 - do not cache attachment bytes by default;
 - retain unresolved or uncertain operation evidence until resolved or explicitly
-  acknowledged;
+  acknowledged; never evict it automatically by age or ordinary quota pressure;
+- permit quota maintenance to compact an operation-owned stale projection only
+  after bounded `target_json`, idempotency data, ownership, uncertainty scope,
+  and reconciliation evidence are durable. Compaction removes or invalidates
+  rebuildable placement, message, address, and attachment metadata but retains
+  the fenced mailbox identity shell and ID. It does not change the operation's
+  unknown state or release its target fence, and it downgrades affected index
+  coverage;
+- after compaction, provider rediscovery matching an unresolved target fence
+  reconstructs operation-owned stale membership or flags and cannot authorize a
+  competing provider effect. Operation-aware reconciliation may resolve the
+  historical operation; explicit acknowledgment may release the fence without
+  inventing its outcome. Rediscovery after acknowledgment may create ordinary
+  index state but is not retroactive proof of that outcome;
+- when unresolved evidence reaches its configured count or byte ceiling, reject
+  new provider-effect mutations that require journal capacity with
+  `OPERATION_EVIDENCE_CAPACITY`; reads, diagnostics, reconciliation, and explicit
+  acknowledgment remain available. Never silently delete unknown evidence merely
+  to admit another mutation;
+- purge cached body and body-derived FTS content when no active membership
+  placement remains;
+- do not retain an implicit user-visible archive of remotely removed messages;
 - purge derived FTS rows with their source cache rows;
-- report partial index coverage after quota eviction.
+- downgrade metadata or membership coverage after any quota eviction that makes
+  the corresponding projection incomplete.
 
-Concrete numeric defaults remain a product configuration decision and must be
-specified with implementation benchmarks rather than guessed in this proposal.
+Concrete numeric defaults and implementation maxima remain a product
+configuration decision and must be benchmarked and documented before
+implementation. Their values are unresolved here, but their presence before mode
+selection, finite narrowing-only precedence, and admission semantics are
+normative.
 
 ## Backup, Restore, and Rebuild
 
@@ -801,9 +1065,27 @@ include keyring secret values or temporary artifacts.
 - Missing secret bindings disable affected accounts and produce CLI remediation;
   they do not trigger plaintext fallback.
 - Missing temporary artifacts are reported as expired and can be fetched again.
-- `index rebuild` preserves operational identities, source mappings, managed
-  accounts, credential bindings, and operation evidence while replacing only
-  rebuildable mail data.
+- `index rebuild` preserves operational account identities, source mappings,
+  managed accounts, credential bindings, operation evidence, and every mailbox
+  identity shell referenced by an unreleased target fence. It may replace
+  rebuildable mail data, but rediscovery reuses those mailbox IDs; a proven rename
+  rebinds the existing ID atomically, and ambiguous continuity remains blocked.
+
+### Open decision: operation-evidence continuity after restore
+
+Schema and secret-binding validation are not sufficient to re-enable provider
+effects after restoring an older backup. A backup may predate a later send, move,
+delete, unknown outcome, or target fence. Restoring it would erase the local
+evidence for that effect and could allow an idempotency key or placement target
+to be acted on again.
+
+Before this proposal can be accepted or restore implemented, it must choose a
+continuity contract. Candidate designs include proof that the backup was taken
+and restored from a quiesced operation epoch, an explicit evidence-continuity
+break that creates a new epoch only after user acknowledgment, or separate
+preservation of append-only operation evidence. No candidate is selected here.
+A restored database remains in maintenance and cannot perform provider effects
+until the accepted continuity check or explicit break procedure completes.
 
 ## Validation
 
@@ -814,6 +1096,20 @@ Persistence tests cover:
 - concurrent readers, writer contention, and bounded busy behavior;
 - sync revision conflicts and atomic cursor advancement;
 - UIDVALIDITY invalidation;
+- QRESYNC/VANISHED application, complete UID-set comparison, distinct addition,
+  flag, and membership timestamps, successful empty/no-change checks, and proof
+  that CONDSTORE/UIDNEXT/count evidence advances only its valid scope;
+- timeout, cancellation, parse failure, response truncation, and every budget
+  boundary proving that partial observation cannot delete by absence or advance
+  complete-membership evidence;
+- effect-boundary stale ownership for membership and flags, flag-independent
+  visibility versus flag-filter/count uncertainty, competing membership commands,
+  an in-flight operation racing new and old syncs, overlapping evidence that
+  requires a post-attempt observation, confirmed local deletion, conditional
+  no-effect restoration after unrelated mailbox updates, mark-as-read racing an
+  unrelated concurrent flag change and remaining stale until a complete
+  provider-observed flag set, stale placement exclusion, external move semantics,
+  orphan cache/FTS cleanup, and no implicit deleted-mail archive;
 - legacy and environment identity reuse across restart; exact v1 canonical
   tuples; address, IDNA host, username, TLS, path, case, symlink, and default-path
   normalization; fingerprint-version migration; conflict behavior; source
@@ -832,10 +1128,24 @@ Persistence tests cover:
   cleanup repair, and proof that the active locator is never deleted;
 - FTS enabled and unavailable paths;
 - body and artifact quota eviction;
+- unresolved-operation metadata compaction or full index rebuild retaining the
+  fenced mailbox identity shell and ID, rediscovery reconstructing operation-owned
+  stale state, a competing mutation rejected by the retained target fence before
+  provider access, `ACKNOWLEDGED_UNKNOWN` releasing that fence without outcome
+  invention, evidence
+  capacity backpressure, and proof that unknown evidence is never silently
+  evicted to admit a new mutation;
+- operation-evidence admission under managed, legacy, and environment-only modes,
+  finite bootstrap byte/count ceilings, and proof that managed, TOML, or
+  environment policy can tighten but never widen those ceilings;
 - operation idempotency, atomic generation/effect-boundary ordering for each
-  compound substep, stale pre-effect claim recovery, stale post-boundary
-  conversion to unknown, partial SMTP acceptance, and uncertain-outcome retention;
+  compound substep, atomic placement revision/UIDVALIDITY checks, stale pre-effect
+  claim recovery, stale post-boundary conversion to unknown, scoped delete
+  without bare EXPUNGE, partial SMTP acceptance, and uncertain-outcome retention;
 - database, WAL, and artifact permissions;
-- online backup, restore, index rebuild, and missing-secret recovery;
+- online backup, index rebuild, and missing-secret recovery;
+- restore from current and older operation epochs, proving that schema/secret
+  validation alone never re-enables provider effects across an unresolved
+  evidence-continuity gap;
 - proof that resolved secret values never reach database pages through normal
   application writes.

--- a/spec/06-mcp-interface-and-client-compatibility.md
+++ b/spec/06-mcp-interface-and-client-compatibility.md
@@ -231,8 +231,13 @@ Metadata search returns a bounded set of:
 - stable message reference;
 - mailbox placement reference required by compatibility tools;
 - subject, normalized sender, selected recipients, and dates;
-- flags, size, short preview, and attachment count when known;
-- freshness, coverage, `has_more`, and opaque `next_cursor`.
+- flags with confirmed/stale projection state, size, short preview, and
+  attachment count when known;
+- metadata observation time, last addition sync, last flag sync, last complete
+  membership reconciliation, and their independent coverage states;
+- bounded reconciliation warnings when stale placements suppress items or stale
+  flags prevent definitive filters, sorting, or exact totals;
+- `has_more` and opaque `next_cursor`.
 
 Defaults are small and hard limits are enforced. The application cursor binds
 filters and ordering; it is unrelated to MCP capability-list cursors.
@@ -246,6 +251,12 @@ known, truncation state, and the next continuation.
 A body must never be fetched merely because metadata was listed. The target API
 should prefer one selected message per call; any compatibility batch path has a
 strict aggregate character budget.
+
+An indexed reference whose provider lookup proves the placement disappeared
+returns a bounded `STALE_MESSAGE_REFERENCE` or `MESSAGE_NOT_FOUND` result and
+triggers local reconciliation. A cache-satisfied result reports its observation
+age; a caller may require fresh remote-existence validation before cached content
+is served.
 
 ### Layer 4: attachment bytes
 
@@ -287,6 +298,20 @@ not require a prompt.
 - Secrets and arbitrary configuration models never appear in schemas.
 - A schema change is additive when possible. Removing or changing a required
   field is treated as a public compatibility event.
+
+### Open decision: send idempotency input
+
+The operation contract requires an idempotency key, but the current public
+`send_email` schema has no such field. Generating a new key for every repeated
+call cannot protect a caller retry after a lost result, while deriving the key
+only from the payload would incorrectly suppress deliberate identical messages.
+
+Before this proposal can be accepted or the journaled send path exposed, it must
+define the public input and absent-key behavior. An additive optional
+`idempotency_key` plus a durable operation ID in every result is the leading
+option: the same key and payload resolves the existing operation, a payload
+mismatch is rejected, and absence starts a new operation. This paragraph records
+the unresolved compatibility decision rather than selecting that option.
 
 ### Account reference compatibility
 
@@ -354,6 +379,9 @@ Annotations help clients apply sensible approval behavior:
   read-only unless the behavior is split or the annotation remains conservative;
 - send, save, mark, move, archive, delete, account mutation, and local file writes
   are non-read-only;
+- message-scoped delete and move approvals never authorize bare mailbox-wide
+  EXPUNGE. Any future mailbox-wide expunge action is separately named and exposes
+  the mailbox-wide scope directly in its arguments and approval text;
 - destructive and idempotent hints reflect actual semantics, including ambiguous
   provider outcomes;
 - open-world hints reflect IMAP/SMTP or filesystem interaction accurately.
@@ -429,9 +457,25 @@ MCP validation covers:
   substeps, and `RESTART_REQUIRED` before side effects after a base-mode change;
 - complete text semantics with and without structured output;
 - bounded metadata pages, body batches, warnings, and errors;
+- distinct metadata, addition-sync, flag-sync, and complete-membership freshness,
+  including successful no-change checks and without presenting a partial refresh
+  as proof against remote deletion;
+- stale indexed references and fresh-validation requests with and without a body
+  cache hit;
+- unknown flag mutation followed by flag-independent output and partial
+  flag-dependent filters or totals, plus a mark-as-read race where an unrelated
+  concurrent flag change prevents confirmation until a complete provider flag
+  set is observed;
+- scoped delete and move fallback proving an unrelated pre-existing `\Deleted`
+  message is never expunged;
+- operation-evidence capacity errors and safe CLI remediation without outcome
+  invention or replay;
 - cursor continuity and stale-cursor errors;
 - resource and prompt enhancements disabled without affecting tools;
 - client-approval-visible arguments for every mutation;
+- the accepted send-idempotency contract, including lost-result retry,
+  same-key/different-payload rejection, and deliberate identical sends as
+  distinct operations;
 - no credentials, secret references, unapproved paths, SQL, or raw provider
   errors in results;
 - message-content prompt-injection boundaries;

--- a/spec/README.md
+++ b/spec/README.md
@@ -113,7 +113,7 @@ or protocol clients.
 | Legacy account configuration | TOML compatibility adapter           | Base config stays in TOML; SQLite stores only non-secret source-to-operational-ID mapping and index data |
 | Environment overrides        | Process environment                  | Read-only runtime config; SQLite may retain only non-secret source identity and index data               |
 | Passwords and tokens         | Selected `SecretStore`               | Opaque backend and locator only                                                                          |
-| Mailbox and message state    | IMAP server                          | Rebuildable local index and cache                                                                        |
+| Mailbox and message state    | IMAP server                          | Rebuildable, freshness-qualified last-observed projection and cache                                      |
 | SMTP delivery acceptance     | SMTP server response                 | Operation evidence and reconciliation state                                                              |
 | Raw MIME and attachments     | IMAP server or explicit local export | Metadata only by default                                                                                 |
 
@@ -154,13 +154,42 @@ not import FastMCP, Typer, sqlite3, keyring, aioimaplib, or aiosmtplib.
 - Network calls and secret-store calls never run inside SQLite transactions.
 - A message placement is identified by account, mailbox, UIDVALIDITY, and UID;
   an IMAP UID alone is not durable.
+- An indexed placement is a timestamped observation, not proof of current remote
+  existence. IMAP remains authoritative for mailbox membership.
+- Absence proves removal only from matching-UIDVALIDITY `VANISHED` or equivalent
+  provider evidence, a confirmed local mutation, or a complete UID-set
+  reconciliation. Partial refresh never deletes by absence.
+- A message-scoped delete or move fallback never issues bare mailbox-wide
+  `EXPUNGE`; without UID EXPUNGE or another proven scoped primitive it returns a
+  non-expunged partial outcome or rejects hard deletion according to policy.
+- Remote disappearance removes a placement, not necessarily the logical message;
+  when no active placement remains, cached body and body-derived FTS content are
+  purged by default and no implicit deleted-mail archive is exposed.
 - SMTP results preserve per-recipient acceptance, rejection, and uncertainty;
   accepted or unknown recipients are never automatically resubmitted.
 - SMTP success is not rolled back when saving the sent copy fails, and an unknown
   sent-copy APPEND is reconciled before retry.
 - Provider-effect operations atomically verify claim ownership and catalog
-  generation while persisting each effect boundary; a stale post-boundary claim
-  becomes unknown rather than being replayed.
+  generation while persisting each effect boundary. Placement-scoped operations
+  also verify the expected active placement and UIDVALIDITY and advance the
+  mailbox revision before provider access; membership-affecting operations mark
+  source targets stale, while flag-only operations mark only the flag projection
+  stale, both with attempt ownership. Post-boundary stale claims become unknown
+  rather than being replayed.
+- Unknown operation evidence is never silently evicted. Rebuildable message
+  metadata may be compacted into bounded target evidence, but every unresolved
+  placement identity remains an enforceable effect-boundary fence. Mailbox IDs
+  referenced by unreleased fences survive full index rebuild or are rebound only
+  with identity evidence; rediscovery reconstructs operation-owned uncertainty
+  rather than enabling a competing mutation. Only reconciliation or explicit acknowledgment releases the fence.
+  Exhausted evidence capacity blocks new provider-effect mutations without
+  inventing an outcome or allowing replay.
+- A `CONFIRMED` flag projection contains one canonical, complete provider-observed
+  flag set. A requested flag delta or prior cache plus delta never proves the
+  resulting set when another client could have changed unrelated flags.
+- Finite operation-evidence byte and unresolved-count ceilings apply in managed,
+  legacy, and environment-only modes; later policy sources may tighten but never
+  widen the bootstrap safety ceiling.
 - Body reads use IMAP PEEK unless the user explicitly requests a read mutation.
 - Legacy and environment accounts may reuse stable SQLite operational identities,
   but their endpoints, policies, and secrets are never copied into managed


### PR DESCRIPTION
## Summary

- strengthen the Local Email App configuration, synchronization, operation-evidence, and MCP compatibility contracts
- add the reviewed UI delivery strategy, with `ui` as the sole graphical command and React replacing Gradio behind it after the release gates
- record unresolved managed-selection, restore-continuity, and send-idempotency decisions explicitly
- keep the detailed implementation plan under the gitignored `local-reference/` directory

## Validation

- `make check`
- `make test` (`533 passed, 1 deselected`)
- `make docs-test`
- rendered all 17 Mermaid diagrams successfully
- independent architecture review: no remaining P0-P3 findings
