### PR TITLE
feat: capability-scope permission model (read-only default)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,10 @@ IMAP-only does not mean read-only. These tools can still change mailbox state:
 - `archive_emails`
 - `delete_emails`
 
+They remain gated by [permission scopes](security.md#permission-scopes), so under
+the read-only default they stay hidden until you grant `draft`, `organize`, or
+`delete`.
+
 See [IMAP-only accounts](guides.md#imap-only-accounts) for examples.
 
 ## Saving sent email
@@ -197,13 +201,14 @@ environment equivalents are `MCP_EMAIL_SERVER_SAVE_TO_SENT` and
 
 ## Global settings
 
-| Setting                      | Default  | Description                                                                |
-| ---------------------------- | -------- | -------------------------------------------------------------------------- |
-| `credential_storage`         | `"auto"` | Select `auto`, `keyring`, or `plaintext` credential storage.               |
-| `enable_attachment_download` | `false`  | Allow `download_attachment` to write files.                                |
-| `allowed_recipients`         | `[]`     | Restrict recipients used by `send_email` and `save_to_mailbox`.            |
-| `allowed_senders`            | `[]`     | Restrict incoming messages by `From` address pattern.                      |
-| `report_blocked_mutations`   | `false`  | Report blocked message IDs instead of returning privacy-preserving no-ops. |
+| Setting                      | Default    | Description                                                                                                        |
+| ---------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------ |
+| `permissions`                | `["read"]` | Capability scopes that expose tools; read-only by default. See [Permission scopes](security.md#permission-scopes). |
+| `credential_storage`         | `"auto"`   | Select `auto`, `keyring`, or `plaintext` credential storage.                                                       |
+| `enable_attachment_download` | `false`    | Allow `download_attachment` to write files.                                                                        |
+| `allowed_recipients`         | `[]`       | Restrict recipients used by `send_email` and `save_to_mailbox`.                                                    |
+| `allowed_senders`            | `[]`       | Restrict incoming messages by `From` address pattern.                                                              |
+| `report_blocked_mutations`   | `false`    | Report blocked message IDs instead of returning privacy-preserving no-ops.                                         |
 
 See [Security](security.md) before enabling attachment downloads or applying
 allowlists.
@@ -241,15 +246,16 @@ values are treated as false. Do not add surrounding whitespace to these values.
 
 ### Global variables
 
-| Variable                                      | Default                                  | Description                                                               |
-| --------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
-| `MCP_EMAIL_SERVER_CONFIG_PATH`                | `~/.config/mcp-email-server/config.toml` | Use a custom TOML path.                                                   |
-| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | `false`                                  | Override attachment download access.                                      |
-| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Empty                                    | Comma-separated recipient addresses; an empty value clears the TOML list. |
-| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Empty                                    | Comma-separated sender globs; an empty value clears the TOML list.        |
-| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | `false`                                  | Override blocked mutation reporting.                                      |
-| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | TOML value or `auto`                     | Override credential storage with `auto`, `keyring`, or `plaintext`.       |
-| `MCP_EMAIL_SERVER_LOG_LEVEL`                  | `INFO`                                   | Set the Loguru logging level, such as `DEBUG` or `WARNING`.               |
+| Variable                                      | Default                                  | Description                                                                                                                    |
+| --------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `MCP_EMAIL_SERVER_CONFIG_PATH`                | `~/.config/mcp-email-server/config.toml` | Use a custom TOML path.                                                                                                        |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | `false`                                  | Override attachment download access.                                                                                           |
+| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Empty                                    | Comma-separated recipient addresses; an empty value clears the TOML list.                                                      |
+| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Empty                                    | Comma-separated sender globs; an empty value clears the TOML list.                                                             |
+| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | `false`                                  | Override blocked mutation reporting.                                                                                           |
+| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | TOML value or `auto`                     | Override credential storage with `auto`, `keyring`, or `plaintext`.                                                            |
+| `MCP_EMAIL_SERVER_PERMISSIONS`                | TOML value or `read`                     | Comma-separated capability scopes; an empty value resets to read-only. See [Permission scopes](security.md#permission-scopes). |
+| `MCP_EMAIL_SERVER_LOG_LEVEL`                  | `INFO`                                   | Set the Loguru logging level, such as `DEBUG` or `WARNING`.                                                                    |
 
 HTTP transport variables are documented separately in
 [Transports](transports.md#streamable-http).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,8 +75,10 @@ After restarting the client:
    `list_available_accounts`.
 2. Ask it to list recent messages for the configured account. This calls
    `list_emails_metadata`.
-3. If SMTP is configured, ask which email tools are available and confirm that
-   `send_email` is present.
+3. Ask which email tools are available. The server is **read-only by default**,
+   so only read tools appear until you grant
+   [permission scopes](security.md#permission-scopes). With the `send` scope and
+   an SMTP-configured account, `send_email` also appears.
 
 If the account is listed but a mail operation fails, check the IMAP or SMTP
 host, port, TLS mode, username, and password. See
@@ -151,5 +153,6 @@ effective environment settings is intended.
 
 - [Configure multiple accounts or advanced TLS settings](configuration.md)
 - [Review the available MCP tools](tools.md)
+- [Grant permission scopes to organize, delete, or send mail](security.md#permission-scopes)
 - [Apply recipient or sender allowlists](security.md)
 - [Run an HTTP transport](transports.md)

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -44,9 +44,11 @@ Or configure one through environment variables without
 ```
 
 If no configured account has SMTP, `send_email` is omitted from the MCP tool
-list. IMAP mutation tools remain available, so this is not a strict read-only
-mode. To limit mutations, also constrain which MCP tools the client may call or
-run the server with an account whose provider permissions are read-only.
+list. IMAP mutation tools such as `move_emails` and `delete_emails` are still
+governed by [permission scopes](security.md#permission-scopes): under the
+read-only default they stay hidden until you grant `organize`, `delete`, or
+`draft`, so an IMAP-only account is read-only unless you opt in. Provider-side
+read-only credentials remain a useful defense in depth.
 
 ## ProtonMail Bridge and self-signed TLS
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,6 +4,44 @@ An email MCP server can read private messages, modify mailboxes, send messages,
 and access local files. Review the controls on this page before exposing it to
 an MCP client or network.
 
+## Permission scopes
+
+The server is **read-only by default**. Every mutating tool is gated behind a
+capability scope: a fresh install can list and read mail, mailboxes, and
+attachments, but cannot organize, delete, or send until you grant more. Tools
+outside the granted scopes are hidden from the tool list _and_ rejected if a
+client calls them anyway.
+
+| Scope      | Grants                                                                                  |
+| ---------- | --------------------------------------------------------------------------------------- |
+| `read`     | Always granted: list and read mail, mailboxes, and attachments.                         |
+| `draft`    | `save_to_mailbox`, restricted to drafts-type folders unless `organize` is also granted. |
+| `organize` | `move_emails`, `archive_emails`, `mark_emails_as_read`.                                 |
+| `delete`   | `delete_emails`.                                                                        |
+| `send`     | `send_email`.                                                                           |
+| `manage`   | `add_email_account`.                                                                    |
+| `full`     | Every scope above.                                                                      |
+
+Set scopes with the `permissions` setting:
+
+```toml
+permissions = ["read", "draft", "send"]  # read, draft, and send; never delete or move
+```
+
+Or with the `MCP_EMAIL_SERVER_PERMISSIONS` environment variable (comma-separated),
+which overrides the TOML value:
+
+```bash
+MCP_EMAIL_SERVER_PERMISSIONS=read,organize,delete
+```
+
+An empty value resets to the read-only default, and unknown scope names are
+rejected at startup. Scopes compose with the feature-based visibility gates: a
+tool appears only when its scope is granted _and_ any other condition is met (for
+example, `send_email` also needs an SMTP-configured account). Upgrading from a
+version without scopes? Set `permissions = ["full"]` to restore the previous
+always-on behavior.
+
 ## Credential storage
 
 Persistent configuration is stored in

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -191,6 +191,11 @@ The tool list adapts to the active configuration:
 `download_attachment` is not hidden when disabled; it checks permission when
 called.
 
+Tool visibility is also gated by [permission scopes](security.md#permission-scopes).
+The server is read-only by default, so `save_to_mailbox` and the mutation and send
+tools appear only when their scope (`draft`, `organize`, `delete`, or `send`) is
+granted — in addition to any condition in the table above.
+
 ## Reply threading
 
 To preserve conversation threading:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -132,9 +132,12 @@ account supplied solely through environment variables.
 
 ## `send_email` is missing
 
-`send_email` is advertised only when at least one configured account contains
-an SMTP `outgoing` section or `MCP_EMAIL_SERVER_SMTP_HOST` is set for the
-environment account.
+`send_email` is advertised only when the `send` scope is granted _and_ at least
+one configured account contains an SMTP `outgoing` section or
+`MCP_EMAIL_SERVER_SMTP_HOST` is set for the environment account. Because the
+server is read-only by default, the most common cause is a missing scope: add
+`send` (or `full`) to `permissions` or `MCP_EMAIL_SERVER_PERMISSIONS`. See
+[Permission scopes](security.md#permission-scopes).
 
 If the tool is visible but sending fails for one account, confirm that the
 selected `account_name` itself has SMTP settings. Visibility is based on all

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable
 from datetime import datetime
 from email.utils import getaddresses
@@ -38,6 +39,34 @@ def _has_allowed_recipients() -> bool:
 
 def _has_allowed_senders() -> bool:
     return bool(get_settings().allowed_senders)
+
+
+def _scope_granted(scope: str) -> bool:
+    return get_settings().has_scope(scope)
+
+
+def _scope_visible(scope: str) -> ToolVisibilityPredicate:
+    return lambda: _scope_granted(scope)
+
+
+def _require_scope(scope: str) -> None:
+    """Call-time enforcement backing the visibility predicates.
+
+    Hiding a tool from list_tools() is cosmetic — a client can still invoke it by
+    name — so every scoped tool re-checks its scope here.
+    """
+    if not _scope_granted(scope):
+        raise PermissionError(
+            f"Permission scope '{scope}' is not granted. Add '{scope}' (or 'full') to the "
+            "'permissions' list in the config file or the MCP_EMAIL_SERVER_PERMISSIONS "
+            "environment variable."
+        )
+
+
+def _is_drafts_mailbox(mailbox: str) -> bool:
+    """True if the mailbox's leaf name is a drafts folder (e.g. Drafts, INBOX.Drafts, [Gmail]/Drafts)."""
+    leaf = re.split(r"[./]", mailbox)[-1].strip().strip('"').lower()
+    return leaf in ("draft", "drafts")
 
 
 def _enforce_recipient_allowlist(
@@ -116,8 +145,12 @@ async def list_available_accounts() -> list[AccountAttributes]:
     return [account.masked() for account in settings.get_accounts()]
 
 
-@mcp.tool(description="Add a new email account configuration to the settings.")
+@mcp.tool(
+    description="Add a new email account configuration to the settings. Requires the 'manage' permission scope.",
+    visible_if=_scope_visible("manage"),
+)
 async def add_email_account(email: EmailSettings) -> str:
+    _require_scope("manage")
     settings = get_settings()
     try:
         settings.add_email(email)
@@ -254,6 +287,10 @@ async def get_emails_content(
         ),
     ] = 20000,
 ) -> EmailContentBatchResponse:
+    # mark_as_read is a flag mutation smuggled into a read tool; hold it to the
+    # same scope as mark_emails_as_read.
+    if mark_as_read:
+        _require_scope("organize")
     handler = dispatch_handler(account_name)
     return await handler.get_emails_content(email_ids, mailbox, mark_as_read, body_offset, max_body_length)
 
@@ -285,7 +322,7 @@ async def list_allowed_senders() -> list[str]:
 
 @mcp.tool(
     description="Send an email using the specified account. Supports replying to emails with proper threading when in_reply_to is provided.",
-    visible_if=_has_send_capable_account,
+    visible_if=lambda: _scope_granted("send") and _has_send_capable_account(),
 )
 async def send_email(
     account_name: Annotated[str, Field(description="The name of the email account to send from.")],
@@ -333,6 +370,7 @@ async def send_email(
         ),
     ] = None,
 ) -> str:
+    _require_scope("send")
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
     await handler.send_email(
@@ -357,7 +395,10 @@ async def send_email(
     "Shares recipient, body, attachment, and threading parameters with send_email; "
     "adds mailbox and flags, and does not support reply_to. "
     "Default folder is Drafts with \\Draft and \\Seen flags. "
-    "Pure IMAP operation — works without SMTP configuration.",
+    "Pure IMAP operation — works without SMTP configuration. "
+    "With only the 'draft' permission scope, the target folder is restricted to drafts-type "
+    "folders; the 'organize' scope lifts that restriction.",
+    visible_if=lambda: _scope_granted("draft"),
 )
 async def save_to_mailbox(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -412,6 +453,12 @@ async def save_to_mailbox(
         ),
     ] = None,
 ) -> str:
+    _require_scope("draft")
+    if not _scope_granted("organize") and not _is_drafts_mailbox(mailbox):
+        raise PermissionError(
+            f"With only the 'draft' scope, save_to_mailbox may target only drafts-type folders, "
+            f"not '{mailbox}'. Grant the 'organize' scope to save to arbitrary folders."
+        )
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
     result = await handler.save_to_mailbox(
@@ -435,7 +482,8 @@ async def save_to_mailbox(
 
 
 @mcp.tool(
-    description="Delete one or more emails by their email_id. Use list_emails_metadata first to get the email_id."
+    description="Delete one or more emails by their email_id. Use list_emails_metadata first to get the email_id.",
+    visible_if=_scope_visible("delete"),
 )
 async def delete_emails(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -445,6 +493,7 @@ async def delete_emails(
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to delete emails from.")] = "INBOX",
 ) -> str:
+    _require_scope("delete")
     handler = dispatch_handler(account_name)
     deleted_ids, failed_ids = await handler.delete_emails(email_ids, mailbox)
 
@@ -455,7 +504,8 @@ async def delete_emails(
 
 
 @mcp.tool(
-    description="Mark one or more emails as read by their email_id. Use list_emails_metadata first to get the email_id."
+    description="Mark one or more emails as read by their email_id. Use list_emails_metadata first to get the email_id.",
+    visible_if=_scope_visible("organize"),
 )
 async def mark_emails_as_read(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -465,6 +515,7 @@ async def mark_emails_as_read(
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The mailbox containing the emails.")] = "INBOX",
 ) -> str:
+    _require_scope("organize")
     handler = dispatch_handler(account_name)
     marked_ids, failed_ids = await handler.mark_emails_as_read(email_ids, mailbox)
 
@@ -475,7 +526,8 @@ async def mark_emails_as_read(
 
 
 @mcp.tool(
-    description="Move one or more emails between IMAP folders by their email_id. Use list_emails_metadata first to get the email_id and list_mailboxes to discover available folders."
+    description="Move one or more emails between IMAP folders by their email_id. Use list_emails_metadata first to get the email_id and list_mailboxes to discover available folders.",
+    visible_if=_scope_visible("organize"),
 )
 async def move_emails(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -488,6 +540,7 @@ async def move_emails(
         str, Field(default="INBOX", description="The source mailbox containing the emails.")
     ] = "INBOX",
 ) -> str:
+    _require_scope("organize")
     handler = dispatch_handler(account_name)
     moved_ids, failed_ids = await handler.move_emails(email_ids, source_mailbox, destination_mailbox)
 
@@ -500,7 +553,8 @@ async def move_emails(
 @mcp.tool(
     description="Archive one or more emails by moving them to the account's Archive folder, "
     "auto-detected via the RFC 6154 \\Archive flag (falling back to common names like Archive or "
-    "[Gmail]/All Mail). Use list_emails_metadata first to get the email_id."
+    "[Gmail]/All Mail). Use list_emails_metadata first to get the email_id.",
+    visible_if=_scope_visible("organize"),
 )
 async def archive_emails(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -510,6 +564,7 @@ async def archive_emails(
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The source mailbox containing the emails.")] = "INBOX",
 ) -> str:
+    _require_scope("organize")
     handler = dispatch_handler(account_name)
     archived_ids, failed_ids, archive_folder = await handler.archive_emails(email_ids, mailbox)
 

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -14,7 +14,16 @@ from typing import Any, Literal, TypeGuard
 from zoneinfo import ZoneInfo
 
 import tomli_w
-from pydantic import BaseModel, Field, PrivateAttr, SecretStr, SerializationInfo, field_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    SecretStr,
+    SerializationInfo,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -34,6 +43,8 @@ _VALID_CREDENTIAL_STORAGE_MODES: tuple[CredentialStorage, ...] = ("auto", "keyri
 def _is_credential_storage_mode(value: str) -> TypeGuard[CredentialStorage]:
     return value in _VALID_CREDENTIAL_STORAGE_MODES
 
+
+_VALID_PERMISSION_SCOPES = ("read", "draft", "organize", "delete", "send", "manage", "full")
 
 # Set by Settings.load_for_migration() around construction so __init__ can skip
 # env-composited state (override pickup, env-account injection, allowlist/bool env
@@ -82,6 +93,17 @@ def _normalize_address_list(raw: Iterable[str]) -> list[str]:
 def _normalize_pattern_list(raw: Iterable[str]) -> list[str]:
     """Lowercase, strip, de-duplicate (order-preserving). Glob characters are preserved."""
     return list(dict.fromkeys(p.strip().lower() for p in raw if p.strip()))
+
+
+def _normalize_scope_list(raw: Iterable[str]) -> list[str]:
+    """Lowercase, strip, de-duplicate (order-preserving); reject unknown scope names."""
+    scopes = list(dict.fromkeys(s.strip().lower() for s in raw if s.strip()))
+    unknown = [s for s in scopes if s not in _VALID_PERMISSION_SCOPES]
+    if unknown:
+        raise ValueError(
+            f"Unknown permission scope(s): {', '.join(unknown)}; valid scopes are {', '.join(_VALID_PERMISSION_SCOPES)}"
+        )
+    return scopes
 
 
 def _reject_sentinel_secret(secret: SecretStr, label: str) -> None:
@@ -372,14 +394,21 @@ class Settings(BaseSettings):
     enable_attachment_download: bool = False
     allowed_recipients: list[str] = []
     allowed_senders: list[str] = []
+    # Capability scopes gating which MCP tools are exposed/callable. Default is
+    # read-only; "full" grants everything. See Settings.has_scope for semantics.
+    permissions: list[str] = ["read"]
     report_blocked_mutations: bool = False
     credential_storage: CredentialStorage = "auto"
 
-    # Env-var override for credential_storage. Kept separate from the loaded field
-    # so environment precedence is explicit. A later store serializes the effective
-    # value because the override controls the credential representation written to
-    # that same file; persisting the old mode would make the file self-contradictory.
+    # Env-var overrides kept off the persisted fields so a later store() never
+    # bakes a temporary override into the TOML (unlike the bool overrides below,
+    # which intentionally do persist). For permissions this matters doubly:
+    # persisting an env-granted "full" would silently escalate the on-disk config.
+    # _credential_storage_override controls the credential representation written
+    # to the file, so store() serializes the effective value rather than the old
+    # mode, which would otherwise make the file self-contradictory.
     _credential_storage_override: CredentialStorage | None = PrivateAttr(default=None)
+    _permissions_override: list[str] | None = PrivateAttr(default=None)
     _loaded_keyring_references: set[tuple[str, str]] = PrivateAttr(default_factory=set)
 
     model_config = SettingsConfigDict(toml_file=CONFIG_PATH, validate_assignment=True, revalidate_instances="always")
@@ -392,6 +421,27 @@ class Settings(BaseSettings):
         store() maps "auto" to a concrete backend via keyring_store.keyring_usable().
         """
         return self._credential_storage_override or self.credential_storage
+
+    @field_validator("permissions")
+    @classmethod
+    def _validate_permissions(cls, v: list[str]) -> list[str]:
+        """Normalize and reject unknown scopes on TOML load and on assignment."""
+        return _normalize_scope_list(v)
+
+    @property
+    def effective_permissions(self) -> list[str]:
+        """The scopes that actually govern tool access: env override, else the field."""
+        return self._permissions_override or self.permissions
+
+    def has_scope(self, scope: str) -> bool:
+        """Return True if the given capability scope is granted.
+
+        "read" is always granted; "full" grants every scope (including "manage").
+        """
+        granted = self.effective_permissions
+        if scope == "read" or "full" in granted:
+            return True
+        return scope in granted
 
     def _apply_bool_env_override(self, attr: str, env_var: str) -> None:
         value = os.getenv(env_var)
@@ -453,6 +503,13 @@ class Settings(BaseSettings):
         env_senders = os.getenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS")
         if env_senders is not None:
             self.allowed_senders = _normalize_pattern_list(env_senders.split(","))
+
+        # Environment variable overrides TOML (comma-separated); an empty string
+        # resets to the read-only default. Held in a PrivateAttr (not the field)
+        # so store() never persists the override.
+        env_permissions = os.getenv("MCP_EMAIL_SERVER_PERMISSIONS")
+        if env_permissions is not None:
+            self._permissions_override = _normalize_scope_list(env_permissions.split(",")) or ["read"]
 
         self._inject_env_account()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ os.environ["MCP_EMAIL_SERVER_LOG_LEVEL"] = "DEBUG"
 # performs best-effort keyring cleanup — a fixture-based guard could apply too late.
 # Individual tests override this via monkeypatch.setenv(...).
 os.environ["MCP_EMAIL_SERVER_CREDENTIAL_STORAGE"] = "plaintext"
+# The server defaults to read-only permissions; the pre-existing suite exercises
+# every tool, so grant everything at import time (same rationale as above).
+# Scope-specific tests override this via monkeypatch.setenv(...).
+os.environ["MCP_EMAIL_SERVER_PERMISSIONS"] = "full"
 
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/e2e/test_stdio_greenmail.py
+++ b/tests/e2e/test_stdio_greenmail.py
@@ -223,6 +223,10 @@ async def test_current_stdio_server_against_greenmail(tmp_path: Path) -> None:
         "MCP_EMAIL_SERVER_CONFIG_PATH": str(config_path),
         "MCP_EMAIL_SERVER_CREDENTIAL_STORAGE": "plaintext",
         "MCP_EMAIL_SERVER_LOG_LEVEL": "WARNING",
+        # The server is read-only by default; grant every capability scope so the
+        # end-to-end run can see and exercise the full tool surface (send, save,
+        # delete, move, ...).
+        "MCP_EMAIL_SERVER_PERMISSIONS": "full",
     })
     console_script = Path(sys.executable).with_name("mcp-email-server")
     assert console_script.is_file(), f"Installed console script not found: {console_script}"

--- a/tests/test_permission_scopes.py
+++ b/tests/test_permission_scopes.py
@@ -1,0 +1,308 @@
+"""Capability-scope permission model: config semantics, tool visibility, call-time enforcement."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_email_server import app as app_module
+from mcp_email_server.app import (
+    _is_drafts_mailbox,
+    add_email_account,
+    archive_emails,
+    delete_emails,
+    get_emails_content,
+    mark_emails_as_read,
+    move_emails,
+    save_to_mailbox,
+    send_email,
+)
+from mcp_email_server.config import EmailServer, EmailSettings, Settings
+
+READ_TOOLS = {
+    "list_available_accounts",
+    "list_emails_metadata",
+    "get_emails_content",
+    "list_mailboxes",
+    "download_attachment",
+}
+ORGANIZE_TOOLS = {"mark_emails_as_read", "move_emails", "archive_emails"}
+
+
+def make_settings(monkeypatch, scopes=None, send_capable=False):
+    """Real Settings with the given scopes and no env permissions override.
+
+    Settings' only source is the TOML file (init kwargs are ignored), so fields
+    are assigned post-construction; validate_assignment covers validation.
+    """
+    monkeypatch.delenv("MCP_EMAIL_SERVER_PERMISSIONS", raising=False)
+    settings = Settings()
+    if scopes is not None:
+        settings.permissions = scopes
+    if send_capable:
+        server = EmailServer(
+            user_name="u",
+            password="p",
+            host="mail.example.com",
+            port=993,
+            use_ssl=True,
+        )
+        settings.emails = [
+            EmailSettings(
+                account_name="acct",
+                full_name="U",
+                email_address="u@example.com",
+                incoming=server,
+                outgoing=server,
+            )
+        ]
+    return settings
+
+
+async def visible_tools(settings):
+    with patch("mcp_email_server.app.get_settings", return_value=settings):
+        return {tool.name for tool in await app_module.mcp.list_tools()}
+
+
+class TestScopeConfig:
+    def test_default_is_read_only(self, monkeypatch):
+        settings = make_settings(monkeypatch)
+        assert settings.permissions == ["read"]
+        assert settings.has_scope("read")
+        for scope in ("draft", "organize", "delete", "send", "manage"):
+            assert not settings.has_scope(scope)
+
+    def test_full_grants_everything(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["full"])
+        for scope in ("read", "draft", "organize", "delete", "send", "manage"):
+            assert settings.has_scope(scope)
+
+    def test_explicit_scopes_only(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["draft", "send"])
+        assert settings.has_scope("read")  # always implied
+        assert settings.has_scope("draft")
+        assert settings.has_scope("send")
+        for scope in ("organize", "delete", "manage"):
+            assert not settings.has_scope(scope)
+
+    def test_unknown_scope_rejected(self, monkeypatch):
+        with pytest.raises(ValueError, match="Unknown permission scope"):
+            make_settings(monkeypatch, ["write"])
+
+    def test_scopes_normalized(self, monkeypatch):
+        settings = make_settings(monkeypatch, [" Send ", "DELETE", "send"])
+        assert settings.permissions == ["send", "delete"]
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PERMISSIONS", "send, ORGANIZE")
+        settings = Settings()
+        assert settings.effective_permissions == ["send", "organize"]
+        assert settings.has_scope("send")
+        assert settings.has_scope("organize")
+        assert not settings.has_scope("delete")
+
+    def test_env_empty_string_resets_to_read_only(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PERMISSIONS", "")
+        settings = Settings()
+        settings.permissions = ["full"]  # env override still wins over the field
+        assert settings.effective_permissions == ["read"]
+        assert not settings.has_scope("send")
+
+    def test_env_unknown_scope_rejected(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PERMISSIONS", "admin")
+        with pytest.raises(ValueError, match="Unknown permission scope"):
+            Settings()
+
+    def test_env_override_not_persisted_by_store(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_PERMISSIONS", "full")
+        cfg = tmp_path / "config.toml"
+        monkeypatch.setitem(Settings.model_config, "toml_file", cfg)
+        settings = Settings()
+        assert settings.has_scope("delete")  # env grants full at runtime
+        settings.store()
+        import tomllib
+
+        stored = tomllib.loads(cfg.read_text())
+        assert stored["permissions"] == ["read"]
+
+
+class TestDraftsMailboxDetection:
+    @pytest.mark.parametrize(
+        "mailbox", ["Drafts", "drafts", "Draft", "INBOX.Drafts", "[Gmail]/Drafts", '"Drafts"', "INBOX/Drafts"]
+    )
+    def test_drafts_folders(self, mailbox):
+        assert _is_drafts_mailbox(mailbox)
+
+    @pytest.mark.parametrize("mailbox", ["INBOX", "Sent", "Drafts2", "Archive", "INBOX.Drafts.Old"])
+    def test_non_drafts_folders(self, mailbox):
+        assert not _is_drafts_mailbox(mailbox)
+
+
+class TestToolVisibility:
+    @pytest.mark.asyncio
+    async def test_read_only_hides_all_mutation_tools(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, send_capable=True))
+        assert tools >= READ_TOOLS
+        assert not (ORGANIZE_TOOLS & tools)
+        for hidden in ("delete_emails", "send_email", "save_to_mailbox", "add_email_account"):
+            assert hidden not in tools
+
+    @pytest.mark.asyncio
+    async def test_full_shows_everything(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, ["full"], send_capable=True))
+        assert tools >= READ_TOOLS | ORGANIZE_TOOLS
+        for name in ("delete_emails", "send_email", "save_to_mailbox", "add_email_account"):
+            assert name in tools
+
+    @pytest.mark.asyncio
+    async def test_organize_without_delete(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, ["organize"]))
+        assert tools >= ORGANIZE_TOOLS
+        assert "delete_emails" not in tools
+
+    @pytest.mark.asyncio
+    async def test_send_without_delete(self, monkeypatch):
+        tools = await visible_tools(make_settings(monkeypatch, ["send"], send_capable=True))
+        assert "send_email" in tools
+        assert "delete_emails" not in tools
+        assert "save_to_mailbox" not in tools
+
+    @pytest.mark.asyncio
+    async def test_send_scope_still_requires_send_capable_account(self, monkeypatch):
+        # send_email needs an SMTP-capable account. save_to_mailbox is a pure IMAP
+        # operation (decoupled from SMTP in #194) and stays visible on the draft
+        # scope alone, independent of send capability.
+        tools = await visible_tools(make_settings(monkeypatch, ["send", "draft"]))
+        assert "send_email" not in tools
+        assert "save_to_mailbox" in tools
+
+    @pytest.mark.asyncio
+    async def test_manage_gates_add_email_account(self, monkeypatch):
+        assert "add_email_account" in await visible_tools(make_settings(monkeypatch, ["manage"]))
+        assert "add_email_account" not in await visible_tools(make_settings(monkeypatch, ["send", "delete"]))
+
+
+class TestCallTimeEnforcement:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "tool,kwargs",
+        [
+            (delete_emails, {"account_name": "a", "email_ids": ["1"]}),
+            (mark_emails_as_read, {"account_name": "a", "email_ids": ["1"]}),
+            (move_emails, {"account_name": "a", "email_ids": ["1"], "destination_mailbox": "X"}),
+            (archive_emails, {"account_name": "a", "email_ids": ["1"]}),
+            (send_email, {"account_name": "a", "recipients": ["x@example.com"], "subject": "s", "body": "b"}),
+        ],
+    )
+    async def test_mutation_tools_blocked_read_only(self, monkeypatch, tool, kwargs):
+        settings = make_settings(monkeypatch)
+        mock_handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            with pytest.raises(PermissionError, match="not granted"):
+                await tool(**kwargs)
+        assert not mock_handler.method_calls
+
+    @pytest.mark.asyncio
+    async def test_add_email_account_blocked_without_manage(self, monkeypatch, email_settings):
+        settings = make_settings(monkeypatch, ["send", "delete"])
+        with patch("mcp_email_server.app.get_settings", return_value=settings):
+            with pytest.raises(PermissionError, match="'manage'"):
+                await add_email_account(email_settings)
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_mark_as_read_needs_organize(self, monkeypatch):
+        settings = make_settings(monkeypatch)
+        mock_handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            with pytest.raises(PermissionError, match="'organize'"):
+                await get_emails_content(account_name="a", email_ids=["1"], mark_as_read=True)
+        mock_handler.get_emails_content.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_plain_read_allowed_read_only(self, monkeypatch):
+        settings = make_settings(monkeypatch)
+        mock_handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            await get_emails_content(account_name="a", email_ids=["1"])
+        mock_handler.get_emails_content.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_emails_content_mark_as_read_allowed_with_organize(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["organize"])
+        mock_handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            await get_emails_content(account_name="a", email_ids=["1"], mark_as_read=True)
+        mock_handler.get_emails_content.assert_called_once()
+
+
+class TestDraftScopeFolderRestriction:
+    def _mock_handler(self):
+        handler = AsyncMock()
+        handler.save_to_mailbox.return_value = "<msg-id>|uid:7"
+        return handler
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mailbox", ["Drafts", "INBOX.Drafts", "[Gmail]/Drafts"])
+    async def test_draft_only_allows_drafts_folders(self, monkeypatch, mailbox):
+        settings = make_settings(monkeypatch, ["draft"], send_capable=True)
+        mock_handler = self._mock_handler()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            result = await save_to_mailbox(
+                account_name="a", recipients=["x@example.com"], subject="s", body="b", mailbox=mailbox
+            )
+        assert "saved" in result
+        mock_handler.save_to_mailbox.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("mailbox", ["INBOX", "Sent", "Archive"])
+    async def test_draft_only_blocks_other_folders(self, monkeypatch, mailbox):
+        settings = make_settings(monkeypatch, ["draft"], send_capable=True)
+        mock_handler = self._mock_handler()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            with pytest.raises(PermissionError, match="drafts-type"):
+                await save_to_mailbox(
+                    account_name="a", recipients=["x@example.com"], subject="s", body="b", mailbox=mailbox
+                )
+        mock_handler.save_to_mailbox.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_draft_plus_organize_allows_any_folder(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["draft", "organize"], send_capable=True)
+        mock_handler = self._mock_handler()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            result = await save_to_mailbox(
+                account_name="a", recipients=["x@example.com"], subject="s", body="b", mailbox="Templates"
+            )
+        assert "saved" in result
+
+    @pytest.mark.asyncio
+    async def test_save_to_mailbox_blocked_without_draft_scope(self, monkeypatch):
+        settings = make_settings(monkeypatch, ["organize"], send_capable=True)
+        mock_handler = self._mock_handler()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=mock_handler),
+        ):
+            with pytest.raises(PermissionError, match="'draft'"):
+                await save_to_mailbox(account_name="a", recipients=["x@example.com"], subject="s", body="b")
+        mock_handler.save_to_mailbox.assert_not_called()


### PR DESCRIPTION
## What this delivers

A **capability-scope permission model** for the email tools, rebased cleanly onto current `main` and with docs harmonized into the new multi-file `docs/` structure (post-#205).

**This supersedes #200**, which was branched a week ago and now conflicts with the docs reorganization (#205) and tooling changes (#204). Same feature, cleanly re-homed.

### The feature
The server is **read-only by default**. Every mutating tool is gated behind a capability scope, set via the `permissions` config field or `MCP_EMAIL_SERVER_PERMISSIONS`. Out-of-scope tools are hidden from the tool list _and_ rejected at call time.

| Scope | Grants |
|---|---|
| `read` | Always granted: list/read mail, mailboxes, attachments |
| `draft` | `save_to_mailbox` (drafts-type folders unless `organize` also granted) |
| `organize` | `move_emails`, `archive_emails`, `mark_emails_as_read` |
| `delete` | `delete_emails` |
| `send` | `send_email` |
| `manage` | `add_email_account` |
| `full` | Everything |

Upgrading from a pre-scopes version? Set `permissions = ["full"]` to restore prior behavior.

### Rebase notes (adopts upstream's current shape)
- Uses upstream's typed `CredentialStorage` and its refactored `DEFAULT_CONFIG_PATH`; adds only `_VALID_PERMISSION_SCOPES` and `_permissions_override`.
- Docs distributed the idiomatic way: `security.md` gets the substantive **Permission scopes** section; `configuration.md` gets the setting + env-var rows; `tools.md` notes scope-gating in "Conditional tools"; `getting-started.md` gets a read-only note.
- Fixed three now-stale passages the read-only default invalidated: getting-started verify step, the `send_email is missing` troubleshooting entry, and the guides.md "IMAP mutation tools always available" claim.

## Test plan
- [x] `uv run pytest -q` — **577 passed**
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run pyright` — **0 errors** (the check added in #204)
- [x] `mkdocs build --strict` — builds, no broken anchors
- [x] `prettier --check docs/*.md` — clean

Security hardening (the former #201) will follow as a separate rebased PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pd8meRq4jSiqaLq715nSD
