### PR TITLE
Fix RFC 2971 ID compatibility for strict IMAP servers

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -340,6 +340,20 @@ sent_folder_name = "INBOX.Sent"
 Set `save_to_sent = false` if the provider already stores sent messages and an
 additional append is unnecessary.
 
+## IMAP reports a malformed `ID` command
+
+`mcp-email-server` sends at most one compact RFC 2971 `ID` command after login,
+and only when the IMAP server advertises the `ID` capability. This form supports
+strict parsers such as NetEase while avoiding an optional command on providers
+that do not implement the extension.
+
+If logs still show `BAD malformed command`, `IMAP ID command failed`, or a
+subsequent `provider_failure`, first upgrade to a release containing the latest
+IMAP compatibility fixes. Then run `mcp-email-server account test ACCOUNT
+incoming` from a visible terminal. If it still fails, report the provider, server
+hostname, application version, and sanitized IMAP command/response sequence.
+Never include the username, password, message data, or authentication payload.
+
 ## IMAP or SMTP TLS fails
 
 Verify that the port and TLS mode match the provider:

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import binascii
 import email.utils
-import inspect
 import mimetypes
 import re
 import ssl
@@ -455,42 +454,65 @@ def _html_to_text(html: str) -> str:
     return text.strip()
 
 
+def _discard_imap_after_id_failure(
+    imap: aioimaplib.IMAP4 | aioimaplib.IMAP4_SSL,
+    command: aioimaplib.Command,
+) -> None:
+    """Abort an IMAP stream whose ID response boundary is no longer known."""
+    protocol = imap.protocol
+    if protocol is None:
+        return
+    transport = protocol.transport
+    if transport is not None:
+        with suppress(Exception):
+            if isinstance(transport, asyncio.WriteTransport):
+                transport.abort()
+            else:
+                transport.close()
+    imap.protocol = None
+    pending_command = protocol.pending_async_commands.get(command.untagged_resp_name)
+    if pending_command is command:
+        protocol.pending_async_commands.pop(command.untagged_resp_name, None)
+    command.close(b"IMAP ID connection aborted", "KO")
+
+
 async def _send_imap_id(imap: aioimaplib.IMAP4 | aioimaplib.IMAP4_SSL) -> None:
-    """Send IMAP ID command with fallback for strict servers like 163.com.
+    """Send one compact RFC 2971 ID command when the server advertises it.
 
-    aioimaplib's id() method sends ID command with spaces between parentheses
-    and content (e.g., 'ID ( "name" "value" )'), which some strict IMAP servers
-    like 163.com reject with 'BAD Parse command error'.
-
-    This function first tries the standard id() method, and if it fails,
-    falls back to sending a raw command with correct format.
+    aioimaplib formats ID lists with spaces immediately inside the parentheses,
+    which the RFC 2971 grammar does not permit and strict servers such as
+    163.com reject. Send the conformant compact form directly instead of first
+    issuing a malformed command and then retrying it.
 
     See: https://github.com/Wh1isper/mcp-email-server/issues/85
+    See: https://github.com/Wh1isper/mcp-email-server/issues/217
     """
+    protocol = imap.protocol
+    if protocol is None:
+        logger.warning("IMAP ID command failed: IMAP protocol is not connected")
+        return
+    if "ID" not in _imap_capabilities(imap):
+        return
+    command = aioimaplib.Command(
+        "ID",
+        protocol.new_tag(),
+        '("name" "mcp-email-server" "version" "1.0.0")',
+        timeout=imap.timeout,
+    )
     try:
-        response = await imap.id(name="mcp-email-server", version="1.0.0")
-        if response.result != "OK":
-            # Fallback for strict servers (e.g., 163.com)
-            # Send raw command with correct parenthesis format
-            protocol = imap.protocol
-            if protocol is None:
-                logger.warning("IMAP ID command failed: IMAP protocol is not connected")
-                return
-            new_tag = protocol.new_tag()
-            # aioimaplib 2.x returns str; retain compatibility with releases or
-            # test doubles that expose an awaitable tag generator.
-            if inspect.isawaitable(new_tag):
-                new_tag = await new_tag
-            await protocol.execute(
-                aioimaplib.Command(
-                    "ID",
-                    new_tag,
-                    '("name" "mcp-email-server" "version" "1.0.0")',
-                )
-            )
+        response = await protocol.execute(command)
     except asyncio.CancelledError:
+        _discard_imap_after_id_failure(imap, command)
         raise
+    except aioimaplib.CommandTimeout:
+        _discard_imap_after_id_failure(imap, command)
+        logger.warning("IMAP ID command timed out")
+        raise TimeoutError("IMAP ID command timed out") from None
     except Exception:
+        _discard_imap_after_id_failure(imap, command)
+        logger.warning("IMAP ID command failed")
+        raise ImapTransportError("IMAP ID command failed (TRANSPORT)") from None
+    if _imap_status(response) != "OK":
         logger.warning("IMAP ID command failed")
 
 

--- a/tests/test_imap_starttls.py
+++ b/tests/test_imap_starttls.py
@@ -3,11 +3,13 @@ import ssl
 from email.mime.text import MIMEText
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aioimaplib
 import pytest
 
 from mcp_email_server.config import EmailServer, EmailSettings
 from mcp_email_server.emails.classic import (
     EmailClient,
+    ImapTransportError,
     _create_starttls_ssl_context,
     _imap_starttls,
     _send_imap_id,
@@ -22,16 +24,18 @@ class Response:
 
 def _make_imap(capabilities=("IMAP4rev1", "STARTTLS")):
     imap = AsyncMock()
+    imap.timeout = 10
     imap._client_task = asyncio.Future()
     imap._client_task.set_result(None)
     imap.wait_hello_from_server = AsyncMock()
     imap.protocol = MagicMock()
     imap.protocol.capabilities = set(capabilities)
+    imap.protocol.pending_async_commands = {}
     imap.protocol.loop = asyncio.get_event_loop()
     imap.protocol.new_tag.return_value = "A001"
     imap.protocol.execute = AsyncMock(return_value=Response("OK"))
     imap.protocol.capability = AsyncMock()
-    imap.protocol.transport = MagicMock()
+    imap.protocol.transport = MagicMock(spec=asyncio.Transport)
     return imap
 
 
@@ -78,15 +82,115 @@ def test_create_starttls_ssl_context_verify_false_is_permissive():
 
 
 @pytest.mark.asyncio
+async def test_send_imap_id_sends_one_compact_command():
+    imap = _make_imap(capabilities=(b"imap4rev1", b"id"))
+
+    await _send_imap_id(imap)
+
+    imap.id.assert_not_awaited()
+    imap.protocol.execute.assert_awaited_once()
+    command = imap.protocol.execute.await_args.args[0]
+    assert command.name == "ID"
+    assert command.tag == "A001"
+    assert command.args == ('("name" "mcp-email-server" "version" "1.0.0")',)
+    assert command._timeout == imap.timeout
+
+
+@pytest.mark.asyncio
+async def test_send_imap_id_skips_server_without_capability():
+    imap = _make_imap(capabilities=("IMAP4rev1",))
+
+    await _send_imap_id(imap)
+
+    imap.id.assert_not_awaited()
+    imap.protocol.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_imap_id_logs_non_ok_response_without_retrying():
+    imap = _make_imap(capabilities=("IMAP4rev1", "ID"))
+    imap.protocol.execute.return_value = Response("BAD")
+
+    with patch("mcp_email_server.emails.classic.logger.warning") as mock_warning:
+        await _send_imap_id(imap)
+
+    imap.protocol.execute.assert_awaited_once()
+    mock_warning.assert_called_once_with("IMAP ID command failed")
+
+
+@pytest.mark.asyncio
+async def test_send_imap_id_discards_connection_after_timeout():
+    imap = _make_imap(capabilities=("IMAP4rev1", "ID"))
+    protocol = imap.protocol
+
+    async def time_out(command: aioimaplib.Command) -> None:
+        protocol.pending_async_commands["ID"] = command
+        raise aioimaplib.CommandTimeout(command)
+
+    protocol.execute.side_effect = time_out
+
+    with (
+        patch("mcp_email_server.emails.classic.logger.warning") as mock_warning,
+        pytest.raises(TimeoutError, match="IMAP ID command timed out"),
+    ):
+        await _send_imap_id(imap)
+
+    assert imap.protocol is None
+    assert protocol.pending_async_commands == {}
+    protocol.transport.abort.assert_called_once_with()
+    mock_warning.assert_called_once_with("IMAP ID command timed out")
+
+
+@pytest.mark.asyncio
+async def test_send_imap_id_discards_connection_on_cancellation():
+    imap = _make_imap(capabilities=("IMAP4rev1", "ID"))
+    protocol = imap.protocol
+    command_started = asyncio.Event()
+
+    async def wait_for_response(command: aioimaplib.Command) -> None:
+        protocol.pending_async_commands["ID"] = command
+        command_started.set()
+        await asyncio.Future()
+
+    protocol.execute.side_effect = wait_for_response
+    operation = asyncio.create_task(_send_imap_id(imap))
+    await command_started.wait()
+    operation.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await operation
+
+    assert imap.protocol is None
+    assert protocol.pending_async_commands == {}
+    protocol.transport.abort.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_send_imap_id_discards_connection_after_transport_failure():
+    imap = _make_imap(capabilities=("IMAP4rev1", "ID"))
+    protocol = imap.protocol
+    protocol.execute.side_effect = ConnectionError("provider detail")
+
+    with (
+        patch("mcp_email_server.emails.classic.logger.warning") as mock_warning,
+        pytest.raises(ImapTransportError, match=r"IMAP ID command failed \(TRANSPORT\)"),
+    ):
+        await _send_imap_id(imap)
+
+    assert imap.protocol is None
+    protocol.transport.abort.assert_called_once_with()
+    mock_warning.assert_called_once_with("IMAP ID command failed")
+
+
+@pytest.mark.asyncio
 async def test_send_imap_id_handles_missing_protocol():
     imap = AsyncMock()
-    imap.id.return_value = Response("BAD")
     imap.protocol = None
 
     with patch("mcp_email_server.emails.classic.logger.warning") as mock_warning:
         await _send_imap_id(imap)
 
-    imap.id.assert_awaited_once_with(name="mcp-email-server", version="1.0.0")
+    imap.id.assert_not_awaited()
     mock_warning.assert_called_once_with("IMAP ID command failed: IMAP protocol is not connected")
 
 


### PR DESCRIPTION
## Summary

- send IMAP `ID` only when the server advertises the RFC 2971 capability
- send the conformant compact parameter-list form directly instead of trying aioimaplib's padded form first
- keep tagged non-OK responses non-fatal, but discard an IMAP stream when timeout, cancellation, or transport failure makes its response boundary uncertain
- add regression coverage for capability gating, exact wire arguments, tagged failures, timeout cleanup, external cancellation, and bounded transport errors
- document troubleshooting for malformed `ID` responses

## RFC 2971 notes

RFC 2971 defines `id_params_list` as a parenthesized list without padding immediately inside the parentheses. The emitted command is therefore:

```text
ID ("name" "mcp-email-server" "version" "1.0.0")
```

The extension is used only when `ID` is present in `CAPABILITY`. A completed tagged `BAD` response has a known protocol boundary and remains safe to ignore; a timeout or execution failure aborts and detaches the connection so a delayed tagged response cannot corrupt a later command.

## Validation

- `make check`
- `make test` — 1160 passed, 5 deselected
- `make docs-test`
- `make test-e2e` — 5 passed
- live unauthenticated handshake probes against `imap.ukr.net` and `imap.163.com` completed `ID` and `LOGOUT` successfully with the new helper

Closes #217