### PR TITLE
feat: add bounded email flag mutations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,11 @@
 `mcp-email-server` is a Python MCP server that connects MCP clients to email
 accounts through IMAP and SMTP.
 
+Canonical repository:
+
+- HTTPS: `https://github.com/Wh1isper/mcp-email-server`
+- SSH: `git@github.com:Wh1isper/mcp-email-server.git`
+
 Primary repository areas:
 
 - `mcp_email_server/app.py` — FastMCP server, resources, tools, and tool visibility.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ You can contribute in many ways:
 
 ## Report Bugs
 
-Report bugs at https://github.com/wh1isper/mcp-email-server/issues
+Report bugs at https://github.com/Wh1isper/mcp-email-server/issues
 
 If you are reporting a bug, please include:
 
@@ -33,7 +33,7 @@ mcp-email-server could always use more documentation, whether as part of the off
 
 ## Submit Feedback
 
-The best way to send feedback is to file an issue at https://github.com/wh1isper/mcp-email-server/issues.
+The best way to send feedback is to file an issue at https://github.com/Wh1isper/mcp-email-server/issues.
 
 If you are proposing a new feature:
 
@@ -168,7 +168,7 @@ This section is for project maintainers.
 
 1. Create an API token on [PyPI](https://pypi.org/).
 2. Add it to the repository's GitHub Actions secrets as `PYPI_TOKEN`.
-3. Create a [GitHub release](https://github.com/wh1isper/mcp-email-server/releases/new).
+3. Create a [GitHub release](https://github.com/Wh1isper/mcp-email-server/releases/new).
 4. Create a canonical `X.Y.Z` version tag, optionally prefixed with `v`, as part of the release.
 
 The release tag is the application version authority. The workflow pins and

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # mcp-email-server
 
-[![Release](https://img.shields.io/github/v/release/wh1isper/mcp-email-server)](https://github.com/wh1isper/mcp-email-server/releases)
-[![Build status](https://img.shields.io/github/actions/workflow/status/wh1isper/mcp-email-server/main.yml?branch=main)](https://github.com/wh1isper/mcp-email-server/actions/workflows/main.yml?query=branch%3Amain)
+[![Release](https://img.shields.io/github/v/release/Wh1isper/mcp-email-server)](https://github.com/Wh1isper/mcp-email-server/releases)
+[![Build status](https://img.shields.io/github/actions/workflow/status/Wh1isper/mcp-email-server/main.yml?branch=main)](https://github.com/Wh1isper/mcp-email-server/actions/workflows/main.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/Wh1isper/mcp-email-server/graph/badge.svg?token=0mToRybKx8)](https://codecov.io/gh/Wh1isper/mcp-email-server)
-[![License](https://img.shields.io/github/license/wh1isper/mcp-email-server)](https://github.com/wh1isper/mcp-email-server/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/Wh1isper/mcp-email-server)](https://github.com/Wh1isper/mcp-email-server/blob/main/LICENSE)
 
 An MCP server for reading, searching, organizing, and sending email through
 IMAP and SMTP.
@@ -105,8 +105,8 @@ see the [documentation](https://mcp-email-server.wh1isper.top/).
 
 ## Development
 
-See [CONTRIBUTING.md](https://github.com/wh1isper/mcp-email-server/blob/main/CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/Wh1isper/mcp-email-server/blob/main/CONTRIBUTING.md).
 
 ## License
 
-This project is licensed under the terms of the [LICENSE](https://github.com/wh1isper/mcp-email-server/blob/main/LICENSE).
+This project is licensed under the terms of the [LICENSE](https://github.com/Wh1isper/mcp-email-server/blob/main/LICENSE).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -578,6 +578,7 @@ account fails its capability check before SMTP access.
 IMAP-only does not mean read-only. These tools can still change mailbox state:
 
 - `save_to_mailbox`
+- `set_email_flags`
 - `mark_emails_as_read`
 - `move_emails`
 - `archive_emails`

--- a/docs/security.md
+++ b/docs/security.md
@@ -445,7 +445,7 @@ The allowlist protects:
 - Metadata listing and pagination.
 - Body retrieval and optional read marking.
 - Attachment download.
-- Deletion and read-state mutations.
+- Deletion and approved flag/read-state mutations.
 - Move and archive operations.
 
 A blocked message's body and attachments are not fetched or marked as read. By
@@ -478,7 +478,11 @@ apply an effect twice; inspect the provider mailbox or delivery evidence first.
 
 Scoped delete and the COPY/delete move fallback require `UIDPLUS` and use only
 `UID EXPUNGE`. They never use mailbox-wide `EXPUNGE`, which could commit another
-client's pending deletions. Metadata projection invalidation is rebuildable: if
+client's pending deletions. The generic `set_email_flags` tool rejects
+`\Deleted`, so it cannot bypass this scoped deletion boundary; it also rejects
+the server-controlled `\Recent` flag and provider-specific keywords.
+
+Metadata projection invalidation is rebuildable: if
 it fails after a provider effect, the result keeps the provider evidence and
 adds a reconciliation warning instead of claiming rollback.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -76,7 +76,7 @@ Every tool advertises reviewed MCP `readOnlyHint`, `destructiveHint`,
 | `list_emails_metadata`, `list_mailboxes`                                     | yes       | no          | yes        | yes        |
 | `get_emails_content`                                                         | no        | no          | yes        | yes        |
 | `send_email`, `save_to_mailbox`                                              | no        | no          | no         | yes        |
-| `mark_emails_as_read`                                                        | no        | no          | yes        | yes        |
+| `set_email_flags`, `mark_emails_as_read`                                     | no        | no          | yes        | yes        |
 | `delete_emails`, `move_emails`, `archive_emails`, `download_attachment`      | no        | yes         | no         | yes        |
 
 `get_emails_content` is conservatively non-read-only because
@@ -251,9 +251,32 @@ account name and both IMAP LIST values are validated before provider access;
 `pattern` must be non-empty and pattern/reference values are each limited to
 1,024 UTF-8 bytes.
 
+### `set_email_flags`
+
+Adds or removes approved IMAP flags from one or more message IDs in the selected
+mailbox. `operation` must be `add` or `remove`, and applies to every supplied
+flag. The non-empty `flags` list accepts unique values from:
+
+- `\Seen`
+- `\Flagged`
+- `\Answered`
+- `\Draft`
+
+The provider sends one UID-scoped `+FLAGS.SILENT` or `-FLAGS.SILENT` operation
+per message so results retain caller order and per-ID evidence. The operation is
+logically idempotent, but an `unknown` result is not retried automatically
+because the mailbox UID epoch or current authority may have changed.
+
+`\Deleted` is intentionally rejected and remains owned by `delete_emails`,
+which applies target-scoped expunge safety. `\Recent` is server-controlled, and
+provider-specific keywords are not part of the portable public contract. To
+mark a message unread, remove `\Seen`.
+
 ### `mark_emails_as_read`
 
-Marks one or more message IDs as read in the selected mailbox.
+Marks one or more message IDs as read in the selected mailbox. This focused
+common-workflow tool uses the same implementation as `set_email_flags` with
+`operation="add"` and `flags=["\\Seen"]`.
 
 ### `move_emails`
 
@@ -288,8 +311,10 @@ be authoritative but the rebuildable local metadata projection could not be
 invalidated.
 
 Mutation requests accept 1 to 100 unique canonical positive decimal IMAP UIDs.
-Mailbox names are limited to 1,024 UTF-8 bytes. Compose requests allow at most
-100 total To/CC/BCC entries of at most 1,024 UTF-8 bytes each; every entry must
+`set_email_flags` accepts one to four unique approved flags and exactly one
+add/remove operation. Mailbox names are limited to 1,024 UTF-8 bytes. Compose
+requests allow at most 100 total To/CC/BCC entries of at most 1,024 UTF-8 bytes
+each; every entry must
 contain exactly one address. Compose requests also allow a 64 KiB UTF-8 subject,
 a 1 MiB UTF-8 body, and 20 attachments. Threading and Reply-To values
 are limited to 64 KiB each. Each attachment path is limited to 4,096 bytes,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -496,4 +496,4 @@ Include:
   removed.
 - Minimal steps to reproduce the problem.
 
-Report issues at <https://github.com/wh1isper/mcp-email-server/issues>.
+Report issues at <https://github.com/Wh1isper/mcp-email-server/issues>.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -188,19 +188,19 @@ seeder and observer, so the system is not solely verifying itself.
 
 ## GreenMail coverage
 
-| Area          | Assertions                                                                                                  |
-| ------------- | ----------------------------------------------------------------------------------------------------------- |
-| MCP lifecycle | stdio subprocess starts, `initialize` succeeds, and expected tools are visible                              |
-| Configuration | v1 TOML compatibility, direct fresh init, reviewed import cutover, explicit recovery selection, and restart |
-| Managed mode  | a Linux SQLite-secret managed account reaches live IMAP; a missing selected database fails without fallback |
-| SMTP          | authenticated Alice-to-Bob delivery succeeds through `send_email`                                           |
-| IMAP read     | Bob can list paged metadata with exact totals and retrieve full content by UID                              |
-| Attachments   | source bytes arrive in Bob's MIME message, appear in full content, download to disk, and match exactly      |
-| Sent copy     | Alice receives the application-created copy in `Sent`                                                       |
-| Flags         | `mark_emails_as_read` produces `\\Seen`; saved drafts have `\\Draft` and `\\Seen`                           |
-| Mailboxes     | the observer provisions `Sent`, `Drafts`, and `Archive`; MCP discovers and uses them                        |
-| Index         | initial projection, qualified SQLite reuse, filter fallback, bounds, and restart reuse are verified         |
-| Mutations     | explicit move, automatic archive selection, draft save, and delete are observed in IMAP                     |
+| Area          | Assertions                                                                                                           |
+| ------------- | -------------------------------------------------------------------------------------------------------------------- |
+| MCP lifecycle | stdio subprocess starts, `initialize` succeeds, and expected tools are visible                                       |
+| Configuration | v1 TOML compatibility, direct fresh init, reviewed import cutover, explicit recovery selection, and restart          |
+| Managed mode  | a Linux SQLite-secret managed account reaches live IMAP; a missing selected database fails without fallback          |
+| SMTP          | authenticated Alice-to-Bob delivery succeeds through `send_email`                                                    |
+| IMAP read     | Bob can list paged metadata with exact totals and retrieve full content by UID                                       |
+| Attachments   | source bytes arrive in Bob's MIME message, appear in full content, download to disk, and match exactly               |
+| Sent copy     | Alice receives the application-created copy in `Sent`                                                                |
+| Flags         | focused mark-read adds `\\Seen`; generic flag mutation removes `\\Seen` and adds `\\Flagged`; drafts retain defaults |
+| Mailboxes     | the observer provisions `Sent`, `Drafts`, and `Archive`; MCP discovers and uses them                                 |
+| Index         | initial projection, qualified SQLite reuse, filter fallback, bounds, and restart reuse are verified                  |
+| Mutations     | explicit move, automatic archive selection, draft save, and delete are observed in IMAP                              |
 
 `list_emails_metadata` currently fetches headers only and therefore returns an
 empty attachment list. Attachment names are verified through

--- a/mcp_email_server/adapters/mutations.py
+++ b/mcp_email_server/adapters/mutations.py
@@ -16,7 +16,6 @@ from mcp_email_server.application.mutations import (
     BatchMutationOutcome,
     DeleteCommand,
     DeliveryMutationOutcome,
-    MarkReadCommand,
     MoveCommand,
     MutationAccountSnapshot,
     MutationProjection,
@@ -27,6 +26,7 @@ from mcp_email_server.application.mutations import (
     SaveToMailboxCommand,
     SendCommand,
     SentCopyMutationOutcome,
+    SetEmailFlagsCommand,
 )
 from mcp_email_server.config import EmailSettings, Settings
 from mcp_email_server.emails.classic import ClassicEmailHandler, _validate_flags
@@ -59,14 +59,16 @@ class ClassicMutationProvider:
     def __init__(self, handler: ClassicEmailHandler) -> None:
         self._handler = handler
 
-    async def mark_read(
+    async def set_flags(
         self,
-        command: MarkReadCommand,
+        command: SetEmailFlagsCommand,
         account: MutationAccountSnapshot,
     ) -> BatchMutationOutcome:
         return await _bounded_mutation_call(
-            self._handler.incoming_client.mark_emails_as_read_with_outcome(
+            self._handler.incoming_client.set_email_flags_with_outcome(
                 list(command.email_ids),
+                command.operation,
+                list(command.flags),
                 command.mailbox,
                 list(account.allowed_senders),
                 account.report_blocked_mutations,

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -13,17 +13,21 @@ from mcp_email_server.application.accounts import AvailableAccount, EffectiveCon
 from mcp_email_server.application.limits import APPLICATION_LIMITS
 from mcp_email_server.application.metadata import ListEmailMetadataQuery
 from mcp_email_server.application.mutations import (
+    MUTABLE_EMAIL_FLAGS,
     AppendMutationOutcome,
     ArchiveCommand,
     ArchiveMutationOutcome,
     BatchMutationOutcome,
     DeleteCommand,
+    FlagOperation,
     MarkReadCommand,
     MoveCommand,
+    MutableEmailFlag,
     RecipientPolicyDeniedError,
     SaveToMailboxCommand,
     SendCommand,
     SendMutationOutcome,
+    SetEmailFlagsCommand,
     TargetMutationOutcome,
 )
 from mcp_email_server.application.reads import (
@@ -72,6 +76,10 @@ async def save_to_mailbox_command(command: SaveToMailboxCommand) -> AppendMutati
 
 async def delete_emails_command(command: DeleteCommand) -> BatchMutationOutcome:
     return await get_application_runtime().mutations.delete.execute(command)
+
+
+async def set_email_flags_command(command: SetEmailFlagsCommand) -> BatchMutationOutcome:
+    return await get_application_runtime().mutations.set_flags.execute(command)
 
 
 async def mark_read_command(command: MarkReadCommand) -> BatchMutationOutcome:
@@ -417,7 +425,8 @@ async def list_allowed_recipients() -> PolicyDiscoveryResult:
         "List the configured inbound sender allowlist — the address patterns whose mail the server "
         "will read or act on. When configured, only these senders' mail is visible to the read tools "
         "(list_emails_metadata, get_emails_content, download_attachment) and eligible for the mutation "
-        "tools (delete_emails, mark_emails_as_read, move_emails, archive_emails). Returns an empty list "
+        "tools (delete_emails, set_email_flags, mark_emails_as_read, move_emails, archive_emails). Returns an "
+        "empty list "
         "when unrestricted."
     ),
     annotations=_READ_ONLY_LOCAL,
@@ -674,8 +683,61 @@ async def delete_emails(
 
 @mcp.tool(
     description=(
-        "Mark one or more emails as read by email_id. Use list_emails_metadata first. Partial or ambiguous "
-        "effects report per-ID succeeded/failed/unknown status and are not retried automatically."
+        "Add or remove approved IMAP flags on one or more emails by email_id. Supported flags are \\Seen, "
+        "\\Flagged, \\Answered, and \\Draft; \\Deleted and provider-specific keywords are not supported. "
+        "Use list_emails_metadata first. Partial or ambiguous effects report per-ID succeeded/failed/unknown "
+        "status and are not retried automatically."
+    ),
+    annotations=_IDEMPOTENT_REMOTE_MUTATION,
+)
+async def set_email_flags(
+    account_name: Annotated[
+        str, Field(max_length=APPLICATION_LIMITS.account_name_bytes, description="The name of the email account.")
+    ],
+    email_ids: Annotated[
+        list[UidInput],
+        Field(
+            min_length=1,
+            max_length=APPLICATION_LIMITS.mutation_uids,
+            description="List of email_id values whose flags should be changed.",
+        ),
+    ],
+    operation: Annotated[
+        FlagOperation,
+        Field(description="Whether to add or remove every supplied flag."),
+    ],
+    flags: Annotated[
+        list[MutableEmailFlag],
+        Field(
+            min_length=1,
+            max_length=len(MUTABLE_EMAIL_FLAGS),
+            description="Unique approved flags to add or remove: \\Seen, \\Flagged, \\Answered, or \\Draft.",
+        ),
+    ],
+    mailbox: Annotated[
+        str,
+        Field(
+            default="INBOX",
+            max_length=APPLICATION_LIMITS.mailbox_bytes,
+            description="The mailbox containing the emails.",
+        ),
+    ] = "INBOX",
+) -> str:
+    outcome = await set_email_flags_command(
+        SetEmailFlagsCommand(account_name, tuple(email_ids), operation, tuple(flags), mailbox)
+    )
+    succeeded = outcome.targets("succeeded")
+    if len(succeeded) == len(email_ids) and not outcome.reconciliation_needed:
+        verb, preposition = ("added", "to") if operation == "add" else ("removed", "from")
+        return f"Successfully {verb} {', '.join(flags)} {preposition} {len(succeeded)} email(s)"
+    return f"Set-flags result [{_tagged_batch_result(outcome)}]"
+
+
+@mcp.tool(
+    description=(
+        "Mark one or more emails as read by email_id. This is the common-workflow equivalent of adding \\Seen "
+        "with set_email_flags. Use list_emails_metadata first. Partial or ambiguous effects report per-ID "
+        "succeeded/failed/unknown status and are not retried automatically."
     ),
     annotations=_IDEMPOTENT_REMOTE_MUTATION,
 )

--- a/mcp_email_server/application/mutations.py
+++ b/mcp_email_server/application/mutations.py
@@ -19,6 +19,9 @@ from mcp_email_server.application.metadata import RuntimeMode
 MutationStatus = Literal["succeeded", "failed", "unknown"]
 MutationProviderPurpose = Literal["incoming", "outgoing", "sent-copy"]
 SentCopyStatus = Literal["skipped", "succeeded", "failed", "unknown"]
+FlagOperation = Literal["add", "remove"]
+MutableEmailFlag = Literal[r"\Seen", r"\Flagged", r"\Answered", r"\Draft"]
+MUTABLE_EMAIL_FLAGS: frozenset[str] = frozenset({r"\Seen", r"\Flagged", r"\Answered", r"\Draft"})
 
 
 ProviderResultT = TypeVar("ProviderResultT")
@@ -125,6 +128,32 @@ class SendMutationOutcome:
 
     def recipients(self, status: MutationStatus) -> list[str]:
         return [outcome.target for outcome in self.delivery if outcome.status == status]
+
+
+@dataclass(frozen=True)
+class SetEmailFlagsCommand:
+    account_name: str
+    email_ids: tuple[str, ...]
+    operation: FlagOperation
+    flags: tuple[MutableEmailFlag, ...]
+    mailbox: str = "INBOX"
+
+    def validate(self) -> None:
+        _validate_account_name(self.account_name)
+        _validate_email_ids(self.email_ids)
+        validate_mailbox_name(self.mailbox)
+        if self.operation not in ("add", "remove"):
+            raise ValueError("operation must be 'add' or 'remove'")
+        if not self.flags:
+            raise ValueError("flags must not be empty")
+        if len(self.flags) > len(MUTABLE_EMAIL_FLAGS):
+            raise ValueError(f"flags must contain at most {len(MUTABLE_EMAIL_FLAGS)} values")
+        if any(not isinstance(flag, str) for flag in self.flags):
+            raise ValueError("flags must contain strings")
+        if len(set(self.flags)) != len(self.flags):
+            raise ValueError("flags must not contain duplicates")
+        if any(flag not in MUTABLE_EMAIL_FLAGS for flag in self.flags):
+            raise ValueError("flags contain an unsupported mutable email flag")
 
 
 @dataclass(frozen=True)
@@ -244,9 +273,9 @@ class MutationAccountAuthority(Protocol):
 
 
 class MutationProvider(Protocol):
-    async def mark_read(
+    async def set_flags(
         self,
-        command: MarkReadCommand,
+        command: SetEmailFlagsCommand,
         account: MutationAccountSnapshot,
     ) -> BatchMutationOutcome: ...
 
@@ -600,14 +629,14 @@ class _MutationWorkflow:
         return True
 
 
-class MarkReadService(_MutationWorkflow):
-    async def execute(self, command: MarkReadCommand) -> BatchMutationOutcome:
+class SetEmailFlagsService(_MutationWorkflow):
+    async def execute(self, command: SetEmailFlagsCommand) -> BatchMutationOutcome:
         command.validate()
         account = self._resolve(command.account_name)
         access = self._open(account)
         try:
             outcome = _validate_batch_result(
-                await _bounded_provider_effect(access.provider.mark_read(command, access.account))
+                await _bounded_provider_effect(access.provider.set_flags(command, access.account))
             )
         except TimeoutError:
             outcome = _validate_batch_result(_timeout_batch(command.email_ids))
@@ -617,6 +646,24 @@ class MarkReadService(_MutationWorkflow):
         return _validate_batch_result(
             BatchMutationOutcome(
                 outcome.outcomes, reconciliation_needed=outcome.reconciliation_needed or not invalidated
+            )
+        )
+
+
+class MarkReadService:
+    """Focused mark-read executor backed by the generic mutable-flag workflow."""
+
+    def __init__(self, set_flags: SetEmailFlagsService) -> None:
+        self._set_flags = set_flags
+
+    async def execute(self, command: MarkReadCommand) -> BatchMutationOutcome:
+        return await self._set_flags.execute(
+            SetEmailFlagsCommand(
+                account_name=command.account_name,
+                email_ids=command.email_ids,
+                operation="add",
+                flags=(r"\Seen",),
+                mailbox=command.mailbox,
             )
         )
 
@@ -840,6 +887,7 @@ class SendService(_MutationWorkflow):
 
 @dataclass(frozen=True)
 class MutationServices:
+    set_flags: SetEmailFlagsService
     mark_read: MarkReadService
     save_to_mailbox: SaveToMailboxService
     delete: DeleteService
@@ -855,8 +903,10 @@ class MutationServices:
         projections: MutationProjectionFactory,
     ) -> MutationServices:
         arguments = (accounts, providers, projections)
+        set_flags = SetEmailFlagsService(*arguments)
         return cls(
-            mark_read=MarkReadService(*arguments),
+            set_flags=set_flags,
+            mark_read=MarkReadService(set_flags),
             save_to_mailbox=SaveToMailboxService(*arguments),
             delete=DeleteService(*arguments),
             move=MoveService(*arguments),

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -37,9 +37,12 @@ from mcp_email_server.application.metadata import (
     MetadataQueryTooBroadError,
 )
 from mcp_email_server.application.mutations import (
+    MUTABLE_EMAIL_FLAGS,
     AppendMutationOutcome,
     BatchMutationOutcome,
     DeliveryMutationOutcome,
+    FlagOperation,
+    MutableEmailFlag,
     MutationStatus,
     SentCopyMutationOutcome,
     TargetMutationOutcome,
@@ -125,6 +128,28 @@ def _validate_flags(flags: list[str]) -> str:
             msg = f"Invalid IMAP flag: {flag!r}"
             raise ValueError(msg)
     return "(" + " ".join(flags) + ")"
+
+
+def _validate_mutable_email_flags(
+    operation: FlagOperation,
+    flags: list[MutableEmailFlag],
+) -> tuple[str, str]:
+    """Validate the bounded public flag policy at the provider boundary."""
+
+    if operation not in ("add", "remove"):
+        raise ValueError("operation must be 'add' or 'remove'")
+    if not flags:
+        raise ValueError("flags must not be empty")
+    if len(flags) > len(MUTABLE_EMAIL_FLAGS):
+        raise ValueError(f"flags must contain at most {len(MUTABLE_EMAIL_FLAGS)} values")
+    if any(not isinstance(flag, str) for flag in flags):
+        raise ValueError("flags must contain strings")
+    if len(set(flags)) != len(flags):
+        raise ValueError("flags must not contain duplicates")
+    if any(flag not in MUTABLE_EMAIL_FLAGS for flag in flags):
+        raise ValueError("flags contain an unsupported mutable email flag")
+    store_operation = "+FLAGS.SILENT" if operation == "add" else "-FLAGS.SILENT"
+    return store_operation, _validate_flags([str(flag) for flag in flags])
 
 
 def encode_mailbox_name(mailbox: str) -> str:
@@ -285,8 +310,8 @@ def _quote_mailbox(mailbox: str) -> str:
     Mailbox names with non-ASCII characters are encoded using Modified UTF-7
     as required by RFC 3501 Section 5.1.3.
 
-    See: https://github.com/wh1isper/mcp-email-server/issues/87
-    See: https://github.com/wh1isper/mcp-email-server/issues/172
+    See: https://github.com/Wh1isper/mcp-email-server/issues/87
+    See: https://github.com/Wh1isper/mcp-email-server/issues/172
     See: https://www.rfc-editor.org/rfc/rfc3501#section-9
     """
     encoded = encode_mailbox_name(mailbox)
@@ -426,7 +451,7 @@ async def _send_imap_id(imap: aioimaplib.IMAP4 | aioimaplib.IMAP4_SSL) -> None:
     This function first tries the standard id() method, and if it fails,
     falls back to sending a raw command with correct format.
 
-    See: https://github.com/wh1isper/mcp-email-server/issues/85
+    See: https://github.com/Wh1isper/mcp-email-server/issues/85
     """
     try:
         response = await imap.id(name="mcp-email-server", version="1.0.0")
@@ -2326,15 +2351,18 @@ class EmailClient:
             await _best_effort_imap_logout(imap)
         return BatchMutationOutcome(tuple(outcomes[email_id] for email_id in email_ids))
 
-    async def mark_emails_as_read_with_outcome(
+    async def set_email_flags_with_outcome(
         self,
         email_ids: list[str],
+        operation: FlagOperation,
+        flags: list[MutableEmailFlag],
         mailbox: str = "INBOX",
         allowed_senders: list[str] | None = None,
         report_blocked_mutations: bool = False,
     ) -> BatchMutationOutcome:
-        """Set \\Seen once per UID and retain cancellation evidence."""
+        """Add or remove approved flags once per UID and retain effect evidence."""
         _validate_imap_uids(email_ids)
+        store_operation, formatted_flags = _validate_mutable_email_flags(operation, flags)
         imap = await self._connect_imap()
         outcomes: list[TargetMutationOutcome] = []
         try:
@@ -2354,7 +2382,7 @@ class EmailClient:
                     )
                     continue
                 try:
-                    response = await imap.uid("store", email_id, "+FLAGS", r"(\Seen)")
+                    response = await imap.uid("store", email_id, store_operation, formatted_flags)
                 except asyncio.CancelledError:
                     outcomes.append(TargetMutationOutcome(email_id, "unknown", "store-unknown"))
                     for remaining_id in email_ids[index + 1 :]:
@@ -2387,6 +2415,23 @@ class EmailClient:
         finally:
             await _best_effort_imap_logout(imap)
         return BatchMutationOutcome(tuple(outcomes))
+
+    async def mark_emails_as_read_with_outcome(
+        self,
+        email_ids: list[str],
+        mailbox: str = "INBOX",
+        allowed_senders: list[str] | None = None,
+        report_blocked_mutations: bool = False,
+    ) -> BatchMutationOutcome:
+        """Focused wrapper for adding \\Seen through the generic flag path."""
+        return await self.set_email_flags_with_outcome(
+            email_ids,
+            "add",
+            [r"\Seen"],
+            mailbox,
+            allowed_senders,
+            report_blocked_mutations,
+        )
 
     async def move_emails_with_outcome(  # noqa: C901 - explicit native/fallback states
         self,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: mcp-email-server
-repo_url: https://github.com/wh1isper/mcp-email-server
+repo_url: https://github.com/Wh1isper/mcp-email-server
 site_url: https://mcp-email-server.wh1isper.top
 site_description: Read, search, organize, and send email through IMAP and SMTP with MCP
 site_author: wh1isper
@@ -17,7 +17,7 @@ nav:
   - Security: security.md
   - Guides: guides.md
   - Troubleshooting: troubleshooting.md
-  - Contributing: https://github.com/wh1isper/mcp-email-server/blob/main/CONTRIBUTING.md
+  - Contributing: https://github.com/Wh1isper/mcp-email-server/blob/main/CONTRIBUTING.md
 
 plugins:
   - search
@@ -48,7 +48,7 @@ theme:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/wh1isper/mcp-email-server
+      link: https://github.com/Wh1isper/mcp-email-server
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/mcp-email-server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ mcp-email-server-plugin = "mcp_email_server.cli:plugin_stdio"
 
 [project.urls]
 Homepage = "https://mcp-email-server.wh1isper.top/"
-Repository = "https://github.com/wh1isper/mcp-email-server"
+Repository = "https://github.com/Wh1isper/mcp-email-server"
 Documentation = "https://mcp-email-server.wh1isper.top/"
 
 [dependency-groups]

--- a/spec/07-mail-mutations-and-provider-effects.md
+++ b/spec/07-mail-mutations-and-provider-effects.md
@@ -42,12 +42,23 @@ UIDVALIDITY where feasible, and avoids using stale projected placement as proof.
 It does not claim to detect every listing-epoch race. An epoch-bound public
 identifier requires a future versioned contract.
 
-## Flags and Mark Read
+## Flags and Read State
 
-Flag updates use UID-scoped IMAP commands and bounded batches. Mark-read and
-mark-unread are explicit mutations separate from body reads. Per-target evidence
-comes from tagged protocol completion and, where required, bounded verification.
-Partial target outcomes are returned individually.
+`set_email_flags` changes one bounded list of UIDs with exactly one operation,
+`add` or `remove`, and one non-empty unique flag list. The public mutable set is
+limited to `\Seen`, `\Flagged`, `\Answered`, and `\Draft`. `\Recent` is
+server-controlled, provider-specific keywords are outside the portable
+contract, and `\Deleted` remains exclusively owned by the scoped
+`delete_emails` workflow.
+
+The provider issues one UID-scoped `+FLAGS.SILENT` or `-FLAGS.SILENT` command per
+target, preserving caller order and per-UID evidence without claiming
+multi-target atomicity. Mark-read remains a focused MCP workflow and delegates
+to the same implementation as adding `\Seen`; removing `\Seen` provides the
+explicit mark-unread operation. Body reads do not mutate flags unless their
+separate `mark_as_read` option requests the focused workflow. Tagged protocol
+completion produces individual success, failure, or unknown outcomes, and an
+ambiguous effect is not retried automatically.
 
 ## Save or Append
 
@@ -153,7 +164,8 @@ paths do not enter public errors.
    effect and resolves only the needed account/role secret.
 2. Per-target results preserve caller order and distinguish success, failure,
    unknown, cancelled-before-effect, and local projection warning.
-3. Body retrieval does not mark read; explicit bounded mark-read does.
+3. Body retrieval does not mark read by default; explicit mark-read and bounded
+   approved flag additions/removals use one shared effect-aware implementation.
 4. Move/archive/delete use native or proven scoped primitives, and tests prove no
    code path issues bare `EXPUNGE` or marks deleted before rejecting unsafe
    capability.

--- a/spec/10-mcp-interface-and-compatibility.md
+++ b/spec/10-mcp-interface-and-compatibility.md
@@ -59,7 +59,9 @@ against worst-case behavior across optional parameters:
   change remote flags, but that flag effect is idempotent;
 - send and append are non-read-only, non-idempotent, open-world additions rather
   than destructive replacement;
-- mark-read is a non-destructive idempotent remote mutation;
+- approved flag add/remove and the focused mark-read entry point are
+  non-destructive idempotent remote mutations; `\Deleted` is not accepted by
+  the generic flag tool;
 - delete, move, and archive are destructive, non-idempotent remote mutations;
 - attachment download is a non-idempotent filesystem write that may replace the
   caller-selected destination.

--- a/tests/e2e/test_stdio_greenmail.py
+++ b/tests/e2e/test_stdio_greenmail.py
@@ -340,6 +340,30 @@ async def test_managed_cli_setup_restart_and_stdio_list_mailboxes_against_greenm
             )
             assert mark["result"] == "Successfully marked 1 email(s) as read"
             assert r"\Seen" in _wait_for_message(ALICE, "INBOX", subject).flags
+            unset_seen = await _call_tool(
+                session,
+                "set_email_flags",
+                {
+                    "account_name": "alice-managed",
+                    "email_ids": [managed_uid],
+                    "operation": "remove",
+                    "flags": [r"\Seen"],
+                },
+            )
+            assert unset_seen["result"] == r"Successfully removed \Seen from 1 email(s)"
+            assert r"\Seen" not in _wait_for_message(ALICE, "INBOX", subject).flags
+            set_flagged = await _call_tool(
+                session,
+                "set_email_flags",
+                {
+                    "account_name": "alice-managed",
+                    "email_ids": [managed_uid],
+                    "operation": "add",
+                    "flags": [r"\Flagged"],
+                },
+            )
+            assert set_flagged["result"] == r"Successfully added \Flagged to 1 email(s)"
+            assert r"\Flagged" in _wait_for_message(ALICE, "INBOX", subject).flags
             with contextlib.closing(sqlite3.connect(database)) as connection:
                 assert connection.execute("SELECT COUNT(*) FROM index_coverage").fetchone()[0] == 0
 
@@ -799,6 +823,7 @@ async def test_current_stdio_server_against_greenmail(tmp_path: Path) -> None:
                 "send_email",
                 "save_to_mailbox",
                 "delete_emails",
+                "set_email_flags",
                 "mark_emails_as_read",
                 "move_emails",
                 "archive_emails",

--- a/tests/fixtures/mcp_catalog.json
+++ b/tests/fixtures/mcp_catalog.json
@@ -256,7 +256,7 @@
                             }
                         ],
                         "default": null,
-                        "description": "Search for text in the entire message \u2014 headers and body (IMAP TEXT).",
+                        "description": "Search for text in the entire message — headers and body (IMAP TEXT).",
                         "title": "Text"
                     },
                     "has_attachment": {
@@ -652,7 +652,7 @@
         },
         {
             "name": "list_allowed_recipients",
-            "description": "List the configured recipient allowlist \u2014 the addresses that send_email is permitted to send to and save_to_mailbox is permitted to address. Returns an empty list when unrestricted.",
+            "description": "List the configured recipient allowlist — the addresses that send_email is permitted to send to and save_to_mailbox is permitted to address. Returns an empty list when unrestricted.",
             "inputSchema": {
                 "properties": {},
                 "title": "list_allowed_recipientsArguments",
@@ -682,7 +682,7 @@
         },
         {
             "name": "list_allowed_senders",
-            "description": "List the configured inbound sender allowlist \u2014 the address patterns whose mail the server will read or act on. When configured, only these senders' mail is visible to the read tools (list_emails_metadata, get_emails_content, download_attachment) and eligible for the mutation tools (delete_emails, mark_emails_as_read, move_emails, archive_emails). Returns an empty list when unrestricted.",
+            "description": "List the configured inbound sender allowlist — the address patterns whose mail the server will read or act on. When configured, only these senders' mail is visible to the read tools (list_emails_metadata, get_emails_content, download_attachment) and eligible for the mutation tools (delete_emails, set_email_flags, mark_emails_as_read, move_emails, archive_emails). Returns an empty list when unrestricted.",
             "inputSchema": {
                 "properties": {},
                 "title": "list_allowed_sendersArguments",
@@ -871,7 +871,7 @@
         },
         {
             "name": "save_to_mailbox",
-            "description": "Compose an email and save it to an IMAP folder (e.g., Drafts). Shares recipient, body, attachment, and threading parameters with send_email; adds mailbox and flags, and does not support reply_to. Default folder is Drafts with \\Draft and \\Seen flags. Pure IMAP operation \u2014 works without SMTP configuration. An ambiguous APPEND is reported as unknown and is not retried automatically.",
+            "description": "Compose an email and save it to an IMAP folder (e.g., Drafts). Shares recipient, body, attachment, and threading parameters with send_email; adds mailbox and flags, and does not support reply_to. Default folder is Drafts with \\Draft and \\Seen flags. Pure IMAP operation — works without SMTP configuration. An ambiguous APPEND is reported as unknown and is not retried automatically.",
             "inputSchema": {
                 "properties": {
                     "account_name": {
@@ -1093,8 +1093,83 @@
             }
         },
         {
+            "name": "set_email_flags",
+            "description": "Add or remove approved IMAP flags on one or more emails by email_id. Supported flags are \\Seen, \\Flagged, \\Answered, and \\Draft; \\Deleted and provider-specific keywords are not supported. Use list_emails_metadata first. Partial or ambiguous effects report per-ID succeeded/failed/unknown status and are not retried automatically.",
+            "inputSchema": {
+                "properties": {
+                    "account_name": {
+                        "description": "The name of the email account.",
+                        "maxLength": 256,
+                        "title": "Account Name",
+                        "type": "string"
+                    },
+                    "email_ids": {
+                        "description": "List of email_id values whose flags should be changed.",
+                        "items": {
+                            "maxLength": 10,
+                            "pattern": "^[1-9][0-9]*$",
+                            "type": "string"
+                        },
+                        "maxItems": 100,
+                        "minItems": 1,
+                        "title": "Email Ids",
+                        "type": "array"
+                    },
+                    "operation": {
+                        "description": "Whether to add or remove every supplied flag.",
+                        "enum": ["add", "remove"],
+                        "title": "Operation",
+                        "type": "string"
+                    },
+                    "flags": {
+                        "description": "Unique approved flags to add or remove: \\Seen, \\Flagged, \\Answered, or \\Draft.",
+                        "items": {
+                            "enum": [
+                                "\\Seen",
+                                "\\Flagged",
+                                "\\Answered",
+                                "\\Draft"
+                            ],
+                            "type": "string"
+                        },
+                        "maxItems": 4,
+                        "minItems": 1,
+                        "title": "Flags",
+                        "type": "array"
+                    },
+                    "mailbox": {
+                        "default": "INBOX",
+                        "description": "The mailbox containing the emails.",
+                        "maxLength": 1024,
+                        "title": "Mailbox",
+                        "type": "string"
+                    }
+                },
+                "required": ["account_name", "email_ids", "operation", "flags"],
+                "title": "set_email_flagsArguments",
+                "type": "object"
+            },
+            "outputSchema": {
+                "properties": {
+                    "result": {
+                        "title": "Result",
+                        "type": "string"
+                    }
+                },
+                "required": ["result"],
+                "title": "set_email_flagsOutput",
+                "type": "object"
+            },
+            "annotations": {
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true,
+                "openWorldHint": true
+            }
+        },
+        {
             "name": "mark_emails_as_read",
-            "description": "Mark one or more emails as read by email_id. Use list_emails_metadata first. Partial or ambiguous effects report per-ID succeeded/failed/unknown status and are not retried automatically.",
+            "description": "Mark one or more emails as read by email_id. This is the common-workflow equivalent of adding \\Seen with set_email_flags. Use list_emails_metadata first. Partial or ambiguous effects report per-ID succeeded/failed/unknown status and are not retried automatically.",
             "inputSchema": {
                 "properties": {
                     "account_name": {

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -1155,7 +1155,7 @@ class TestBatchFetchDates:
         with >1000 responses in a single buffer, this exceeds Python's default
         recursion limit and causes a RecursionError / infinite hang.
 
-        See: https://github.com/wh1isper/mcp-email-server/pull/155
+        See: https://github.com/Wh1isper/mcp-email-server/pull/155
         """
         # Simulate a mailbox with 1500 UIDs — must result in multiple chunks
         num_uids = 1500

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,7 +1,7 @@
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from mcp.types import TextContent
@@ -21,6 +21,7 @@ from mcp_email_server.app import (
     move_emails,
     save_to_mailbox,
     send_email,
+    set_email_flags,
 )
 from mcp_email_server.application.accounts import AvailableAccount, EffectiveConfiguration
 from mcp_email_server.application.limits import APPLICATION_LIMITS
@@ -31,6 +32,7 @@ from mcp_email_server.application.mutations import (
     RecipientPolicyDeniedError,
     SendMutationOutcome,
     SentCopyMutationOutcome,
+    SetEmailFlagsCommand,
     TargetMutationOutcome,
 )
 from mcp_email_server.config import EmailServer, EmailSettings, ProviderSettings
@@ -390,7 +392,13 @@ class TestMcpTools:
         content_ids = tools["get_emails_content"]["email_ids"]
         assert content_ids["maxItems"] == APPLICATION_LIMITS.content_email_ids
         assert content_ids["items"]["maxLength"] == len(str(APPLICATION_LIMITS.maximum_imap_uid))
-        for tool_name in ("delete_emails", "mark_emails_as_read", "move_emails", "archive_emails"):
+        for tool_name in (
+            "delete_emails",
+            "set_email_flags",
+            "mark_emails_as_read",
+            "move_emails",
+            "archive_emails",
+        ):
             ids = tools[tool_name]["email_ids"]
             assert ids["maxItems"] == APPLICATION_LIMITS.mutation_uids
             assert ids["items"]["maxLength"] == len(str(APPLICATION_LIMITS.maximum_imap_uid))
@@ -405,6 +413,11 @@ class TestMcpTools:
         flags = tools["save_to_mailbox"]["flags"]["anyOf"][0]
         assert flags["maxItems"] == APPLICATION_LIMITS.flags
         assert flags["items"]["maxLength"] == APPLICATION_LIMITS.flag_bytes
+        mutable_flags = tools["set_email_flags"]["flags"]
+        assert mutable_flags["minItems"] == 1
+        assert mutable_flags["maxItems"] == 4
+        assert mutable_flags["items"]["enum"] == [r"\Seen", r"\Flagged", r"\Answered", r"\Draft"]
+        assert tools["set_email_flags"]["operation"]["enum"] == ["add", "remove"]
 
     @pytest.mark.asyncio
     async def test_send_email(self):
@@ -811,6 +824,63 @@ class TestMcpTools:
         with patch("mcp_email_server.app.effective_configuration", return_value=configuration):
             result = await list_allowed_senders()
         assert result == ["*@example.com", "bob@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_set_email_flags_command_dispatches_to_runtime_service() -> None:
+    outcome = _batch_outcome(succeeded=("1",))
+    runtime = MagicMock()
+    runtime.mutations.set_flags.execute = AsyncMock(return_value=outcome)
+    command = SetEmailFlagsCommand("test", ("1",), "add", (r"\Seen",))
+
+    with patch("mcp_email_server.app.get_application_runtime", return_value=runtime):
+        assert await app_module.set_email_flags_command(command) is outcome
+
+    runtime.mutations.set_flags.execute.assert_awaited_once_with(command)
+
+
+@pytest.mark.asyncio
+async def test_set_email_flags_maps_command_and_formats_success() -> None:
+    command_handler = AsyncMock(return_value=_batch_outcome(succeeded=("1", "2")))
+    with patch("mcp_email_server.app.set_email_flags_command", command_handler):
+        result = await set_email_flags(
+            "test",
+            ["1", "2"],
+            "remove",
+            [r"\Seen", r"\Flagged"],
+            "Archive",
+        )
+
+    assert result == r"Successfully removed \Seen, \Flagged from 2 email(s)"
+    command = command_handler.await_args.args[0]
+    assert command.account_name == "test"
+    assert command.email_ids == ("1", "2")
+    assert command.operation == "remove"
+    assert command.flags == (r"\Seen", r"\Flagged")
+    assert command.mailbox == "Archive"
+
+
+@pytest.mark.asyncio
+async def test_set_email_flags_formats_add_success() -> None:
+    command_handler = AsyncMock(return_value=_batch_outcome(succeeded=("1",)))
+    with patch("mcp_email_server.app.set_email_flags_command", command_handler):
+        result = await set_email_flags("test", ["1"], "add", [r"\Flagged"])
+
+    assert result == r"Successfully added \Flagged to 1 email(s)"
+
+
+@pytest.mark.asyncio
+async def test_set_email_flags_formats_partial_and_ambiguous_outcomes() -> None:
+    command_handler = AsyncMock(
+        return_value=BatchMutationOutcome((
+            TargetMutationOutcome("1", "succeeded"),
+            TargetMutationOutcome("2", "unknown", "store-unknown"),
+        ))
+    )
+    with patch("mcp_email_server.app.set_email_flags_command", command_handler):
+        result = await set_email_flags("test", ["1", "2"], "add", [r"\Flagged"])
+
+    assert result == "Set-flags result [succeeded: 1; unknown: 2 (store-unknown); warning: reconciliation needed]"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mutation_adapters.py
+++ b/tests/test_mutation_adapters.py
@@ -7,19 +7,19 @@ import pytest
 from mcp_email_server.adapters.mutations import ClassicMutationProvider
 from mcp_email_server.application.mutations import (
     AppendMutationOutcome,
-    MarkReadCommand,
     MutationAccountSnapshot,
     MutationProviderError,
     SaveToMailboxCommand,
     SendCommand,
     SentCopyMutationOutcome,
+    SetEmailFlagsCommand,
 )
 from mcp_email_server.config import EmailSettings
 
 
-def _mark_read_provider(error: BaseException) -> ClassicMutationProvider:
+def _set_flags_provider(error: BaseException) -> ClassicMutationProvider:
     handler = MagicMock()
-    handler.incoming_client.mark_emails_as_read_with_outcome = AsyncMock(side_effect=error)
+    handler.incoming_client.set_email_flags_with_outcome = AsyncMock(side_effect=error)
     return ClassicMutationProvider(handler)
 
 
@@ -37,10 +37,10 @@ def _account() -> MutationAccountSnapshot:
     ],
 )
 async def test_mutation_adapter_preserves_control_and_policy_exceptions(error: BaseException) -> None:
-    provider = _mark_read_provider(error)
+    provider = _set_flags_provider(error)
 
     with pytest.raises(type(error)) as caught:
-        await provider.mark_read(MarkReadCommand("primary", ("1",)), _account())
+        await provider.set_flags(SetEmailFlagsCommand("primary", ("1",), "add", (r"\Seen",)), _account())
 
     assert caught.value is error
 
@@ -48,16 +48,36 @@ async def test_mutation_adapter_preserves_control_and_policy_exceptions(error: B
 @pytest.mark.asyncio
 async def test_mutation_adapter_sanitizes_unexpected_provider_failure() -> None:
     provider_detail = "provider-controlled secret detail"
-    provider = _mark_read_provider(RuntimeError(provider_detail))
+    provider = _set_flags_provider(RuntimeError(provider_detail))
 
     with pytest.raises(
         MutationProviderError,
         match=r"^provider_failure: mutation provider request failed$",
     ) as caught:
-        await provider.mark_read(MarkReadCommand("primary", ("1",)), _account())
+        await provider.set_flags(SetEmailFlagsCommand("primary", ("1",), "add", (r"\Seen",)), _account())
 
     assert provider_detail not in str(caught.value)
     assert caught.value.__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test_mutation_adapter_forwards_generic_flag_contract_and_policy() -> None:
+    outcome = MagicMock()
+    handler = MagicMock()
+    handler.incoming_client.set_email_flags_with_outcome = AsyncMock(return_value=outcome)
+    provider = ClassicMutationProvider(handler)
+    account = MutationAccountSnapshot("primary", "managed", ("*@allowed.test",), (), True)
+    command = SetEmailFlagsCommand("primary", ("1", "2"), "remove", (r"\Seen", r"\Flagged"), "Archive")
+
+    assert await provider.set_flags(command, account) is outcome
+    handler.incoming_client.set_email_flags_with_outcome.assert_awaited_once_with(
+        ["1", "2"],
+        "remove",
+        [r"\Seen", r"\Flagged"],
+        "Archive",
+        ["*@allowed.test"],
+        True,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_mutation_application.py
+++ b/tests/test_mutation_application.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,8 +17,10 @@ from mcp_email_server.application.mutations import (
     BatchMutationOutcome,
     DeleteCommand,
     DeliveryMutationOutcome,
+    FlagOperation,
     MarkReadCommand,
     MoveCommand,
+    MutableEmailFlag,
     MutationAccountSnapshot,
     MutationProjectionError,
     MutationProviderAccess,
@@ -27,6 +30,7 @@ from mcp_email_server.application.mutations import (
     SendCommand,
     SendMutationOutcome,
     SentCopyMutationOutcome,
+    SetEmailFlagsCommand,
     TargetMutationOutcome,
 )
 from mcp_email_server.emails.classic import ClassicEmailHandler
@@ -72,6 +76,50 @@ def _services(
     )
 
 
+@pytest.mark.parametrize(
+    ("operation", "flags", "message"),
+    [
+        ("replace", (r"\Seen",), "operation must be"),
+        ("add", (), "flags must not be empty"),
+        (
+            "add",
+            (r"\Seen", r"\Flagged", r"\Answered", r"\Draft", r"\Seen"),
+            "flags must contain at most",
+        ),
+        ("remove", (1,), "flags must contain strings"),
+        ("remove", (r"\Seen", r"\Seen"), "flags must not contain duplicates"),
+        ("add", (r"\Deleted",), "unsupported mutable email flag"),
+        ("remove", (r"\Recent",), "unsupported mutable email flag"),
+        ("add", ("ProviderKeyword",), "unsupported mutable email flag"),
+    ],
+)
+def test_set_email_flags_command_rejects_unsupported_contract(
+    operation: str,
+    flags: tuple[object, ...],
+    message: str,
+) -> None:
+    command = SetEmailFlagsCommand(
+        "primary",
+        ("1",),
+        cast(FlagOperation, operation),
+        cast(tuple[MutableEmailFlag, ...], flags),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        command.validate()
+
+
+@pytest.mark.parametrize("operation", ["add", "remove"])
+def test_set_email_flags_command_accepts_supported_contract(operation: FlagOperation) -> None:
+    SetEmailFlagsCommand(
+        "primary",
+        ("1", "2"),
+        operation,
+        (r"\Seen", r"\Flagged", r"\Answered", r"\Draft"),
+        "Archive",
+    ).validate()
+
+
 def test_unknown_outcome_models_always_require_reconciliation() -> None:
     batch = BatchMutationOutcome((TargetMutationOutcome("1", "unknown"),))
     append = AppendMutationOutcome("unknown", "", mailbox="Drafts")
@@ -93,7 +141,7 @@ def test_unknown_outcome_models_always_require_reconciliation() -> None:
 @pytest.mark.asyncio
 async def test_mark_read_unknown_is_not_replayed_and_invalidates_projection() -> None:
     provider = MagicMock()
-    provider.mark_read = AsyncMock(
+    provider.set_flags = AsyncMock(
         return_value=_batch(
             TargetMutationOutcome("9", "succeeded"),
             TargetMutationOutcome("10", "unknown", "store"),
@@ -106,7 +154,10 @@ async def test_mark_read_unknown_is_not_replayed_and_invalidates_projection() ->
     assert result.targets("succeeded") == ["9"]
     assert result.targets("unknown") == ["10"]
     assert result.reconciliation_needed is True
-    provider.mark_read.assert_awaited_once()
+    provider.set_flags.assert_awaited_once()
+    flag_command = provider.set_flags.await_args.args[0]
+    assert flag_command.operation == "add"
+    assert flag_command.flags == (r"\Seen",)
     factory.open.assert_called_once_with("primary", expected_mode="managed", purpose="incoming")
     projection.invalidate.assert_awaited_once_with(("INBOX",))
 
@@ -563,11 +614,11 @@ async def test_mutation_timeout_is_unknown_and_never_replayed(monkeypatch, workf
     services, _, _, projection = _services(provider=provider)
 
     if workflow == "mark_read":
-        provider.mark_read = AsyncMock(side_effect=_hang_provider)
+        provider.set_flags = AsyncMock(side_effect=_hang_provider)
         result = await services.mark_read.execute(MarkReadCommand("primary", ("7", "8")))
         assert result.targets("unknown") == ["7", "8"]
         assert result.reconciliation_needed is True
-        provider.mark_read.assert_awaited_once()
+        provider.set_flags.assert_awaited_once()
         projection.invalidate.assert_awaited_once_with(("INBOX",))
     elif workflow == "save":
         provider.save_to_mailbox = AsyncMock(side_effect=_hang_provider)

--- a/tests/test_mutation_provider_outcomes.py
+++ b/tests/test_mutation_provider_outcomes.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiosmtplib.errors import SMTPRecipientRefused, SMTPResponseException
 
+from mcp_email_server.application.mutations import FlagOperation, MutableEmailFlag
 from mcp_email_server.emails.classic import EmailClient
 
 
@@ -57,6 +59,67 @@ async def test_mark_read_disconnect_response_is_unknown(email_server) -> None:
         result = await client.mark_emails_as_read_with_outcome(["8"], allowed_senders=[])
 
     assert (result.outcomes[0].status, result.outcomes[0].detail) == ("unknown", "store-unknown")
+
+
+@pytest.mark.asyncio
+async def test_set_email_flags_removes_multiple_flags_with_silent_store(email_server) -> None:
+    client = EmailClient(email_server)
+    imap = _imap()
+    with patch.object(client, "_connect_imap", AsyncMock(return_value=imap)):
+        result = await client.set_email_flags_with_outcome(
+            ["8", "9"],
+            "remove",
+            [r"\Seen", r"\Flagged"],
+            mailbox="Archive",
+            allowed_senders=[],
+        )
+
+    assert result.targets("succeeded") == ["8", "9"]
+    assert [call.args for call in imap.uid.await_args_list] == [
+        ("store", "8", "-FLAGS.SILENT", r"(\Seen \Flagged)"),
+        ("store", "9", "-FLAGS.SILENT", r"(\Seen \Flagged)"),
+    ]
+    imap.select.assert_awaited_once_with('"Archive"')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("operation", "flags", "message"),
+    [
+        ("replace", [r"\Seen"], "operation must be"),
+        ("add", [], "flags must not be empty"),
+        (
+            "add",
+            [r"\Seen", r"\Flagged", r"\Answered", r"\Draft", r"\Seen"],
+            "flags must contain at most",
+        ),
+        ("remove", [1], "flags must contain strings"),
+        ("remove", [r"\Seen", r"\Seen"], "flags must not contain duplicates"),
+        ("add", [r"\Deleted"], "unsupported mutable email flag"),
+        ("remove", [r"\Recent"], "unsupported mutable email flag"),
+        ("add", ["ProviderKeyword"], "unsupported mutable email flag"),
+    ],
+)
+async def test_set_email_flags_rejects_invalid_contract_before_connect(
+    email_server,
+    operation: str,
+    flags: list[object],
+    message: str,
+) -> None:
+    client = EmailClient(email_server)
+    connect = AsyncMock()
+
+    with (
+        patch.object(client, "_connect_imap", connect),
+        pytest.raises(ValueError, match=message),
+    ):
+        await client.set_email_flags_with_outcome(
+            ["8"],
+            cast(FlagOperation, operation),
+            cast(list[MutableEmailFlag], flags),
+        )
+
+    connect.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add `set_email_flags` with one `add`/`remove` operation and the portable mutable flags `\\Seen`, `\\Flagged`, `\\Answered`, and `\\Draft`
- preserve sender-policy filtering, per-UID effect outcomes, timeout/reconciliation behavior, and metadata projection invalidation
- keep focused `mark_emails_as_read` while delegating it to the same generic flag mutation workflow
- reject `\\Deleted`, `\\Recent`, duplicate flags, and provider-specific keywords before provider access
- update the MCP catalog snapshot, specifications, user/security documentation, and canonical repository URLs

## Validation

- `make check`
- `make test` — 1137 passed, 5 deselected; 86.23% coverage
- changed production lines — 66/66 covered (100%)
- `make docs-test`
- `make test-e2e` — 5 passed against GreenMail
- independent code review — no P0/P1/P2/P3 findings
- GitHub Actions — all required checks passed

Closes #148
