### PR TITLE
fix(imap): handle omitted empty search responses

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -199,12 +199,14 @@ again.
 so the application could not prove the requested page and exact filtered total
 within its work budget. Narrow the mailbox or add a date, sender, recipient,
 subject, body, text, flag, or attachment filter. Increasing `page_size` cannot
-bypass the limit; `page_size` is restricted to 1 through 100. An `invalid UID
-search results` or incomplete provider-metadata error means the server returned
-a malformed UID set or did not return exact sender/INTERNALDATE evidence for
-every requested UID. The request is rejected rather than expanding a UID range
-or returning an incorrect page; retry after the mailbox is stable or report the
-provider issue.
+bypass the limit; `page_size` is restricted to 1 through 100. Some providers,
+including iCloud, omit the untagged empty `SEARCH` response and return only a
+successful tagged completion line; this known response shape is treated as zero
+matches. An `invalid UID search results` or incomplete provider-metadata error
+means the server returned another malformed UID set or did not return exact
+sender/INTERNALDATE evidence for every requested UID. The request is rejected
+rather than expanding a UID range or returning an incorrect page; retry after
+the mailbox is stable or report the provider issue.
 
 Non-ASCII subject, body, text, sender, or recipient filters are sent as
 synchronizing UTF-8 IMAP literals with `CHARSET UTF-8`. If a provider rejects the

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -670,6 +670,15 @@ def _normalize_search_uids(messages: Any) -> list[str]:  # noqa: C901 - bounded 
     else:
         raise MetadataProviderObservationError("Provider returned invalid UID search results")
 
+    # iCloud omits the untagged `* SEARCH` line when a search has no matches.
+    # aioimaplib then exposes only the tagged completion text in `lines`, while
+    # compliant empty responses contain an empty payload before that text.
+    # Recognize only the observed completion-only format; all other non-UID
+    # payloads remain provider observation failures.
+    if len(messages) == 1 and re.fullmatch(r"SEARCH completed \(took [0-9]+ ms\)", text, flags=re.IGNORECASE):
+        logger.debug("Provider omitted the empty UID SEARCH payload; treating the successful search as empty")
+        return []
+
     result: list[str] = []
     seen: set[str] = set()
     for token in text.split():
@@ -1913,6 +1922,9 @@ class EmailClient:
                 return 0, []
 
             email_ids = _normalize_search_uids(messages)
+            if not email_ids:
+                logger.warning("No messages returned from search")
+                return 0, []
             logger.info(f"Found {len(email_ids)} email IDs")
             header_budget = _MetadataHeaderBudget()
 

--- a/tests/test_metadata_provider.py
+++ b/tests/test_metadata_provider.py
@@ -403,9 +403,61 @@ async def test_snapshot_same_count_wrong_internaldate_uid_set_cannot_claim_compl
 
 
 @pytest.mark.asyncio
+async def test_provider_fallback_treats_icloud_completion_only_search_response_as_empty() -> None:
+    client = _client()
+    imap = _imap()
+    imap.select.return_value = ("OK", [])
+    imap.uid_search.return_value = ("OK", [b"SEARCH completed (took 2 ms)"])
+    with (
+        patch.object(client, "_connect_imap", AsyncMock(return_value=imap)),
+        patch.object(client, "_batch_fetch_dates", AsyncMock()) as dates,
+        patch.object(client, "_batch_fetch_headers", AsyncMock()) as headers,
+    ):
+        total, emails = await client.get_emails_metadata()
+
+    assert total == 0
+    assert emails == []
+    dates.assert_not_awaited()
+    headers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_provider_fallback_rejects_completion_text_with_extra_response_elements() -> None:
+    client = _client()
+    imap = _imap()
+    imap.select.return_value = ("OK", [])
+    imap.uid_search.return_value = (
+        "OK",
+        [b"SEARCH completed (took 2 ms)", b"unexpected response"],
+    )
+    with (
+        patch.object(client, "_connect_imap", AsyncMock(return_value=imap)),
+        patch.object(client, "_batch_fetch_dates", AsyncMock()) as dates,
+        patch.object(client, "_batch_fetch_headers", AsyncMock()) as headers,
+    ):
+        with pytest.raises(MetadataProviderObservationError, match="invalid UID search results"):
+            await client.get_emails_metadata()
+
+    dates.assert_not_awaited()
+    headers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "search_payload",
-    [b"1:*", b"1,2", b"0", b"01", b"4294967296", b"1 1", b"\xff"],
+    [
+        b"1:*",
+        b"1,2",
+        b"0",
+        b"01",
+        b"4294967296",
+        b"1 1",
+        b"SEARCH failed",
+        b"SEARCH completed but results were omitted",
+        b"SEARCH completed (took 2 ms) trailing-data",
+        b"UID SEARCH completed (took 2 ms)",
+        b"\xff",
+    ],
 )
 async def test_provider_fallback_rejects_noncanonical_search_uids_before_fetch_work(
     search_payload: bytes,

--- a/tests/test_rfc_interoperability.py
+++ b/tests/test_rfc_interoperability.py
@@ -247,12 +247,18 @@ def _recording_imap(timeout: float = 1.0, *, fail_write_at: int | None = None):
     return imap, protocol, transport
 
 
+async def _wait_for_transport_writes(transport: _RecordingTransport, count: int = 1) -> None:
+    async with asyncio.timeout(1.0):
+        while len(transport.writes) < count:
+            await asyncio.sleep(0)
+
+
 @pytest.mark.asyncio
 async def test_uid_search_treats_icloud_completion_only_response_as_empty():
     imap, protocol, transport = _recording_imap()
 
     search_task = asyncio.create_task(_uid_search(imap, ["ALL"]))
-    await asyncio.sleep(0)
+    await _wait_for_transport_writes(transport)
 
     tag = transport.writes[0].split(maxsplit=1)[0]
     protocol.data_received(tag + b" OK SEARCH completed (took 2 ms)\r\n")

--- a/tests/test_rfc_interoperability.py
+++ b/tests/test_rfc_interoperability.py
@@ -20,6 +20,7 @@ from mcp_email_server.emails.classic import (
     _ImapAppendMode,
     _ImapSearchLiteral,
     _message_requires_smtputf8,
+    _normalize_search_uids,
     _parse_list_responses,
     _uid_search,
     _validate_flags,
@@ -244,6 +245,22 @@ def _recording_imap(timeout: float = 1.0, *, fail_write_at: int | None = None):
     imap.protocol = protocol
     imap.timeout = timeout
     return imap, protocol, transport
+
+
+@pytest.mark.asyncio
+async def test_uid_search_treats_icloud_completion_only_response_as_empty():
+    imap, protocol, transport = _recording_imap()
+
+    search_task = asyncio.create_task(_uid_search(imap, ["ALL"]))
+    await asyncio.sleep(0)
+
+    tag = transport.writes[0].split(maxsplit=1)[0]
+    protocol.data_received(tag + b" OK SEARCH completed (took 2 ms)\r\n")
+    response = await search_task
+
+    assert response.result == "OK"
+    assert response.lines == [b"SEARCH completed (took 2 ms)"]
+    assert _normalize_search_uids(response.lines) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- recognize iCloud's completion-only empty search response as zero matches
- keep UID parsing fail-closed for every other malformed payload
- skip metadata fetch work when the normalized search result is empty
- document the provider interoperability behavior

## Root cause

iCloud can omit the untagged `* SEARCH` response when a search has no matches and send only:

```text
<tag> OK SEARCH completed (took 2 ms)
```

`aioimaplib` exposes that as `Response("OK", [b"SEARCH completed (took 2 ms)"])`. The strict UID validator correctly rejects the completion text as non-numeric, but the provider intended it to represent an empty result.

This wire shape was independently captured in [Home Assistant core #132042](https://github.com/home-assistant/core/issues/132042), and its completion-only handling was validated by an iCloud user in [Home Assistant core #132081](https://github.com/home-assistant/core/pull/132081).

The compatibility exception is intentionally narrow: it requires a successful command, exactly one response element, and the observed `SEARCH completed (took <integer> ms)` format. UID ranges, comma-separated sets, duplicates, zero, leading zeroes, overflow, non-ASCII data, near matches, arbitrary suffixes, and extra response elements still fail closed.

## Tests

- protocol-level regression using the real `aioimaplib` parser
- provider-level regression proving empty results return before date/header fetches
- negative boundary coverage for malformed and near-match payloads
- `make check`
- `make test` (`1400 passed, 37 skipped, 5 deselected`; 87.55% coverage)
- `make docs-test`
- `make test-e2e` (`5 passed`)

Closes #236
