### PR TITLE
fix(imap): parse short message literals

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -169,9 +169,11 @@ If a body extends beyond the requested window, the returned body ends with
 `max_body_length`.
 
 The batch response reports requested and retrieved counts and includes
-`failed_ids` for messages that could not be fetched. Each returned email also
-includes nullable `in_reply_to` and `references` values from the corresponding
-RFC headers. `references` is returned as one decoded, unfolded string with
+`failed_ids` for messages that could not be fetched. A full-message literal from
+a successful IMAP FETCH is parsed regardless of its byte length; protocol
+metadata without a message literal is not treated as content. Each returned
+email also includes nullable `in_reply_to` and `references` values from the
+corresponding RFC headers. `references` is returned as one decoded, unfolded string with
 folding spaces and tabs normalized. Missing and whitespace-only values become
 `null`; if an invalid message repeats either header, the parser's first observed
 value is returned. This is untrusted observational header data, not a validated

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -19,6 +19,7 @@ from email.parser import BytesParser
 from email.policy import SMTP as SMTP_POLICY
 from email.policy import SMTPUTF8 as SMTPUTF8_POLICY
 from email.policy import default
+from itertools import pairwise
 from pathlib import Path
 from typing import Any, cast
 
@@ -1486,30 +1487,34 @@ class EmailClient:
                 logger.info("IMAP logout failed")
 
     def _check_email_content(self, data: list) -> bool:
-        """Check if the fetched data contains actual email content."""
-        for item in data:
-            if isinstance(item, bytes) and b"FETCH (" in item and b"RFC822" not in item and b"BODY" not in item:
-                # This is just metadata, not actual content
-                continue
-            elif isinstance(item, bytes | bytearray) and len(item) > 100:
-                # This looks like email content
-                return True
-        return False
+        """Check whether a FETCH response contains a full-message literal."""
+        return self._extract_raw_email(data) is not None
 
     def _extract_raw_email(self, data: list) -> bytes | None:
-        """Extract raw email bytes from IMAP response data."""
-        # The email content is typically at index 1 as a bytearray
-        if len(data) > 1 and isinstance(data[1], bytearray):
-            return bytes(data[1])
+        """Extract the full-message literal that follows its FETCH marker."""
+        for marker, payload in pairwise(data):
+            if (
+                not isinstance(marker, bytes)
+                or re.match(
+                    rb"(?:\d+\s+)?FETCH\b.*(?:BODY(?:\.PEEK)?\[\]|RFC822)(?=$|[\s<{])",
+                    marker,
+                    flags=re.IGNORECASE,
+                )
+                is None
+            ):
+                continue
+            if not isinstance(payload, bytes | bytearray):
+                continue
 
-        # Search through all items for email content
-        for item in data:
-            if isinstance(item, bytes | bytearray) and len(item) > 100:
-                # Skip IMAP protocol responses
-                if isinstance(item, bytes) and b"FETCH" in item:
-                    continue
-                # This is likely the email content
-                return bytes(item) if isinstance(item, bytearray) else item
+            literal_size = re.search(rb"\{(\d+)\}\s*$", marker)
+            if literal_size is not None and len(payload) != int(literal_size.group(1)):
+                continue
+            # aioimaplib represents parsed literals as bytearray. Plain bytes are
+            # accepted only when the wire marker supplies the literal length.
+            if isinstance(payload, bytearray):
+                return bytes(payload)
+            if literal_size is not None:
+                return payload
         return None
 
     async def _fetch_email_with_formats(self, imap, email_id: str) -> list | None:

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -180,6 +180,53 @@ async def test_low_level_mutation_uid_sinks_reject_before_imap_io(email_client: 
     connect.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload_type", [bytes, bytearray])
+async def test_get_email_body_accepts_short_fetch_literal(
+    email_client: EmailClient,
+    mock_imap: AsyncMock,
+    payload_type: type[bytes] | type[bytearray],
+) -> None:
+    raw_email = b"Date: Thu, 1 Jan 2026 00:00:00 +0000\r\nFrom: a@example.test\r\nSubject: Hi\r\n\r\nOK\r\n"
+    assert len(raw_email) == 79
+    fetch_data = [b"1 FETCH (UID 1 BODY[] {79}", payload_type(raw_email), b")"]
+    mock_imap.uid = AsyncMock(return_value=("OK", fetch_data))
+
+    with patch.object(email_client, "_connect_imap", AsyncMock(return_value=mock_imap)):
+        result = await email_client.get_email_body_by_id("1")
+
+    assert result is not None
+    assert result["email_id"] == "1"
+    assert result["subject"] == "Hi"
+    assert result["body"] == "OK\r\n"
+    mock_imap.uid.assert_awaited_once_with("fetch", "1", "BODY.PEEK[]")
+
+
+@pytest.mark.parametrize("payload_type", [bytes, bytearray])
+def test_extract_raw_email_rejects_literal_length_mismatch(
+    email_client: EmailClient,
+    payload_type: type[bytes] | type[bytearray],
+) -> None:
+    payload = payload_type(b"short")
+    data = [b"1 FETCH (UID 1 BODY[] {6}", payload, b")"]
+
+    assert email_client._extract_raw_email(data) is None
+    assert email_client._check_email_content(data) is False
+
+
+@pytest.mark.asyncio
+async def test_fetch_email_rejects_protocol_metadata_without_literal(email_client: EmailClient) -> None:
+    metadata = [b"1 FETCH (UID 1 FLAGS (" + b"custom-flag " * 10 + b") RFC822.SIZE 123456)"]
+    assert len(metadata[0]) > 100
+    imap = AsyncMock()
+    imap.uid = AsyncMock(return_value=("OK", metadata))
+
+    result = await email_client._fetch_email_with_formats(imap, "1")
+
+    assert result is None
+    assert imap.uid.await_count == 2
+
+
 class TestEmailClient:
     def test_init(self, email_server):
         """Test initialization of EmailClient."""

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -214,6 +214,24 @@ def test_extract_raw_email_rejects_literal_length_mismatch(
     assert email_client._check_email_content(data) is False
 
 
+@pytest.mark.parametrize(
+    ("marker", "payload"),
+    [
+        (b"FETCH BODY[]", None),
+        (b"FETCH BODY[]", b"raw email without a literal declaration"),
+    ],
+)
+def test_extract_raw_email_rejects_non_literal_payload(
+    email_client: EmailClient,
+    marker: bytes,
+    payload: bytes | None,
+) -> None:
+    data = [marker, payload]
+
+    assert email_client._extract_raw_email(data) is None
+    assert email_client._check_email_content(data) is False
+
+
 @pytest.mark.asyncio
 async def test_fetch_email_rejects_protocol_metadata_without_literal(email_client: EmailClient) -> None:
     metadata = [b"1 FETCH (UID 1 FLAGS (" + b"custom-flag " * 10 + b") RFC822.SIZE 123456)"]


### PR DESCRIPTION
Recognize full-message FETCH literals by response structure instead of a minimum payload size. Reject metadata-only and length-mismatched responses.

Assisted-by: YAAI <261597362+yaai-bot@users.noreply.github.com>
