### PR TITLE
security: download-path confinement, CRLF rejection, resource limits

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,13 +197,14 @@ environment equivalents are `MCP_EMAIL_SERVER_SAVE_TO_SENT` and
 
 ## Global settings
 
-| Setting                      | Default  | Description                                                                |
-| ---------------------------- | -------- | -------------------------------------------------------------------------- |
-| `credential_storage`         | `"auto"` | Select `auto`, `keyring`, or `plaintext` credential storage.               |
-| `enable_attachment_download` | `false`  | Allow `download_attachment` to write files.                                |
-| `allowed_recipients`         | `[]`     | Restrict recipients used by `send_email` and `save_to_mailbox`.            |
-| `allowed_senders`            | `[]`     | Restrict incoming messages by `From` address pattern.                      |
-| `report_blocked_mutations`   | `false`  | Report blocked message IDs instead of returning privacy-preserving no-ops. |
+| Setting                      | Default       | Description                                                                                                                  |
+| ---------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `credential_storage`         | `"auto"`      | Select `auto`, `keyring`, or `plaintext` credential storage.                                                                 |
+| `enable_attachment_download` | `false`       | Allow `download_attachment` to write files.                                                                                  |
+| `attachment_download_dir`    | `~/Downloads` | Directory that `download_attachment` save paths must resolve within. See [Attachment access](security.md#attachment-access). |
+| `allowed_recipients`         | `[]`          | Restrict recipients used by `send_email` and `save_to_mailbox`.                                                              |
+| `allowed_senders`            | `[]`          | Restrict incoming messages by `From` address pattern.                                                                        |
+| `report_blocked_mutations`   | `false`       | Report blocked message IDs instead of returning privacy-preserving no-ops.                                                   |
 
 See [Security](security.md) before enabling attachment downloads or applying
 allowlists.
@@ -241,15 +242,16 @@ values are treated as false. Do not add surrounding whitespace to these values.
 
 ### Global variables
 
-| Variable                                      | Default                                  | Description                                                               |
-| --------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
-| `MCP_EMAIL_SERVER_CONFIG_PATH`                | `~/.config/mcp-email-server/config.toml` | Use a custom TOML path.                                                   |
-| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | `false`                                  | Override attachment download access.                                      |
-| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Empty                                    | Comma-separated recipient addresses; an empty value clears the TOML list. |
-| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Empty                                    | Comma-separated sender globs; an empty value clears the TOML list.        |
-| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | `false`                                  | Override blocked mutation reporting.                                      |
-| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | TOML value or `auto`                     | Override credential storage with `auto`, `keyring`, or `plaintext`.       |
-| `MCP_EMAIL_SERVER_LOG_LEVEL`                  | `INFO`                                   | Set the Loguru logging level, such as `DEBUG` or `WARNING`.               |
+| Variable                                      | Default                                  | Description                                                                              |
+| --------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `MCP_EMAIL_SERVER_CONFIG_PATH`                | `~/.config/mcp-email-server/config.toml` | Use a custom TOML path.                                                                  |
+| `MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD` | `false`                                  | Override attachment download access.                                                     |
+| `MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR`    | `~/Downloads`                            | Directory `download_attachment` save paths must resolve within; empty resets to default. |
+| `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS`         | Empty                                    | Comma-separated recipient addresses; an empty value clears the TOML list.                |
+| `MCP_EMAIL_SERVER_ALLOWED_SENDERS`            | Empty                                    | Comma-separated sender globs; an empty value clears the TOML list.                       |
+| `MCP_EMAIL_SERVER_REPORT_BLOCKED_MUTATIONS`   | `false`                                  | Override blocked mutation reporting.                                                     |
+| `MCP_EMAIL_SERVER_CREDENTIAL_STORAGE`         | TOML value or `auto`                     | Override credential storage with `auto`, `keyring`, or `plaintext`.                      |
+| `MCP_EMAIL_SERVER_LOG_LEVEL`                  | `INFO`                                   | Set the Loguru logging level, such as `DEBUG` or `WARNING`.                              |
 
 HTTP transport variables are documented separately in
 [Transports](transports.md#streamable-http).

--- a/docs/security.md
+++ b/docs/security.md
@@ -218,16 +218,34 @@ Or:
 MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD=true
 ```
 
-Use an absolute destination path with `download_attachment` so the target is
-unambiguous. The implementation also accepts relative paths and resolves them
-against the server process's working directory. Run the server with filesystem
-permissions that limit where it can write, and do not assume attachments are
-safe to open or execute.
+`download_attachment` writes only inside `attachment_download_dir` (default
+`~/Downloads`). Because attachment bytes are attacker-controlled — anyone can
+email you a file — a `save_path` that resolves outside that directory, including
+through `..` or a symlink, is rejected. This prevents the tool from being steered
+into overwriting files such as `~/.ssh/authorized_keys`, a crontab, or the
+configuration file. A relative `save_path` resolves under the directory. Set the
+directory with `attachment_download_dir` or
+`MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR`; an empty value resets to the default.
+Still run the server with filesystem permissions appropriate to that directory,
+and do not assume attachments are safe to open or execute.
 
 The separate `attachments` parameter on `send_email` and `save_to_mailbox`
 reads local file paths. Relative paths are likewise resolved against the server
 process's working directory. Only connect clients that should be trusted to
 request access to files visible to that process.
+
+## Message and input limits
+
+Carriage-return and line-feed characters are rejected in recipient addresses,
+header values, and attachment paths. This closes SMTP-envelope and header
+injection — including through `bcc`, which is handed to the SMTP layer without
+being placed in a header and would otherwise let a newline inject extra
+commands or recipients.
+
+Tool inputs are bounded so a single call cannot exhaust memory:
+`list_emails_metadata` caps `page_size` at 500, batch tools accept at most 100
+`email_ids` per call, and `download_attachment` rejects attachments larger than
+25 MB.
 
 ## TLS certificate verification
 
@@ -256,9 +274,13 @@ Limit this exception to the specific local connection. See
 ## HTTP transport security
 
 SSE and Streamable HTTP validate `Host` and `Origin` headers by default to
-reduce DNS rebinding risk. Network exposure still requires appropriate
-authentication, authorization, TLS termination, and firewall policy around the
-server.
+reduce DNS rebinding risk. That validation is **not authentication**: the
+transports ship no token or auth layer, so any non-loopback bind
+(`MCP_HOST=0.0.0.0`, a LAN IP, or a published container) exposes every email
+tool — read, send, delete — to whatever can reach the port. Put your own
+authentication in front of it (an authenticating reverse proxy, mTLS, or a
+private network) and terminate TLS there.
 
-See [Transports](transports.md#dns-rebinding-protection) for allowed host and
-origin settings.
+See [DNS rebinding protection](transports.md#dns-rebinding-protection) for why
+`Host`/`Origin` checks are not a substitute for authentication, plus allowed
+host and origin settings.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -164,9 +164,10 @@ blocked IDs.
 
 ### `download_attachment`
 
-Downloads one named attachment from a message and writes it to a path on the
-server host. Use an absolute path when possible. A relative path is resolved
-against the server process's working directory.
+Downloads one named attachment from a message and writes it inside
+`attachment_download_dir` (default `~/Downloads`). A relative `save_path`
+resolves under that directory, and a path that escapes it — via `..` or a
+symlink — is rejected. See [Attachment access](security.md#attachment-access).
 
 The tool is registered even when downloading is disabled, but calling it then
 raises a permission error. Enable it explicitly with:

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -99,6 +99,16 @@ Explicit `--host` and `--port` options override those defaults.
 Both HTTP transports validate `Host` and `Origin` headers by default. Loopback
 hosts and origins are allowed for local use.
 
+> **`Host`/`Origin` validation is not authentication.** It defends against
+> browser-driven DNS rebinding, not a direct network attacker. The `Host` header
+> is attacker-supplied: with a wildcard bind (`0.0.0.0`/`::`) the allowlist falls
+> back to loopback names, so anyone who reaches the port can send `Host: localhost`
+> and pass; a concrete LAN-IP bind auto-allows that IP, so `Host: <lan-ip>` passes
+> too. Once past the check, every email tool — read, send, delete — is reachable
+> with no credentials. Treat any non-loopback bind as an unauthenticated email
+> gateway and put real authentication (a token-checking reverse proxy, mTLS, or a
+> private network) in front of it.
+
 When binding to a named non-loopback host, that host is included in the derived
 allowlist. When binding to a wildcard address such as `0.0.0.0` or `::`, the
 server cannot infer the public hostname. Configure the expected service names

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -186,9 +186,11 @@ Or:
 MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD=true
 ```
 
-Use an absolute `save_path` when possible and ensure the server process can
-write to its parent directory. A relative path is resolved against the server
-process's working directory.
+The `save_path` must resolve within `attachment_download_dir` (default
+`~/Downloads`); a path outside it is rejected with a `PermissionError`. Set
+`attachment_download_dir` or `MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR` to permit
+another location, and ensure the server process can write there. A relative
+`save_path` resolves under that directory.
 
 ## A message mutation reports success but nothing changed
 

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -1,6 +1,8 @@
-from collections.abc import Callable
+import os
+from collections.abc import Callable, Iterable
 from datetime import datetime
 from email.utils import getaddresses
+from pathlib import Path
 from typing import Annotated, Any, Literal
 
 from mcp.server.fastmcp import FastMCP
@@ -26,6 +28,10 @@ from mcp_email_server.emails.models import (
 AnyFunction = Callable[..., Any]
 ToolVisibilityPredicate = Callable[[], bool]
 
+# Resource-exhaustion ceilings on tool inputs (self-DoS guards).
+MAX_PAGE_SIZE = 500
+MAX_EMAIL_IDS_PER_CALL = 100
+
 
 def _has_send_capable_account() -> bool:
     settings = get_settings()
@@ -38,6 +44,46 @@ def _has_allowed_recipients() -> bool:
 
 def _has_allowed_senders() -> bool:
     return bool(get_settings().allowed_senders)
+
+
+def _resolve_download_path(save_path: str, root: Path) -> Path:
+    """Resolve save_path and confine it within root, resolving symlinks.
+
+    Relative paths resolve under root; absolute paths must already be within it.
+    The FULL candidate is canonicalised with realpath — including the final
+    component — so a symlink planted at the target path can't redirect the write
+    outside root. Raises PermissionError on any path that escapes root, or on a
+    path with no filename component.
+    """
+    candidate = Path(save_path).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    # realpath resolves symlinks in every component (the final one too); a
+    # non-existent trailing name is simply normalised, so a not-yet-created target
+    # still validates. This is what closes final-component symlink escapes.
+    resolved = Path(os.path.realpath(candidate))
+    if not resolved.is_relative_to(root):
+        raise PermissionError(
+            f"Attachment save_path {save_path!r} resolves outside the permitted download "
+            f"directory {root}. Set 'attachment_download_dir' (or "
+            "MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR) to permit it."
+        )
+    if resolved == root or not resolved.name:
+        raise PermissionError(f"Attachment save_path {save_path!r} must name a file, not the download directory.")
+    return resolved
+
+
+def _reject_crlf(values: Iterable[str | None], label: str) -> None:
+    """Raise ValueError if any value contains a CR or LF.
+
+    Header CRLF is caught by the stdlib email serializer, but SMTP-envelope
+    recipients (notably bcc, which is never placed in a header) are passed
+    straight to aiosmtplib, which writes RCPT TO raw without a CRLF check — so a
+    newline there injects extra SMTP commands/recipients. Reject at the boundary.
+    """
+    for value in values:
+        if value is not None and ("\r" in value or "\n" in value):
+            raise ValueError(f"{label} must not contain newline characters: {value!r}")
 
 
 def _enforce_recipient_allowlist(
@@ -141,9 +187,12 @@ async def list_emails_metadata(
     account_name: Annotated[str, Field(description="The name of the email account.")],
     page: Annotated[
         int,
-        Field(default=1, description="The page number to retrieve (starting from 1)."),
+        Field(default=1, ge=1, description="The page number to retrieve (starting from 1)."),
     ] = 1,
-    page_size: Annotated[int, Field(default=10, description="The number of emails to retrieve per page.")] = 10,
+    page_size: Annotated[
+        int,
+        Field(default=10, ge=1, le=MAX_PAGE_SIZE, description="The number of emails to retrieve per page (max 500)."),
+    ] = 10,
     before: Annotated[
         datetime | None,
         Field(default=None, description="Retrieve emails before this datetime (UTC)."),
@@ -221,7 +270,10 @@ async def get_emails_content(
     email_ids: Annotated[
         list[str],
         Field(
-            description="List of email_id to retrieve (obtained from list_emails_metadata). Can be a single email_id or multiple email_ids."
+            min_length=1,
+            max_length=MAX_EMAIL_IDS_PER_CALL,
+            description="List of email_id to retrieve (obtained from list_emails_metadata). Can be a single "
+            "email_id or multiple email_ids (max 100 per call).",
         ),
     ],
     mailbox: Annotated[str, Field(default="INBOX", description="The mailbox to retrieve emails from.")] = "INBOX",
@@ -333,6 +385,9 @@ async def send_email(
         ),
     ] = None,
 ) -> str:
+    _reject_crlf([*recipients, *(cc or []), *(bcc or [])], "Recipient address")
+    _reject_crlf([subject, in_reply_to, references, reply_to], "Header value")
+    _reject_crlf(attachments or [], "Attachment path")
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
     await handler.send_email(
@@ -412,6 +467,9 @@ async def save_to_mailbox(
         ),
     ] = None,
 ) -> str:
+    _reject_crlf([*recipients, *(cc or []), *(bcc or [])], "Recipient address")
+    _reject_crlf([subject, in_reply_to, references], "Header value")
+    _reject_crlf(attachments or [], "Attachment path")
     _enforce_recipient_allowlist(recipients, cc, bcc)
     handler = dispatch_handler(account_name)
     result = await handler.save_to_mailbox(
@@ -538,7 +596,9 @@ async def list_mailboxes(
 
 
 @mcp.tool(
-    description="Download an email attachment and save it to the specified path. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
+    description="Download an email attachment and save it under the permitted download directory. This "
+    "feature must be explicitly enabled in settings (enable_attachment_download=true). The save_path is "
+    "confined to attachment_download_dir (default ~/Downloads); paths resolving outside it are rejected.",
 )
 async def download_attachment(
     account_name: Annotated[str, Field(description="The name of the email account.")],
@@ -551,7 +611,8 @@ async def download_attachment(
     save_path: Annotated[
         str,
         Field(
-            description="The destination path. Relative paths are resolved against the server process working directory; absolute paths are recommended."
+            description="Where to save the attachment. Must resolve within the configured "
+            "attachment_download_dir (default ~/Downloads); a relative path is taken relative to it."
         ),
     ],
     mailbox: Annotated[str, Field(description="The mailbox to search in (default: INBOX).")] = "INBOX",
@@ -563,5 +624,6 @@ async def download_attachment(
         )
         raise PermissionError(msg)
 
+    confined_path = _resolve_download_path(save_path, settings.attachment_download_root)
     handler = dispatch_handler(account_name)
-    return await handler.download_attachment(email_id, attachment_name, save_path, mailbox)
+    return await handler.download_attachment(email_id, attachment_name, str(confined_path), mailbox)

--- a/mcp_email_server/config.py
+++ b/mcp_email_server/config.py
@@ -370,6 +370,10 @@ class Settings(BaseSettings):
     providers: list[ProviderSettings] = []
     db_location: str = CONFIG_PATH.with_name("db.sqlite3").as_posix()
     enable_attachment_download: bool = False
+    # Directory that download_attachment save paths must resolve within. Confines
+    # the arbitrary-filesystem-write primitive that enable_attachment_download opens
+    # up. Unset => defaults to ~/Downloads (see Settings.attachment_download_root).
+    attachment_download_dir: str | None = None
     allowed_recipients: list[str] = []
     allowed_senders: list[str] = []
     report_blocked_mutations: bool = False
@@ -392,6 +396,16 @@ class Settings(BaseSettings):
         store() maps "auto" to a concrete backend via keyring_store.keyring_usable().
         """
         return self._credential_storage_override or self.credential_storage
+
+    @property
+    def attachment_download_root(self) -> Path:
+        """Directory that download_attachment save paths must resolve within.
+
+        Defaults to ~/Downloads when unset. Fully resolved (symlinks included) so
+        callers can containment-check candidate paths against a canonical root.
+        """
+        raw = self.attachment_download_dir or "~/Downloads"
+        return Path(os.path.realpath(Path(raw).expanduser()))
 
     def _apply_bool_env_override(self, attr: str, env_var: str) -> None:
         value = os.getenv(env_var)
@@ -453,6 +467,11 @@ class Settings(BaseSettings):
         env_senders = os.getenv("MCP_EMAIL_SERVER_ALLOWED_SENDERS")
         if env_senders is not None:
             self.allowed_senders = _normalize_pattern_list(env_senders.split(","))
+
+        env_download_dir = os.getenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR")
+        if env_download_dir is not None:
+            # An empty string resets to the default (~/Downloads) rather than "".
+            self.attachment_download_dir = env_download_dir.strip() or None
 
         self._inject_env_account()
 

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -4,6 +4,7 @@ import binascii
 import email.utils
 import inspect
 import mimetypes
+import os
 import re
 import ssl
 import time
@@ -37,6 +38,16 @@ from mcp_email_server.log import logger
 
 # Maximum body length before truncation (characters)
 MAX_BODY_LENGTH = 20000
+
+# Maximum size of a single attachment, in bytes. On the outbound (send) path the
+# file is stat'd before it is read, so this genuinely caps memory. On the inbound
+# (download) path the message is already fetched, so this bounds what is written to
+# disk (it does not prevent the fetch itself from loading the message into memory).
+MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024
+
+# Aggregate cap across all attachments on a single outbound message.
+MAX_TOTAL_ATTACHMENT_BYTES = 50 * 1024 * 1024
+MAX_ATTACHMENT_COUNT = 50
 
 # Common Archive folder names, used as a fallback when no RFC 6154 \Archive flag is found.
 _ARCHIVE_FOLDER_CANDIDATES = ("Archive", "Archives", "[Gmail]/All Mail")
@@ -1090,6 +1101,23 @@ class EmailClient:
                 return bytes(item) if isinstance(item, bytearray) else item
         return None
 
+    def _find_attachment_in_message(self, email_message, attachment_name: str) -> tuple[bytes | None, str | None]:
+        """Return (data, mime_type) for the named attachment, or (None, None) if absent."""
+        normalized = self._normalize_attachment_name(attachment_name)
+        if not email_message.is_multipart():
+            return None, None
+        for part in email_message.walk():
+            # Match attachments listed by ``_parse_email_data`` — this includes
+            # inline-disposition parts with a filename (e.g. iOS Mail photos).
+            if not self._is_attachment_part(part):
+                continue
+            filename = part.get_filename()
+            if not isinstance(filename, str):
+                continue
+            if self._normalize_attachment_name(filename) == normalized:
+                return _decoded_payload(part), part.get_content_type()
+        return None, None
+
     async def _fetch_email_with_formats(self, imap, email_id: str) -> list | None:
         """Try non-mutating fetch formats to get email data."""
         fetch_formats = ["BODY.PEEK[]", "(BODY.PEEK[])"]
@@ -1218,34 +1246,31 @@ class EmailClient:
             parser = BytesParser(policy=default)
             email_message = parser.parsebytes(raw_email)
 
-            # Find the attachment
-            attachment_data: bytes | None = None
-            mime_type = None
-            normalized_attachment_name = self._normalize_attachment_name(attachment_name)
-
-            if email_message.is_multipart():
-                for part in email_message.walk():
-                    # Match attachments listed by ``_parse_email_data`` — this includes
-                    # inline-disposition parts with a filename (e.g. iOS Mail photos).
-                    if not self._is_attachment_part(part):
-                        continue
-                    filename = part.get_filename()
-                    if not isinstance(filename, str):
-                        continue
-                    if self._normalize_attachment_name(filename) == normalized_attachment_name:
-                        attachment_data = _decoded_payload(part)
-                        mime_type = part.get_content_type()
-                        break
+            attachment_data, mime_type = self._find_attachment_in_message(email_message, attachment_name)
 
             if attachment_data is None:
                 msg = f"Attachment '{attachment_name}' not found in email {email_id}"
                 logger.error(msg)
                 raise ValueError(msg)
 
-            # Save to disk
+            if len(attachment_data) > MAX_ATTACHMENT_BYTES:
+                msg = (
+                    f"Attachment '{attachment_name}' is {len(attachment_data)} bytes, "
+                    f"exceeding the {MAX_ATTACHMENT_BYTES}-byte limit"
+                )
+                logger.error(msg)
+                raise ValueError(msg)
+
+            # Save to disk. save_path is already confined to the download root by
+            # app._resolve_download_path; O_NOFOLLOW additionally refuses to follow a
+            # symlink swapped into the final component after that check (TOCTOU), and
+            # the attachment lands owner-only.
             save_file = Path(save_path)
             save_file.parent.mkdir(parents=True, exist_ok=True)
-            save_file.write_bytes(attachment_data)
+            open_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(save_file, open_flags, 0o600)
+            with os.fdopen(fd, "wb") as f:
+                f.write(attachment_data)
 
             logger.info(f"Attachment '{attachment_name}' saved to {save_path}")
 
@@ -1276,6 +1301,12 @@ class EmailClient:
             logger.error(msg)
             raise ValueError(msg)
 
+        size = path.stat().st_size
+        if size > MAX_ATTACHMENT_BYTES:
+            msg = f"Attachment {file_path} is {size} bytes, exceeding the {MAX_ATTACHMENT_BYTES}-byte limit"
+            logger.error(msg)
+            raise ValueError(msg)
+
         return path
 
     def _create_attachment_part(self, path: Path) -> MIMEApplication:
@@ -1298,16 +1329,31 @@ class EmailClient:
 
     def _create_message_with_attachments(self, body: str, html: bool, attachments: list[str]) -> MIMEMultipart:
         """Create multipart message with attachments."""
+        if len(attachments) > MAX_ATTACHMENT_COUNT:
+            msg = f"Too many attachments: {len(attachments)} (max {MAX_ATTACHMENT_COUNT})"
+            logger.error(msg)
+            raise ValueError(msg)
+
         msg = MIMEMultipart()
         content_type = "html" if html else "plain"
         text_part = MIMEText(body, content_type, "utf-8")
         msg.attach(text_part)
 
+        total_bytes = 0
         for file_path in attachments:
             try:
                 path = self._validate_attachment(file_path)
-                attachment_part = self._create_attachment_part(path)
-                msg.attach(attachment_part)
+                size = path.stat().st_size
+            except Exception as e:
+                logger.error(f"Failed to attach file {file_path}: {e}")
+                raise
+            total_bytes += size
+            if total_bytes > MAX_TOTAL_ATTACHMENT_BYTES:
+                # Checked via stat before the file is read, so an over-limit set is
+                # rejected without loading the offending file into memory.
+                raise ValueError(f"Total attachment size exceeds the {MAX_TOTAL_ATTACHMENT_BYTES}-byte limit")
+            try:
+                msg.attach(self._create_attachment_part(path))
             except Exception as e:
                 logger.error(f"Failed to attach file {file_path}: {e}")
                 raise

--- a/tests/e2e/test_stdio_greenmail.py
+++ b/tests/e2e/test_stdio_greenmail.py
@@ -223,6 +223,10 @@ async def test_current_stdio_server_against_greenmail(tmp_path: Path) -> None:
         "MCP_EMAIL_SERVER_CONFIG_PATH": str(config_path),
         "MCP_EMAIL_SERVER_CREDENTIAL_STORAGE": "plaintext",
         "MCP_EMAIL_SERVER_LOG_LEVEL": "WARNING",
+        # download_attachment confines save paths to attachment_download_dir
+        # (default ~/Downloads); point it at the test's tmp dir so the roundtrip
+        # download below is permitted instead of rejected.
+        "MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR": str(tmp_path),
     })
     console_script = Path(sys.executable).with_name("mcp-email-server")
     assert console_script.is_file(), f"Installed console script not found: {console_script}"

--- a/tests/test_crlf_injection.py
+++ b/tests/test_crlf_injection.py
@@ -1,0 +1,90 @@
+"""CRLF / SMTP-envelope injection hardening for send_email and save_to_mailbox."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_email_server.app import _reject_crlf, save_to_mailbox, send_email
+
+
+class TestRejectCrlfHelper:
+    @pytest.mark.parametrize("bad", ["a@b.com\r\nRSET", "a@b.com\nBcc: x@y.com", "x\ry", "line1\nline2"])
+    def test_rejects_newlines(self, bad):
+        with pytest.raises(ValueError, match="must not contain newline"):
+            _reject_crlf([bad], "Recipient address")
+
+    def test_allows_clean_values_and_none(self):
+        _reject_crlf(["a@b.com", "b@c.com", None], "Recipient address")  # no raise
+
+
+def _mock_send_settings():
+    settings = MagicMock()
+    settings.has_scope.return_value = True
+    settings.allowed_recipients = []
+    return settings
+
+
+class TestSendEmailCrlf:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"recipients": ["a@b.com\r\nRCPT TO:<evil@x.com>"]},
+            {"recipients": ["a@b.com"], "cc": ["c@d.com\nBcc: evil@x.com"]},
+            {"recipients": ["a@b.com"], "bcc": ["e@f.com\r\nDATA"]},
+            {"recipients": ["a@b.com"], "reply_to": "r@s.com\r\nX-Injected: 1"},
+            {"recipients": ["a@b.com"], "in_reply_to": "<id>\r\nX: y"},
+            {"recipients": ["a@b.com"], "attachments": ["/data/ok\r\n/etc/passwd"]},
+        ],
+    )
+    async def test_send_email_rejects_crlf(self, kwargs):
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=_mock_send_settings()),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(ValueError, match="must not contain newline"):
+                await send_email(account_name="a", subject="s", body="b", **kwargs)
+        handler.send_email.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_email_rejects_crlf_subject(self):
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=_mock_send_settings()),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(ValueError, match="must not contain newline"):
+                await send_email(account_name="a", recipients=["a@b.com"], subject="Hi\r\nBcc: evil@x.com", body="b")
+        handler.send_email.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_email_clean_passes(self):
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=_mock_send_settings()),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            await send_email(account_name="a", recipients=["a@b.com"], subject="s", body="b", bcc=["c@d.com"])
+        handler.send_email.assert_called_once()
+
+
+class TestSaveToMailboxCrlf:
+    @pytest.mark.asyncio
+    async def test_save_to_mailbox_rejects_crlf_bcc(self):
+        handler = AsyncMock()
+        handler.save_to_mailbox.return_value = "<id>|uid:1"
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=_mock_send_settings()),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(ValueError, match="must not contain newline"):
+                await save_to_mailbox(
+                    account_name="a",
+                    recipients=["a@b.com"],
+                    subject="s",
+                    body="b",
+                    mailbox="Drafts",
+                    bcc=["e@f.com\r\nRSET"],
+                )
+        handler.save_to_mailbox.assert_not_called()

--- a/tests/test_download_path_confinement.py
+++ b/tests/test_download_path_confinement.py
@@ -1,0 +1,181 @@
+"""download_attachment save_path confinement (arbitrary-write hardening)."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from mcp_email_server.app import _resolve_download_path
+from mcp_email_server.config import Settings
+
+
+class TestResolveDownloadPath:
+    def test_absolute_within_root_allowed(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path))
+        target = root / "sub" / "file.pdf"
+        assert _resolve_download_path(str(target), root) == target
+
+    def test_relative_resolves_under_root(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path))
+        assert _resolve_download_path("report.pdf", root) == root / "report.pdf"
+        assert _resolve_download_path("nested/report.pdf", root) == root / "nested" / "report.pdf"
+
+    def test_absolute_outside_root_rejected(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path)) / "downloads"
+        root.mkdir()
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path("/etc/cron.d/evil", root)
+
+    def test_dotdot_traversal_rejected(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path)) / "downloads"
+        root.mkdir()
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path(str(root / ".." / "escape.txt"), root)
+
+    def test_relative_dotdot_traversal_rejected(self, tmp_path):
+        root = Path(os.path.realpath(tmp_path)) / "downloads"
+        root.mkdir()
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path("../escape.txt", root)
+
+    def test_intermediate_symlink_escape_rejected(self, tmp_path):
+        real = Path(os.path.realpath(tmp_path))
+        root = real / "downloads"
+        root.mkdir()
+        outside = real / "outside"
+        outside.mkdir()
+        # A symlink DIR inside root pointing outside must not become a write channel.
+        (root / "link").symlink_to(outside)
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path(str(root / "link" / "pwned.txt"), root)
+
+    def test_final_component_symlink_escape_rejected(self, tmp_path):
+        # Regression: a symlink AT the target path (final component) pointing outside
+        # root previously slipped through because only the parent was canonicalised.
+        real = Path(os.path.realpath(tmp_path))
+        root = real / "downloads"
+        root.mkdir()
+        secret = real / "secret"
+        secret.mkdir()
+        (root / "authorized_keys").symlink_to(secret / "authorized_keys")
+        with pytest.raises(PermissionError, match="outside the permitted download"):
+            _resolve_download_path(str(root / "authorized_keys"), root)
+
+    def test_final_component_symlink_within_root_allowed(self, tmp_path):
+        # A symlink whose target stays inside root is fine; it resolves in-bounds.
+        real = Path(os.path.realpath(tmp_path))
+        root = real / "downloads"
+        (root / "sub").mkdir(parents=True)
+        (root / "alias").symlink_to(root / "sub" / "real.bin")
+        resolved = _resolve_download_path(str(root / "alias"), root)
+        assert resolved == root / "sub" / "real.bin"
+
+    def test_symlinked_root_itself_is_canonicalised(self, tmp_path):
+        # If the root is reached via a symlink, a save under it still validates.
+        real = Path(os.path.realpath(tmp_path))
+        actual = real / "actual_downloads"
+        actual.mkdir()
+        result = _resolve_download_path(str(actual / "a.bin"), actual)
+        assert result == actual / "a.bin"
+
+    def test_root_itself_rejected(self, tmp_path):
+        # save_path must name a file, not the download directory itself (avoids a
+        # later IsADirectoryError on write).
+        root = Path(os.path.realpath(tmp_path))
+        with pytest.raises(PermissionError, match="must name a file"):
+            _resolve_download_path(str(root), root)
+
+    @pytest.mark.parametrize("empty", ["", ".", "./"])
+    def test_empty_or_dot_path_rejected(self, tmp_path, empty):
+        root = Path(os.path.realpath(tmp_path))
+        with pytest.raises(PermissionError, match="must name a file"):
+            _resolve_download_path(empty, root)
+
+
+class TestAttachmentDownloadRootConfig:
+    def test_defaults_to_downloads(self, monkeypatch):
+        monkeypatch.delenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR", raising=False)
+        settings = Settings()
+        assert settings.attachment_download_dir is None
+        assert settings.attachment_download_root == Path(os.path.realpath(Path("~/Downloads").expanduser()))
+
+    def test_field_sets_root(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR", raising=False)
+        settings = Settings()
+        settings.attachment_download_dir = str(tmp_path)
+        assert settings.attachment_download_root == Path(os.path.realpath(tmp_path))
+
+    def test_env_override(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR", str(tmp_path))
+        settings = Settings()
+        assert settings.attachment_download_dir == str(tmp_path)
+        assert settings.attachment_download_root == Path(os.path.realpath(tmp_path))
+
+    def test_env_empty_resets_to_default(self, monkeypatch):
+        monkeypatch.setenv("MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR", "   ")
+        settings = Settings()
+        assert settings.attachment_download_dir is None
+        assert settings.attachment_download_root == Path(os.path.realpath(Path("~/Downloads").expanduser()))
+
+
+class TestDownloadAttachmentTool:
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self, monkeypatch):
+        from unittest.mock import AsyncMock, patch
+
+        from mcp_email_server.app import download_attachment
+
+        settings = Settings()
+        settings.enable_attachment_download = False
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(PermissionError, match="disabled"):
+                await download_attachment(account_name="a", email_id="1", attachment_name="x.pdf", save_path="x.pdf")
+        handler.download_attachment.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_escaping_path_rejected_before_handler(self, monkeypatch, tmp_path):
+        from unittest.mock import AsyncMock, patch
+
+        from mcp_email_server.app import download_attachment
+
+        settings = Settings()
+        settings.enable_attachment_download = True
+        settings.attachment_download_dir = str(tmp_path)
+        handler = AsyncMock()
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            with pytest.raises(PermissionError, match="outside the permitted download"):
+                await download_attachment(
+                    account_name="a",
+                    email_id="1",
+                    attachment_name="x.pdf",
+                    save_path="/etc/cron.d/evil",
+                )
+        handler.download_attachment.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_confined_path_passed_to_handler(self, monkeypatch, tmp_path):
+        from unittest.mock import AsyncMock, patch
+
+        from mcp_email_server.app import download_attachment
+
+        settings = Settings()
+        settings.enable_attachment_download = True
+        settings.attachment_download_dir = str(tmp_path)
+        handler = AsyncMock()
+        handler.download_attachment.return_value = None
+        with (
+            patch("mcp_email_server.app.get_settings", return_value=settings),
+            patch("mcp_email_server.app.dispatch_handler", return_value=handler),
+        ):
+            await download_attachment(
+                account_name="a", email_id="1", attachment_name="x.pdf", save_path="reports/x.pdf"
+            )
+        passed = handler.download_attachment.call_args.args[2]
+        assert passed == str(Path(os.path.realpath(tmp_path)) / "reports" / "x.pdf")

--- a/tests/test_email_attachments.py
+++ b/tests/test_email_attachments.py
@@ -778,3 +778,63 @@ class TestDownloadAttachmentSenderAllowlist:
             )
         assert result["attachment_name"] == "ausflug.png"
         mock_senders.assert_not_called()
+
+
+class TestFindAttachmentInMessage:
+    """Direct coverage for the attachment lookup used by download_attachment."""
+
+    @staticmethod
+    def _multipart_with_attachment() -> MIMEMultipart:
+        msg = MIMEMultipart()
+        msg.attach(MIMEText("body text"))
+        # An attachment-disposition part with no filename — must be walked past
+        # (exercises the filename guard) before the named attachment is found.
+        noname = MIMEApplication(b"noname-bytes", _subtype="octet-stream")
+        noname.add_header("Content-Disposition", "attachment")
+        msg.attach(noname)
+        part = MIMEApplication(b"PDF-BYTES", _subtype="pdf")
+        part.add_header("Content-Disposition", "attachment", filename="doc.pdf")
+        msg.attach(part)
+        return msg
+
+    def test_finds_named_attachment(self, email_client):
+        data, mime_type = email_client._find_attachment_in_message(self._multipart_with_attachment(), "doc.pdf")
+        assert data == b"PDF-BYTES"
+        assert mime_type == "application/pdf"
+
+    def test_missing_attachment_returns_none(self, email_client):
+        data, mime_type = email_client._find_attachment_in_message(self._multipart_with_attachment(), "absent.pdf")
+        assert data is None
+        assert mime_type is None
+
+    def test_non_multipart_returns_none(self, email_client):
+        data, mime_type = email_client._find_attachment_in_message(MIMEText("plain text"), "anything")
+        assert data is None
+        assert mime_type is None
+
+    @pytest.mark.asyncio
+    async def test_download_rejects_oversized_attachment(self, email_client, tmp_path, monkeypatch):
+        """download_attachment refuses an attachment above the size ceiling."""
+        import asyncio
+
+        monkeypatch.setattr("mcp_email_server.emails.classic.MAX_ATTACHMENT_BYTES", 8)
+        mock_imap = AsyncMock()
+        mock_imap._client_task = asyncio.Future()
+        mock_imap._client_task.set_result(None)
+        mock_imap.wait_hello_from_server = AsyncMock()
+        mock_imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+        mock_imap.select = AsyncMock(return_value=("OK", [b"1"]))
+        mock_imap.logout = AsyncMock()
+
+        with (
+            patch.object(email_client, "_fetch_email_with_formats", return_value=[b"data"]),
+            patch.object(email_client, "_extract_raw_email", return_value=b"raw"),
+            patch.object(email_client, "_find_attachment_in_message", return_value=(b"X" * 100, "application/pdf")),
+            patch.object(email_client, "imap_class", return_value=mock_imap),
+        ):
+            with pytest.raises(ValueError, match="exceeding"):
+                await email_client.download_attachment(
+                    email_id="123",
+                    attachment_name="big.pdf",
+                    save_path=str(tmp_path / "big.pdf"),
+                )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,4 +1,6 @@
+import os
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -630,18 +632,20 @@ class TestMcpTools:
             assert "Attachment download is disabled" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_download_attachment_enabled(self):
+    async def test_download_attachment_enabled(self, tmp_path):
         """Test download_attachment MCP tool when feature is enabled."""
+        save_target = tmp_path / "document.pdf"
         attachment_response = AttachmentDownloadResponse(
             email_id="12345",
             attachment_name="document.pdf",
             mime_type="application/pdf",
             size=1024,
-            saved_path="/var/downloads/document.pdf",
+            saved_path=str(save_target),
         )
 
         mock_settings = MagicMock()
         mock_settings.enable_attachment_download = True
+        mock_settings.attachment_download_root = Path(os.path.realpath(tmp_path))
 
         mock_handler = AsyncMock()
         mock_handler.download_attachment.return_value = attachment_response
@@ -652,7 +656,7 @@ class TestMcpTools:
                     account_name="test_account",
                     email_id="12345",
                     attachment_name="document.pdf",
-                    save_path="/var/downloads/document.pdf",
+                    save_path=str(save_target),
                 )
 
                 assert result == attachment_response
@@ -662,7 +666,7 @@ class TestMcpTools:
                 assert result.size == 1024
 
                 mock_handler.download_attachment.assert_called_once_with(
-                    "12345", "document.pdf", "/var/downloads/document.pdf", "INBOX"
+                    "12345", "document.pdf", str(Path(os.path.realpath(save_target))), "INBOX"
                 )
 
     @pytest.mark.asyncio

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,0 +1,110 @@
+"""Resource-exhaustion ceilings: page_size, email_ids batch, attachment size."""
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+from mcp_email_server import app as app_module
+from mcp_email_server.app import MAX_EMAIL_IDS_PER_CALL, MAX_PAGE_SIZE
+from mcp_email_server.config import EmailServer
+from mcp_email_server.emails.classic import (
+    MAX_ATTACHMENT_BYTES,
+    MAX_ATTACHMENT_COUNT,
+    MAX_TOTAL_ATTACHMENT_BYTES,
+    EmailClient,
+)
+
+
+class TestToolInputCeilings:
+    @pytest.mark.asyncio
+    async def test_page_size_over_limit_rejected(self):
+        with pytest.raises(ToolError):
+            await app_module.mcp.call_tool(
+                "list_emails_metadata", {"account_name": "x", "page_size": MAX_PAGE_SIZE + 1}
+            )
+
+    @pytest.mark.asyncio
+    async def test_page_zero_rejected(self):
+        with pytest.raises(ToolError):
+            await app_module.mcp.call_tool("list_emails_metadata", {"account_name": "x", "page": 0})
+
+    @pytest.mark.asyncio
+    async def test_email_ids_over_limit_rejected(self):
+        ids = [str(i) for i in range(MAX_EMAIL_IDS_PER_CALL + 1)]
+        with pytest.raises(ToolError):
+            await app_module.mcp.call_tool("get_emails_content", {"account_name": "x", "email_ids": ids})
+
+    @pytest.mark.asyncio
+    async def test_empty_email_ids_rejected(self):
+        with pytest.raises(ToolError):
+            await app_module.mcp.call_tool("get_emails_content", {"account_name": "x", "email_ids": []})
+
+    @pytest.mark.asyncio
+    async def test_schema_advertises_bounds(self):
+        # The published inputSchema must carry the constraints so clients see them.
+        tools = await app_module.mcp.list_tools()
+        by_name = {t.name: t for t in tools}
+        meta = by_name["list_emails_metadata"].inputSchema["properties"]
+        assert meta["page_size"]["maximum"] == MAX_PAGE_SIZE
+        assert meta["page_size"]["minimum"] == 1
+        assert meta["page"]["minimum"] == 1
+        content = by_name["get_emails_content"].inputSchema["properties"]
+        assert content["email_ids"]["maxItems"] == MAX_EMAIL_IDS_PER_CALL
+        assert content["email_ids"]["minItems"] == 1
+
+
+@pytest.fixture
+def email_client():
+    server = EmailServer(user_name="u", password="p", host="smtp.example.com", port=465, use_ssl=True)
+    return EmailClient(server, sender="Test User <test@example.com>")
+
+
+class TestAttachmentSizeCap:
+    def test_oversize_attachment_rejected(self, email_client, tmp_path, monkeypatch):
+        # Shrink the cap so we don't have to write 25 MB to disk.
+        monkeypatch.setattr("mcp_email_server.emails.classic.MAX_ATTACHMENT_BYTES", 1024)
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"x" * 2048)
+        with pytest.raises(ValueError, match="exceeding the"):
+            email_client._validate_attachment(str(big))
+
+    def test_within_limit_attachment_accepted(self, email_client, tmp_path):
+        ok = tmp_path / "ok.bin"
+        ok.write_bytes(b"x" * 16)
+        assert email_client._validate_attachment(str(ok)).name == "ok.bin"
+
+    def test_default_caps(self):
+        assert MAX_ATTACHMENT_BYTES == 25 * 1024 * 1024
+        assert MAX_TOTAL_ATTACHMENT_BYTES == 50 * 1024 * 1024
+        assert MAX_ATTACHMENT_COUNT == 50
+
+
+class TestAggregateAttachmentCaps:
+    def test_too_many_attachments_rejected(self, email_client, tmp_path, monkeypatch):
+        monkeypatch.setattr("mcp_email_server.emails.classic.MAX_ATTACHMENT_COUNT", 3)
+        files = []
+        for i in range(4):
+            f = tmp_path / f"f{i}.bin"
+            f.write_bytes(b"x")
+            files.append(str(f))
+        with pytest.raises(ValueError, match="Too many attachments"):
+            email_client._create_message_with_attachments("body", False, files)
+
+    def test_total_size_over_limit_rejected(self, email_client, tmp_path, monkeypatch):
+        monkeypatch.setattr("mcp_email_server.emails.classic.MAX_TOTAL_ATTACHMENT_BYTES", 1000)
+        files = []
+        for i in range(3):
+            f = tmp_path / f"f{i}.bin"
+            f.write_bytes(b"x" * 600)  # 3 * 600 = 1800 > 1000
+            files.append(str(f))
+        with pytest.raises(ValueError, match="Total attachment size"):
+            email_client._create_message_with_attachments("body", False, files)
+
+    def test_within_aggregate_limits_ok(self, email_client, tmp_path):
+        files = []
+        for i in range(2):
+            f = tmp_path / f"f{i}.bin"
+            f.write_bytes(b"x" * 16)
+            files.append(str(f))
+        msg = email_client._create_message_with_attachments("body", False, files)
+        # text part + 2 attachments
+        assert len(msg.get_payload()) == 3


### PR DESCRIPTION
## What this delivers

Three **security-hardening** fixes to the email tools, rebased cleanly onto current `main` and with docs harmonized into the new multi-file `docs/` structure (post-#205).

**This supersedes #201**, which was branched a week ago and now conflicts with the docs reorganization (#205) and the pyright/tooling changes (#204). Same fixes, cleanly re-homed.

### Fixes
1. **`download_attachment` path confinement** — save paths are confined to `attachment_download_dir` (default `~/Downloads`). A `save_path` escaping it via `..` or a symlink (including a final-component symlink) is rejected, so attacker-controlled attachment bytes can't be written over `~/.ssh/authorized_keys`, a crontab, or the config file. New `attachment_download_dir` setting + `MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR`.
2. **CRLF injection rejection** — reject CR/LF in recipients, header values, and attachment paths. Closes SMTP-envelope injection via `bcc` (handed to aiosmtplib without being placed in a header).
3. **Resource-exhaustion ceilings** — `page_size ≤ 500`, `≤ 100 email_ids` per call, and a 25 MB attachment cap guard against self-DoS from unbounded tool inputs.

### Rebase / integration notes
- Adopted upstream's robust `_decoded_payload` in the extracted `_find_attachment_in_message` helper (upstream added that decoder after this branch was first written).
- Typed `_reject_crlf` as `Iterable[str | None]` to satisfy the pyright check added in #204.
- Docs distributed the idiomatic way: `security.md` (attachment access rewrite, HTTP-transport = not-auth, new "Message and input limits"), `transports.md` (unauthenticated-gateway warning under DNS-rebinding), `configuration.md` (setting + env rows), and corrected now-stale `download_attachment` guidance in `tools.md`/`troubleshooting.md`.
- **E2E:** `download_attachment` confinement required pointing `MCP_EMAIL_SERVER_ATTACHMENT_DOWNLOAD_DIR` at the GreenMail test's `tmp_path`, or the roundtrip download is rejected.

## Test plan
- [x] `uv run pytest -q` — **578 passed** (new: `test_crlf_injection.py`, `test_download_path_confinement.py`, `test_resource_limits.py`)
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run pyright` — **0 errors** (#204's check)
- [x] `mkdocs build --strict` — builds, no broken anchors
- [x] `prettier --check docs/*.md` — clean

Companion to #209 (permission model). The two are independent at the code level; when both land, whichever merges second needs a small `app.py` rebase where they both touch `send_email`/`save_to_mailbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pd8meRq4jSiqaLq715nSD
