### PR TITLE
feat(attachments): add safe default download directory

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -569,13 +569,27 @@ Or:
 MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD=true
 ```
 
-Use an absolute destination path with `download_attachment` so the target is
-unambiguous. The implementation also accepts relative paths and resolves them
-against the server process's working directory. The application fetches at most
-a 50 MiB raw message, accepts at most 25 MiB of decoded attachment bytes, and
-passes bytes rather than a path to the artifact writer. The writer operates only
-on the exact requested target. Filesystem capability preflight occurs before
-credential resolution, provider construction, download, or MIME decoding.
+Omit `save_path` to use the default application download area. The adapter resolves
+the current user's Downloads location, creates an `mcp-email-server` child, and
+uses a bounded sanitized attachment basename plus a cryptographically random
+suffix. On Windows, the adapter uses a recognized absolute Downloads Known
+Folder registry value and otherwise falls back to the profile's `~/Downloads`;
+other platforms use `~/Downloads`. Missing components are created through the secure
+traversal. A redirected Windows location is accepted when it remains on safe
+local fixed NTFS storage; unsupported or unsafe redirection fails closed. The
+application child, not the general Downloads directory, is the sensitive
+immediate parent and receives the platform private profile when created. The
+adapter never falls back to the process working directory or changes the
+Downloads parent's permissions.
+
+An explicit `save_path` remains supported for compatibility. Prefer an absolute
+path so the target is unambiguous; relative explicit paths resolve against the
+server process's working directory and are never silently rewritten. The
+application fetches at most a 50 MiB raw message, accepts at most 25 MiB of
+decoded attachment bytes, and passes bytes rather than a path to the artifact
+writer. The writer operates only on the explicit or preflight-resolved target.
+Filesystem capability preflight occurs before credential resolution, provider
+construction, download, or MIME decoding.
 
 On POSIX, the writer traverses parent components through pinned no-follow
 directory descriptors, rejects unsafe ownership or writable non-sticky parents,
@@ -586,11 +600,13 @@ parent descriptor, and verifies final identity and size.
 On Windows, the writer applies the [local fixed NTFS boundary](#windows-filesystem-boundary),
 rejects every reparse point and hard-linked/permissive target, creates a private
 same-directory sibling, flushes it, performs same-volume write-through replace,
-and verifies final volume/file identity and size. Pre-replace failure preserves
-an existing target. The next operation removes only old prefix-matching temporary
-files that still pass owner, DACL, type, link, age, and identity checks. No
-platform uses a weaker path-based fallback. An existing private regular file at
-the exact requested path can be replaced.
+and verifies final volume/file identity and size. Broader permissions on held
+Downloads ancestors do not need to be removed; only the application child is the
+sensitive immediate parent. Pre-replace failure preserves an existing target.
+The next operation removes only old prefix-matching temporary files that still
+pass owner, DACL, type, link, age, and identity checks. No platform uses a weaker
+path-based fallback. An existing private regular file at the exact explicit or
+resolved path can be replaced.
 
 These traversals prevent provider-controlled filenames and common
 symlink/junction/FIFO/device races from redirecting the write; they are not a

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -355,9 +355,16 @@ blocked IDs.
 
 ### `download_attachment`
 
-Downloads one named attachment from a message and writes it to a path on the
-server host. Use an absolute path when possible. A relative path is resolved
-against the server process's working directory.
+Downloads one named attachment from a message to the server host. By default,
+the server creates a safe randomized filename under the current user's
+`Downloads/mcp-email-server` directory. On Windows, it uses a valid Downloads
+Known Folder registry value and otherwise falls back to the profile's `~/Downloads`; on
+other platforms it uses `~/Downloads`. The returned
+`saved_path` reports the resolved absolute destination.
+
+`save_path` is optional. When supplied, it remains an exact destination: use an
+absolute path when possible. A relative explicit path is resolved against the
+server process's working directory.
 
 The tool is registered even when downloading is disabled, but calling it then
 raises a permission error. Enable it explicitly with:
@@ -366,16 +373,21 @@ raises a permission error. Enable it explicitly with:
 enable_attachment_download = true
 ```
 
-The application checks current account and feature policy, then preflights the
-local destination before provider construction, credential resolution, download,
-or MIME decoding. It checks authority again after fetch immediately before the
-write, so revocation during a slow fetch discards the payload. Raw messages above
-50 MiB and decoded attachments above 25 MiB are rejected. The mail adapter
-returns bytes only and never receives the path.
+The application checks current account and feature policy, resolves and
+preflights the local destination before provider construction, credential
+resolution, download, or MIME decoding. For a default destination, it sanitizes
+the attachment name, removes path/device syntax, adds a cryptographically random
+suffix, and creates the application subdirectory with private permissions. It
+checks authority again after fetch immediately before the write, so revocation
+during a slow fetch discards the payload. Raw messages above 50 MiB and decoded
+attachments above 25 MiB are rejected. The mail adapter returns bytes only and
+never receives the resolved path.
 
-The artifact adapter writes only the exact destination. POSIX uses pinned
-no-follow directory descriptors and owner-only files. Windows supports only a
-local fixed NTFS drive-letter path and uses held non-reparse handles, protected
+The artifact adapter writes only the explicit or preflight-resolved destination.
+It never falls back to the process working directory when default resolution
+fails. POSIX uses pinned no-follow directory descriptors and owner-only files.
+Windows supports only a local fixed NTFS drive-letter path and uses held
+non-reparse handles, protected
 DACLs, hard-link/identity checks, `FlushFileBuffers`, and same-volume
 write-through replacement. Symlinked or junction parents, linked/permissive or
 non-regular targets, UNC/network/device/alternate-stream/non-NTFS paths, and

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -401,17 +401,31 @@ Or:
 MCP_EMAIL_SERVER_ENABLE_ATTACHMENT_DOWNLOAD=true
 ```
 
-Use an absolute `save_path` when possible and ensure the server process can
-write to its parent directory. A relative path is resolved against the server
-process's working directory. Filesystem support is checked before provider
-fetch. The destination fails closed if any parent is a symlink/reparse point or
-not a directory, or if the target is linked, permissive, a FIFO/device, or other
-non-regular object.
+Normally omit `save_path`. The server then creates a safe randomized file under the
+current user's `Downloads/mcp-email-server` directory and returns its absolute
+path. It securely creates missing components and gives the application child
+private permissions; it does not change permissions on the general Downloads
+directory. Windows accepts a redirected Downloads Known Folder when it remains
+on safe local fixed NTFS storage and falls back to the profile's `~/Downloads`
+when the registry value is unavailable, malformed, or non-absolute. If the resolved location
+fails the platform security profile, use an explicit safe local destination
+instead.
+
+For an explicit destination, use an absolute `save_path` when possible and
+ensure the server process can write to its parent directory. A relative path is
+resolved against the server process's working directory. Filesystem support is
+checked before provider fetch. The destination fails closed if any parent is a
+symlink/reparse point or not a directory, or if the target is linked,
+permissive, a FIFO/device, or another non-regular object.
 
 On Windows, use an ordinary local fixed NTFS drive-letter path with a parent
 directory below the volume root; direct `C:\\file`-style storage is unsupported.
-Junctions and all reparse tags are rejected along with UNC/mapped network paths, `\\?\\`/`\\.\\`
-device paths, alternate streams such as `file:stream`, and FAT/exFAT. Move the
+For an explicit path, the immediate parent must not grant another SID permission
+to create, modify, delete, or change security on entries. Read-only ACEs do not
+need to be removed. The default application child avoids requiring the Downloads
+folder itself to satisfy this sensitive-parent rule. Junctions and all reparse
+tags are rejected along with UNC/mapped network paths, `\\?\\`/`\\.\\` device
+paths, alternate streams such as `file:stream`, and FAT/exFAT. Move the
 destination to local NTFS rather than bypassing the check. Old application temp
 files are deleted only after bounded owner/DACL/type/link/identity validation;
 a substituted or unverified entry is deliberately left untouched.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -130,8 +130,9 @@ file/directory symlinks, a Developer-
 Mode-independent junction, hard links, owner/DACL policy, lock contention and
 killed-owner release, concurrent and crash-boundary replacement, complete-old-
 or-new atomicity, validated stale cleanup, managed bootstrap/catalog plus
-the private SQLite secret store, attachment preflight, and spill lifecycle. A
-missing
+the private SQLite secret store, explicit attachment preflight, default private
+attachment-directory creation below a shared Downloads ancestor, and spill
+lifecycle. A missing
 symlink privilege fails the native gate distinctly; symlink, junction, DACL,
 lock, crash, and atomic-write coverage may not be replaced by mocks.
 

--- a/mcp_email_server/adapters/reads.py
+++ b/mcp_email_server/adapters/reads.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import errno
 import os
+import re
 import secrets
 import stat
+import unicodedata
 from pathlib import Path
 from typing import Any
 
@@ -169,9 +172,86 @@ _SECURE_ATTACHMENT_WRITES_SUPPORTED = (
     and os.stat in os.supports_follow_symlinks
 ) or (os.name == "nt" and windows_security_supported())
 
+_DEFAULT_ATTACHMENT_DIRECTORY = "mcp-email-server"
+_DEFAULT_FILENAME_INVALID = re.compile(r'[<>:"/\\|?*\x00-\x1f\x7f]')
+_WINDOWS_DOWNLOADS_FOLDER_ID = "{374DE290-123F-4565-9164-39C4925E467B}"
+
+if os.name == "nt":  # pragma: win32 cover
+    import winreg as _winreg
+else:
+    _winreg = None
+winreg: Any = _winreg
+
+
+def _truncate_utf8(value: str, maximum_bytes: int) -> str:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= maximum_bytes:
+        return value
+    return encoded[:maximum_bytes].decode("utf-8", errors="ignore")
+
+
+def _safe_default_filename(attachment_name: str) -> str:
+    normalized = unicodedata.normalize("NFC", attachment_name)
+    without_controls = "".join(
+        "_" if unicodedata.category(character) in {"Cc", "Cf", "Cs"} else character for character in normalized
+    )
+    cleaned = _DEFAULT_FILENAME_INVALID.sub("_", without_controls).strip(" .")
+    if not cleaned:
+        cleaned = "attachment"
+    suffix = Path(cleaned).suffix
+    if len(suffix.encode("utf-8")) > 24:
+        suffix = ""
+    stem = cleaned[: -len(suffix)] if suffix else cleaned
+    stem = _truncate_utf8(stem.rstrip(" ."), 160).rstrip(" .") or "attachment"
+    return f"{stem}-{secrets.token_hex(16)}{suffix}"
+
+
+def _windows_downloads_registry_value() -> tuple[object, int] | None:
+    if winreg is None:
+        return None
+    key_path = r"Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders"
+    try:
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path) as key:
+            result = winreg.QueryValueEx(key, _WINDOWS_DOWNLOADS_FOLDER_ID)
+    except OSError:
+        return None
+    if not isinstance(result, tuple) or len(result) != 2 or not isinstance(result[1], int):
+        return None
+    return result
+
+
+def _default_downloads_directory() -> Path:
+    if os.name == "nt" and winreg is not None:  # pragma: no cover - native Windows CI
+        entry = _windows_downloads_registry_value()
+        if entry is not None:
+            value, value_type = entry
+            if isinstance(value, str) and value_type in {winreg.REG_SZ, winreg.REG_EXPAND_SZ}:
+                try:
+                    expanded = Path(os.path.expandvars(value)).expanduser()
+                except (OSError, ValueError):
+                    pass
+                else:
+                    if expanded.is_absolute():
+                        return expanded
+    return Path.home() / "Downloads"
+
+
+def _resolve_artifact_destination(save_path: str | None, attachment_name: str) -> Path:
+    try:
+        requested = (
+            Path(save_path).expanduser()
+            if save_path is not None
+            else _default_downloads_directory()
+            / _DEFAULT_ATTACHMENT_DIRECTORY
+            / _safe_default_filename(attachment_name)
+        )
+        return Path(os.path.abspath(requested))
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise PermissionError("Attachment destination could not be resolved") from exc
+
 
 class LocalArtifactWriter:
-    """Write an exact caller path through the platform filesystem-security adapter."""
+    """Resolve and securely write an explicit or default local artifact path."""
 
     @staticmethod
     def _validate_directory(descriptor: int) -> None:
@@ -203,7 +283,11 @@ class LocalArtifactWriter:
                             dir_fd=directory_descriptor,
                         )
                     except FileNotFoundError:
-                        os.mkdir(component, mode=0o700, dir_fd=directory_descriptor)
+                        # Another preflight may create the same component first.
+                        # Reopen it through the pinned no-follow descriptor and
+                        # apply the full validation below.
+                        with contextlib.suppress(FileExistsError):
+                            os.mkdir(component, mode=0o700, dir_fd=directory_descriptor)
                         child_descriptor = os.open(
                             component,
                             directory_flags,
@@ -298,8 +382,8 @@ class LocalArtifactWriter:
             os.close(parent_descriptor)
 
     @staticmethod
-    def _preflight(save_path: str) -> None:
-        path = Path(os.path.abspath(Path(save_path).expanduser()))
+    def _preflight(save_path: str | None, attachment_name: str) -> str:
+        path = _resolve_artifact_destination(save_path, attachment_name)
         if not _SECURE_ATTACHMENT_WRITES_SUPPORTED:
             raise PermissionError(
                 "Attachment download is unavailable because this platform cannot enforce secure destination traversal"
@@ -307,19 +391,20 @@ class LocalArtifactWriter:
         try:
             if os.name == "nt":  # pragma: no cover - native Windows CI
                 preflight_artifact_destination(path)
-                return
+                return path.as_posix()
             parent_descriptor = LocalArtifactWriter._open_posix_parent(path)
             try:
                 LocalArtifactWriter._validate_existing_target(parent_descriptor, path.name)
             finally:
                 os.close(parent_descriptor)
+            return path.as_posix()
         except PermissionError:
             raise
         except (OSError, WindowsSecurityError) as exc:
             raise PermissionError("Attachment destination parent is unsafe") from exc
 
-    async def preflight(self, save_path: str) -> None:
-        await asyncio.to_thread(self._preflight, save_path)
+    async def preflight(self, save_path: str | None, attachment_name: str) -> str:
+        return await asyncio.to_thread(self._preflight, save_path, attachment_name)
 
     @staticmethod
     def _write(save_path: str, payload: AttachmentPayload) -> str:

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -879,7 +879,7 @@ async def list_mailboxes(
 
 
 @mcp.tool(
-    description="Download an email attachment and save it to the specified path. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
+    description="Download an email attachment. By default it is saved with a safe randomized name under the current user's Downloads/mcp-email-server directory; an explicit destination path remains supported. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
     annotations=_FILESYSTEM_WRITE,
 )
 async def download_attachment(
@@ -901,12 +901,12 @@ async def download_attachment(
         ),
     ],
     save_path: Annotated[
-        str,
+        str | None,
         Field(
             max_length=APPLICATION_LIMITS.attachment_path_bytes,
-            description="The destination path. Relative paths are resolved against the server process working directory; absolute paths are recommended.",
+            description="Optional exact destination path. Omit it to use a safe randomized filename under the current user's Downloads/mcp-email-server directory. Relative explicit paths are resolved against the server process working directory.",
         ),
-    ],
+    ] = None,
     mailbox: Annotated[
         str,
         Field(

--- a/mcp_email_server/application/reads.py
+++ b/mcp_email_server/application/reads.py
@@ -111,7 +111,7 @@ class DownloadAttachmentCommand:
     account_name: str
     email_id: str
     attachment_name: str
-    save_path: str
+    save_path: str | None = None
     mailbox: str = "INBOX"
 
     def validate(self) -> None:
@@ -123,11 +123,12 @@ class DownloadAttachmentCommand:
             field_name="attachment_name",
             maximum_bytes=APPLICATION_LIMITS.attachment_path_bytes,
         )
-        validate_controlled_string(
-            self.save_path,
-            field_name="save_path",
-            maximum_bytes=APPLICATION_LIMITS.attachment_path_bytes,
-        )
+        if self.save_path is not None:
+            validate_controlled_string(
+                self.save_path,
+                field_name="save_path",
+                maximum_bytes=APPLICATION_LIMITS.attachment_path_bytes,
+            )
 
 
 class ReadAccountAuthority(Protocol):
@@ -166,7 +167,7 @@ class ReadProviderFactory(Protocol):
 
 
 class ArtifactWriter(Protocol):
-    async def preflight(self, save_path: str) -> None: ...
+    async def preflight(self, save_path: str | None, attachment_name: str) -> str: ...
 
     async def write(self, save_path: str, payload: AttachmentPayload) -> str: ...
 
@@ -378,9 +379,9 @@ class AttachmentDownloadService:
             raise PermissionError(
                 "Attachment download is disabled. Set 'enable_attachment_download=true' in settings to enable this feature."
             )
-        # Reject unsupported or unsafe local storage before credential resolution,
-        # provider construction, download, or MIME decoding.
-        await self._artifacts.preflight(command.save_path)
+        # Resolve and reject unsupported or unsafe local storage before credential
+        # resolution, provider construction, download, or MIME decoding.
+        resolved_path = await self._artifacts.preflight(command.save_path, command.attachment_name)
         access = self._providers.open(account.account_name, expected_mode=account.mode)
         if not access.account.enable_attachment_download:
             raise PermissionError(
@@ -394,7 +395,7 @@ class AttachmentDownloadService:
             raise PermissionError(
                 "Attachment download is disabled. Set 'enable_attachment_download=true' in settings to enable this feature."
             )
-        saved_path = await self._artifacts.write(command.save_path, payload)
+        saved_path = await self._artifacts.write(resolved_path, payload)
         response = AttachmentDownloadResponse(
             email_id=payload.email_id,
             attachment_name=payload.attachment_name,

--- a/spec/02-domain-model-and-authority.md
+++ b/spec/02-domain-model-and-authority.md
@@ -95,18 +95,19 @@ their identity and coverage tokens provide projection qualification.
 
 ## Authority Matrix
 
-| Concept                                      | Authority                                | Consequence                                          |
-| -------------------------------------------- | ---------------------------------------- | ---------------------------------------------------- |
-| process mode and selected catalog path       | bootstrap snapshot                       | frozen until restart                                 |
-| managed account, policy, lifecycle, revision | selected managed catalog                 | no environment or TOML override                      |
-| managed secret value                         | `SecretStore`                            | never copied to catalog or ordinary cache            |
-| managed binding lifecycle                    | selected catalog                         | value operations coordinate through revisioned state |
-| legacy effective account                     | TOML plus environment composition        | available only in legacy mode                        |
-| provider capability                          | current provider session evidence        | rechecked when safety depends on it                  |
-| mailbox/message state                        | IMAP                                     | index absence cannot delete provider truth           |
-| SMTP delivery                                | SMTP response evidence                   | not inferred from sent-copy state                    |
-| sent-copy placement                          | IMAP APPEND evidence                     | independent from SMTP delivery                       |
-| attachment destination                       | caller request plus current local policy | exact path, no implicit rewrite                      |
+| Concept                                      | Authority                                | Consequence                                                  |
+| -------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------ |
+| process mode and selected catalog path       | bootstrap snapshot                       | frozen until restart                                         |
+| managed account, policy, lifecycle, revision | selected managed catalog                 | no environment or TOML override                              |
+| managed secret value                         | `SecretStore`                            | never copied to catalog or ordinary cache                    |
+| managed binding lifecycle                    | selected catalog                         | value operations coordinate through revisioned state         |
+| legacy effective account                     | TOML plus environment composition        | available only in legacy mode                                |
+| provider capability                          | current provider session evidence        | rechecked when safety depends on it                          |
+| mailbox/message state                        | IMAP                                     | index absence cannot delete provider truth                   |
+| SMTP delivery                                | SMTP response evidence                   | not inferred from sent-copy state                            |
+| sent-copy placement                          | IMAP APPEND evidence                     | independent from SMTP delivery                               |
+| explicit attachment destination              | caller request plus current local policy | exact path, no implicit rewrite                              |
+| default attachment destination               | local artifact adapter                   | resolved before provider work under validated download child |
 
 ## Provider Outcomes
 

--- a/spec/06-mail-read-model-and-metadata-index.md
+++ b/spec/06-mail-read-model-and-metadata-index.md
@@ -120,12 +120,24 @@ Body reads:
 
 Marking read is a separate mutation under spec 07.
 
-## Attachment Retrieval and Exact Destination
+## Attachment Retrieval and Destination Selection
 
 Attachment materialization is an explicit local filesystem effect. The caller
-supplies the exact destination path. Compatibility requires preserving that
-path; the service MUST NOT silently rewrite it into an approved workspace,
-rename it, or append a provider filename.
+may supply an exact destination path. Compatibility requires preserving an
+explicit path; the service MUST NOT silently rewrite it into an approved
+workspace, rename it, or append a provider filename.
+
+When the caller omits the destination, the local artifact adapter resolves the
+current user's Downloads location and uses an `mcp-email-server` subdirectory
+beneath it, creating that child with private permissions when absent. It
+derives a bounded safe leaf name from the selected attachment name and adds a
+cryptographically random suffix before filesystem
+preflight. Provider-controlled path components, traversal, device names, and
+platform-invalid characters are never used verbatim. The resolved absolute path
+is fixed before provider construction and is used unchanged for the later write.
+Failure to resolve or validate the default directory fails before provider work;
+the adapter never weakens its platform profile or falls back to the process
+working directory.
 
 The effect is permitted only when:
 
@@ -146,8 +158,10 @@ The effect is permitted only when:
 10. final identity, type, owner, permissions or DACL, link count, and size are
     revalidated before success is returned.
 
-On Windows this effect is supported only on local fixed NTFS storage under spec 08. It creates a random same-directory sibling exclusively with a protected
-private DACL, writes through a held non-reparse handle, calls
+On Windows this effect is supported only on local fixed NTFS storage under spec 08.
+
+It creates a random same-directory sibling exclusively with a protected private
+DACL, writes through a held non-reparse handle, calls
 `FlushFileBuffers`, and replaces with
 `MoveFileExW(MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)` when overwrite
 is allowed. `MOVEFILE_COPY_ALLOWED` is forbidden. The target is reopened with
@@ -157,10 +171,10 @@ preserves an existing target. Cleanup deletes only a verified object created by
 the operation; a crash remnant is eligible only for the bounded prefix-, owner-,
 DACL-, type-, and identity-validated cleanup in spec 08.
 
-The result reports the exact requested destination in a bounded local-only
-response. Logs and remote/provider errors do not include it. Partial files are
-removed when their identity can be proven; otherwise the operation returns a
-bounded cleanup warning without deleting an unverified path.
+The result reports the exact explicit or resolved destination in a bounded
+local-only response. Logs and remote/provider errors do not include it. Partial
+files are removed when their identity can be proven; otherwise the operation
+returns a bounded cleanup warning without deleting an unverified path.
 
 ## Index Writes and Failures
 
@@ -189,12 +203,13 @@ catalog authority or secret binding state.
    to the documented limit without persisting content or reply-thread headers;
    tests cover present, absent, whitespace-only, folded, duplicate, malformed,
    per-field, and aggregate `In-Reply-To`/`References` behavior.
-6. Attachment tests cover explicit enablement, exact path preservation, size
-   limits, capability preflight before provider work, symlinks, Windows
-   junctions and other reparse points, hard links, non-regular targets,
-   permissions/DACLs, no-clobber/overwrite, concurrent and crash-boundary
-   replacement, validated partial/stale cleanup, final identity, and absence of
-   path leakage to provider. Windows filesystem cases run on real NTFS rather
-   than mocks alone.
+6. Attachment tests cover explicit enablement, exact explicit-path
+   preservation, default Downloads/application-child resolution, safe
+   randomized leaf naming, size limits, capability preflight before provider
+   work, symlinks, Windows junctions and other reparse points, hard links,
+   non-regular targets, permissions/DACLs, no-clobber/overwrite, concurrent and
+   crash-boundary replacement, validated partial/stale cleanup, final identity,
+   and absence of path leakage to provider. Windows filesystem cases run on real
+   NTFS rather than mocks alone.
 7. Projection failure cannot turn known provider read evidence into a false mail
    failure, and rebuild cannot alter catalog or credential state.

--- a/spec/08-sqlite-persistence-and-filesystem-security.md
+++ b/spec/08-sqlite-persistence-and-filesystem-security.md
@@ -133,7 +133,12 @@ those rights cannot retarget the held chain. The exact file and any non-private
 sensitive immediate parent still reject untrusted write/delete/ACL-owner access
 and reparse substitution. A null DACL, unresolved ownership, or an owner outside
 the trusted set fails closed throughout the chain. Private immediate parents use
-the stricter private-object policy and reject every untrusted allow ACE.
+the stricter private-object policy and reject every untrusted allow ACE. The
+default attachment destination therefore uses a newly created private
+`mcp-email-server` directory below the user's Downloads location rather than
+requiring the Downloads directory itself to satisfy the sensitive-parent DACL
+profile. The Downloads ancestors remain subject to volume, ownership, reparse,
+and held-handle identity validation and are never automatically rehardened.
 
 ## Mandatory Pre-open Sequence
 

--- a/tests/fixtures/mcp_catalog.json
+++ b/tests/fixtures/mcp_catalog.json
@@ -1438,7 +1438,7 @@
         },
         {
             "name": "download_attachment",
-            "description": "Download an email attachment and save it to the specified path. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
+            "description": "Download an email attachment. By default it is saved with a safe randomized name under the current user's Downloads/mcp-email-server directory; an explicit destination path remains supported. This feature must be explicitly enabled in settings (enable_attachment_download=true) due to security considerations.",
             "inputSchema": {
                 "properties": {
                     "account_name": {
@@ -1460,10 +1460,18 @@
                         "type": "string"
                     },
                     "save_path": {
-                        "description": "The destination path. Relative paths are resolved against the server process working directory; absolute paths are recommended.",
-                        "maxLength": 4096,
-                        "title": "Save Path",
-                        "type": "string"
+                        "anyOf": [
+                            {
+                                "maxLength": 4096,
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "default": null,
+                        "description": "Optional exact destination path. Omit it to use a safe randomized filename under the current user's Downloads/mcp-email-server directory. Relative explicit paths are resolved against the server process working directory.",
+                        "title": "Save Path"
                     },
                     "mailbox": {
                         "default": "INBOX",
@@ -1473,12 +1481,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "account_name",
-                    "email_id",
-                    "attachment_name",
-                    "save_path"
-                ],
+                "required": ["account_name", "email_id", "attachment_name"],
                 "title": "download_attachmentArguments",
                 "type": "object"
             },

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -519,6 +519,29 @@ class TestMcpTools:
         assert command.mailbox == "INBOX"
 
     @pytest.mark.asyncio
+    async def test_download_attachment_allows_default_destination(self):
+        attachment_response = AttachmentDownloadResponse(
+            email_id="12345",
+            attachment_name="document.pdf",
+            mime_type="application/pdf",
+            size=1024,
+            saved_path="/home/user/Downloads/mcp-email-server/document-abcd.pdf",
+        )
+        command_handler = AsyncMock(return_value=attachment_response)
+
+        with patch("mcp_email_server.app.download_attachment_command", command_handler):
+            result = await download_attachment(
+                account_name="test_account",
+                email_id="12345",
+                attachment_name="document.pdf",
+            )
+
+        assert result == attachment_response
+        command = command_handler.await_args.args[0]
+        assert command.save_path is None
+        assert command.mailbox == "INBOX"
+
+    @pytest.mark.asyncio
     async def test_send_email_with_reply_headers(self):
         command_handler = AsyncMock(
             return_value=SendMutationOutcome(

--- a/tests/test_read_adapters.py
+++ b/tests/test_read_adapters.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import asyncio
 import os
 import stat
+import threading
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import ANY, AsyncMock, Mock
 
 import pytest
 
@@ -235,7 +236,8 @@ async def test_artifact_writer_writes_only_explicit_regular_file(tmp_path: Path)
     destination = tmp_path / "downloads" / "document.pdf"
     payload = AttachmentPayload("1", "document.pdf", "application/pdf", b"document")
 
-    await LocalArtifactWriter().preflight(str(destination))
+    resolved = await LocalArtifactWriter().preflight(str(destination), payload.attachment_name)
+    assert resolved == destination.as_posix()
     assert not destination.exists()
     saved_path = await LocalArtifactWriter().write(str(destination), payload)
 
@@ -245,13 +247,183 @@ async def test_artifact_writer_writes_only_explicit_regular_file(tmp_path: Path)
         assert stat.S_IMODE(destination.stat().st_mode) == 0o600
 
 
+def test_default_attachment_filename_is_bounded_and_preserves_short_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(reads_adapter.secrets, "token_hex", lambda _length: "0123456789abcdef" * 2)
+
+    filename = reads_adapter._safe_default_filename(f"{'é' * 2000}.pdf")
+
+    assert len(filename.encode("utf-8")) <= 217
+    assert filename.endswith("-0123456789abcdef0123456789abcdef.pdf")
+
+
+def test_default_attachment_filename_removes_unicode_format_controls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reads_adapter.secrets, "token_hex", lambda _length: "0123456789abcdef" * 2)
+
+    filename = reads_adapter._safe_default_filename("invoice\u202efdp.exe")
+
+    assert "\u202e" not in filename
+    assert filename == "invoice_fdp-0123456789abcdef0123456789abcdef.exe"
+
+
+def test_windows_downloads_registry_lookup_is_bounded_and_handles_access_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RegistryKey:
+        def __enter__(self) -> object:
+            return object()
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    registry = Mock(
+        HKEY_CURRENT_USER=object(),
+        REG_SZ=1,
+        REG_EXPAND_SZ=2,
+        OpenKey=Mock(return_value=RegistryKey()),
+        QueryValueEx=Mock(return_value=(r"%USERPROFILE%\Downloads", 2)),
+    )
+    monkeypatch.setattr(reads_adapter, "winreg", registry)
+
+    assert reads_adapter._windows_downloads_registry_value() == (r"%USERPROFILE%\Downloads", 2)
+    registry.QueryValueEx.assert_called_once_with(ANY, reads_adapter._WINDOWS_DOWNLOADS_FOLDER_ID)
+
+    registry.OpenKey.side_effect = OSError("access denied")
+    assert reads_adapter._windows_downloads_registry_value() is None
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows Known Folder contract")
+def test_windows_default_downloads_directory_expands_and_validates_registry_value(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    assert reads_adapter.winreg is not None
+    monkeypatch.setenv("MCP_EMAIL_TEST_DOWNLOADS", os.fspath(tmp_path))
+    monkeypatch.setattr(
+        reads_adapter,
+        "_windows_downloads_registry_value",
+        lambda: (r"%MCP_EMAIL_TEST_DOWNLOADS%\Relocated", reads_adapter.winreg.REG_EXPAND_SZ),
+    )
+
+    assert reads_adapter._default_downloads_directory() == tmp_path / "Relocated"
+
+    monkeypatch.setattr(
+        reads_adapter,
+        "_windows_downloads_registry_value",
+        lambda: ("relative", reads_adapter.winreg.REG_SZ),
+    )
+    assert reads_adapter._default_downloads_directory() == Path.home() / "Downloads"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "posix", reason="POSIX concurrent directory creation contract")
+async def test_artifact_writer_concurrent_default_first_use_reopens_created_directory(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    downloads = tmp_path / "Downloads"
+    downloads.mkdir()
+    monkeypatch.setattr(reads_adapter, "_default_downloads_directory", lambda: downloads)
+    real_mkdir = os.mkdir
+    creation_barrier = threading.Barrier(2)
+
+    def concurrent_mkdir(path: str, *args: object, **kwargs: object) -> None:
+        if path == "mcp-email-server":
+            creation_barrier.wait(timeout=5)
+        real_mkdir(path, *args, **kwargs)
+
+    monkeypatch.setattr(os, "mkdir", concurrent_mkdir)
+    writer = LocalArtifactWriter()
+
+    destinations = await asyncio.gather(
+        writer.preflight(None, "first.pdf"),
+        writer.preflight(None, "second.pdf"),
+    )
+
+    assert len(destinations) == 2
+    assert {Path(destination).parent for destination in destinations} == {downloads / "mcp-email-server"}
+
+
+@pytest.mark.asyncio
+async def test_artifact_writer_uses_private_default_download_subdirectory_and_safe_randomized_name(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    downloads = tmp_path / "Downloads"
+    monkeypatch.setattr(reads_adapter, "_default_downloads_directory", lambda: downloads)
+    monkeypatch.setattr(reads_adapter.secrets, "token_hex", lambda _length: "0123456789abcdef0123456789abcdef")
+    payload = AttachmentPayload("1", "../CON?.pdf", "application/pdf", b"document")
+
+    resolved = await LocalArtifactWriter().preflight(None, payload.attachment_name)
+    expected = downloads / "mcp-email-server" / "_CON_-0123456789abcdef0123456789abcdef.pdf"
+    saved_path = await LocalArtifactWriter().write(resolved, payload)
+
+    assert resolved == expected.as_posix()
+    assert saved_path == expected.as_posix()
+    assert expected.read_bytes() == b"document"
+    assert not (tmp_path / "CON?.pdf").exists()
+    if os.name == "posix":
+        assert stat.S_IMODE(expected.parent.stat().st_mode) == 0o700
+        assert stat.S_IMODE(expected.stat().st_mode) == 0o600
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "nt", reason="native Windows DACL contract")
+async def test_artifact_writer_default_private_child_allows_shared_downloads_ancestor(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import ntsecuritycon
+    import win32con
+    import win32security
+
+    from mcp_email_server.windows_security import validate_private_directory
+
+    downloads = tmp_path / "Downloads"
+    downloads.mkdir()
+    descriptor = win32security.GetNamedSecurityInfo(
+        os.fspath(downloads),
+        win32security.SE_FILE_OBJECT,
+        win32security.DACL_SECURITY_INFORMATION,
+    )
+    dacl = descriptor.GetSecurityDescriptorDacl()
+    everyone = win32security.CreateWellKnownSid(win32security.WinWorldSid, None)
+    rights = ntsecuritycon.FILE_ADD_SUBDIRECTORY | ntsecuritycon.FILE_DELETE_CHILD | ntsecuritycon.GENERIC_WRITE
+    dacl.AddAccessAllowedAceEx(win32security.ACL_REVISION, 0, rights, everyone)
+    win32security.SetNamedSecurityInfo(
+        os.fspath(downloads),
+        win32security.SE_FILE_OBJECT,
+        win32security.DACL_SECURITY_INFORMATION,
+        None,
+        None,
+        dacl,
+        None,
+    )
+    monkeypatch.setattr(reads_adapter, "_default_downloads_directory", lambda: downloads)
+    monkeypatch.setattr(reads_adapter.secrets, "token_hex", lambda _length: "0123456789abcdef0123456789abcdef")
+    payload = AttachmentPayload("1", "document.pdf", "application/pdf", b"document")
+
+    with pytest.raises(PermissionError, match="parent is unsafe"):
+        await LocalArtifactWriter().preflight(str(downloads / "direct.pdf"), payload.attachment_name)
+
+    resolved = await LocalArtifactWriter().preflight(None, payload.attachment_name)
+    saved_path = await LocalArtifactWriter().write(resolved, payload)
+
+    expected = downloads / "mcp-email-server" / "document-0123456789abcdef0123456789abcdef.pdf"
+    assert saved_path == expected.as_posix()
+    assert expected.read_bytes() == b"document"
+    identity = validate_private_directory(expected.parent)
+    assert identity.attributes & win32con.FILE_ATTRIBUTE_DIRECTORY
+
+
 @pytest.mark.asyncio
 async def test_artifact_writer_fails_closed_without_pinned_traversal(monkeypatch, tmp_path: Path) -> None:
     destination = tmp_path / "download.txt"
     monkeypatch.setattr("mcp_email_server.adapters.reads._SECURE_ATTACHMENT_WRITES_SUPPORTED", False)
 
     with pytest.raises(PermissionError, match="platform cannot enforce"):
-        await LocalArtifactWriter().preflight(str(destination))
+        await LocalArtifactWriter().preflight(str(destination), "download.txt")
     with pytest.raises(PermissionError, match="platform cannot enforce"):
         await LocalArtifactWriter().write(
             str(destination),
@@ -272,7 +444,7 @@ async def test_artifact_writer_rejects_symlink_destination_without_overwrite(tmp
         pytest.skip("symlinks unavailable")
 
     with pytest.raises(PermissionError):
-        await LocalArtifactWriter().preflight(str(destination))
+        await LocalArtifactWriter().preflight(str(destination), "download.txt")
     with pytest.raises(PermissionError):
         await LocalArtifactWriter().write(
             str(destination),

--- a/tests/test_read_adapters.py
+++ b/tests/test_read_adapters.py
@@ -253,9 +253,13 @@ def test_default_attachment_filename_is_bounded_and_preserves_short_extension(
     monkeypatch.setattr(reads_adapter.secrets, "token_hex", lambda _length: "0123456789abcdef" * 2)
 
     filename = reads_adapter._safe_default_filename(f"{'é' * 2000}.pdf")
+    fallback_name = reads_adapter._safe_default_filename("...")
+    long_suffix_name = reads_adapter._safe_default_filename(f"report.{'x' * 25}")
 
     assert len(filename.encode("utf-8")) <= 217
     assert filename.endswith("-0123456789abcdef0123456789abcdef.pdf")
+    assert fallback_name == "attachment-0123456789abcdef0123456789abcdef"
+    assert long_suffix_name == f"report.{'x' * 25}-0123456789abcdef0123456789abcdef"
 
 
 def test_default_attachment_filename_removes_unicode_format_controls(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -291,6 +295,29 @@ def test_windows_downloads_registry_lookup_is_bounded_and_handles_access_errors(
 
     registry.OpenKey.side_effect = OSError("access denied")
     assert reads_adapter._windows_downloads_registry_value() is None
+
+    registry.OpenKey.side_effect = None
+    registry.QueryValueEx.return_value = "malformed"
+    assert reads_adapter._windows_downloads_registry_value() is None
+
+    monkeypatch.setattr(reads_adapter, "winreg", None)
+    assert reads_adapter._windows_downloads_registry_value() is None
+
+
+def test_default_downloads_directory_falls_back_without_windows_registry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reads_adapter, "winreg", None)
+
+    assert reads_adapter._default_downloads_directory() == Path.home() / "Downloads"
+
+
+def test_default_artifact_destination_sanitizes_resolution_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_resolution() -> Path:
+        raise OSError("home directory unavailable")
+
+    monkeypatch.setattr(reads_adapter, "_default_downloads_directory", fail_resolution)
+
+    with pytest.raises(PermissionError, match="could not be resolved"):
+        reads_adapter._resolve_artifact_destination(None, "document.pdf")
 
 
 @pytest.mark.skipif(os.name != "nt", reason="native Windows Known Folder contract")

--- a/tests/test_read_application.py
+++ b/tests/test_read_application.py
@@ -168,7 +168,7 @@ async def test_attachment_service_preflights_filesystem_before_provider_or_crede
     with pytest.raises(PermissionError, match="unsupported local storage"):
         await AttachmentDownloadService(authority, factory, artifacts).execute(command)
 
-    artifacts.preflight.assert_awaited_once_with(command.save_path)
+    artifacts.preflight.assert_awaited_once_with(command.save_path, command.attachment_name)
     factory.open.assert_not_called()
     provider.fetch_attachment.assert_not_awaited()
     artifacts.write.assert_not_awaited()
@@ -214,7 +214,7 @@ async def test_attachment_service_writes_only_bounded_provider_payload_through_a
     payload = AttachmentPayload("1", "document.pdf", "application/pdf", b"content")
     provider.fetch_attachment = AsyncMock(return_value=payload)
     artifacts = Mock()
-    artifacts.preflight = AsyncMock()
+    artifacts.preflight = AsyncMock(return_value="/approved/document.pdf")
     artifacts.write = AsyncMock(return_value="/approved/document.pdf")
     command = DownloadAttachmentCommand("work", "1", "document.pdf", "downloads/document.pdf")
 
@@ -222,7 +222,26 @@ async def test_attachment_service_writes_only_bounded_provider_payload_through_a
 
     assert response.size == len(payload.content)
     assert response.saved_path == "/approved/document.pdf"
-    artifacts.write.assert_awaited_once_with(command.save_path, payload)
+    artifacts.preflight.assert_awaited_once_with(command.save_path, command.attachment_name)
+    artifacts.write.assert_awaited_once_with("/approved/document.pdf", payload)
+
+
+@pytest.mark.asyncio
+async def test_attachment_service_uses_resolved_default_path_without_exposing_it_to_provider() -> None:
+    authority, factory, provider = _ports(initial=_account(downloads=True), fresh=_account(downloads=True))
+    payload = AttachmentPayload("1", "document.pdf", "application/pdf", b"content")
+    provider.fetch_attachment = AsyncMock(return_value=payload)
+    artifacts = Mock()
+    artifacts.preflight = AsyncMock(return_value="/home/user/Downloads/mcp-email-server/document-abcd.pdf")
+    artifacts.write = AsyncMock(return_value="/home/user/Downloads/mcp-email-server/document-abcd.pdf")
+    command = DownloadAttachmentCommand("work", "1", "document.pdf")
+
+    response = await AttachmentDownloadService(authority, factory, artifacts).execute(command)
+
+    assert response.saved_path == "/home/user/Downloads/mcp-email-server/document-abcd.pdf"
+    artifacts.preflight.assert_awaited_once_with(None, "document.pdf")
+    provider.fetch_attachment.assert_awaited_once_with(command, factory.open.return_value.account)
+    artifacts.write.assert_awaited_once_with(response.saved_path, payload)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Make save_path optional and resolve omitted destinations under a per-user Downloads/mcp-email-server directory. Preserve explicit path behavior and add cross-platform security coverage and documentation.

Assisted-by: YAAI <261597362+yaai-bot@users.noreply.github.com>
