### PR TITLE
fix(metadata): apply exact datetime boundaries

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -104,7 +104,7 @@ Important parameters include:
 | `page`                        | `1`      | One-based result page.                      |
 | `page_size`                   | `10`     | Number of results per page, from 1 to 100.  |
 | `mailbox`                     | `INBOX`  | Mailbox to search.                          |
-| `before` / `since`            | None     | UTC datetime boundaries.                    |
+| `before` / `since`            | None     | Timezone-aware `INTERNALDATE` boundaries.   |
 | `subject`                     | None     | Subject filter.                             |
 | `from_address` / `to_address` | None     | Address filters.                            |
 | `seen`                        | None     | Filter by read status.                      |
@@ -119,7 +119,12 @@ Important parameters include:
 
 The response contains pagination metadata, a filtered `total`, and message
 metadata including `email_id`, `message_id`, subject, sender, recipients, and
-date. Every message also returns `provider_keywords`, containing all observed
+date. `since` is inclusive, `before` is exclusive, and both compare the
+provider's IMAP `INTERNALDATE` as an absolute instant. Each value must include a
+UTC offset; values with any valid offset are normalized to UTC. Ordering uses the
+same `INTERNALDATE` value. The returned `date` remains the message's RFC 5322
+`Date` header and can differ from the provider timestamp used for filtering and
+ordering. Every message also returns `provider_keywords`, containing all observed
 non-system IMAP keywords, and `semantic_tags`, containing the configured semantic
 names that map to those keywords. Unknown keywords remain visible in
 `provider_keywords`; standard flags remain
@@ -147,8 +152,13 @@ and reject unknown values before provider access. ASCII filter values retain the
 atom or quoted-string encoding. Non-ASCII filter values use synchronizing UTF-8
 literals with `CHARSET UTF-8`; a provider that rejects that charset returns a
 bounded search failure rather than receiving malformed raw UTF-8 command text.
-Date criteria always use the protocol's English month tokens regardless of the
-server process locale. A response normally omits `warnings`; if a validated IMAP
+Because base IMAP `BEFORE` and `SINCE` ignore the time and timezone components
+of `INTERNALDATE`, date criteria are conservative candidate filters. The server
+widens them across adjacent calendar dates, fetches complete `INTERNALDATE`
+evidence, and reapplies the exact `[since, before)` interval before calculating
+`total`, ordering, and pagination. Date criteria always use the protocol's
+English month tokens regardless of the server process locale. A response
+normally omits `warnings`; if a validated IMAP
 result was returned but its rebuildable projection could not be persisted, the
 response includes `warnings: ["projection_write_failed"]`. It never includes the
 local exception detail.

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -304,7 +304,11 @@ async def list_email_tags(
 
 
 @mcp.tool(
-    description="List email metadata (email_id, subject, sender, recipients, date) without body content. Returns email_id for use with get_emails_content.",
+    description=(
+        "List email metadata (email_id, subject, sender, recipients, date) without body content. "
+        "Time filtering and ordering use provider INTERNALDATE; the returned date is the message's RFC 5322 Date header. "
+        "Returns email_id for use with get_emails_content."
+    ),
     annotations=_READ_ONLY_REMOTE,
 )
 async def list_emails_metadata(
@@ -321,11 +325,23 @@ async def list_emails_metadata(
     ] = 10,
     before: Annotated[
         datetime | None,
-        Field(default=None, description="Retrieve emails before this datetime (UTC)."),
+        Field(
+            default=None,
+            description=(
+                "Filter to messages whose provider INTERNALDATE is earlier than this timezone-aware datetime "
+                "(exclusive); any UTC offset is accepted and normalized to UTC."
+            ),
+        ),
     ] = None,
     since: Annotated[
         datetime | None,
-        Field(default=None, description="Retrieve emails since this datetime (UTC)."),
+        Field(
+            default=None,
+            description=(
+                "Filter to messages whose provider INTERNALDATE is equal to or later than this timezone-aware "
+                "datetime (inclusive); any UTC offset is accepted and normalized to UTC."
+            ),
+        ),
     ] = None,
     subject: Annotated[
         str | None,
@@ -353,7 +369,10 @@ async def list_emails_metadata(
     ] = None,
     order: Annotated[
         Literal["asc", "desc"],
-        Field(default=None, description="Sort matching emails by date: oldest first (`asc`) or newest first (`desc`)."),
+        Field(
+            default=None,
+            description="Sort matching emails by provider INTERNALDATE: oldest first (`asc`) or newest first (`desc`).",
+        ),
     ] = "desc",
     mailbox: Annotated[
         str,

--- a/mcp_email_server/application/metadata.py
+++ b/mcp_email_server/application/metadata.py
@@ -46,6 +46,18 @@ async def _bounded_provider_call(operation: Awaitable[ProviderResultT]) -> Provi
         raise MetadataProviderError("provider request timed out") from None
 
 
+def normalize_datetime_boundary(value: datetime | None, *, field_name: str) -> datetime | None:
+    """Return one timezone-aware query boundary as a UTC instant."""
+    if value is None:
+        return None
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must include a timezone offset")
+    try:
+        return value.astimezone(UTC)
+    except (OverflowError, ValueError):
+        raise ValueError(f"{field_name} cannot be represented in UTC") from None
+
+
 @dataclass(frozen=True)
 class ListEmailMetadataQuery:
     account_name: str
@@ -80,6 +92,8 @@ class ListEmailMetadataQuery:
             raise ValueError("page_size must be between 1 and 100")
         if self.order not in ("asc", "desc"):
             raise ValueError("order must be 'asc' or 'desc'")
+        normalize_datetime_boundary(self.before, field_name="before")
+        normalize_datetime_boundary(self.since, field_name="since")
         validate_controlled_string(
             self.mailbox,
             field_name="mailbox",

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -10,7 +10,7 @@ import unicodedata
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from email import encoders
 from email.header import Header
 from email.headerregistry import Address, AddressHeader
@@ -44,6 +44,7 @@ from mcp_email_server.application.metadata import (
     MailboxState,
     MetadataProviderObservationError,
     MetadataQueryTooBroadError,
+    normalize_datetime_boundary,
 )
 from mcp_email_server.application.mutations import (
     MUTABLE_EMAIL_FLAGS,
@@ -1470,10 +1471,34 @@ class EmailClient:
         tag_match: Literal["all", "any"] = "all",
     ) -> list[ImapSearchToken]:
         search_criteria: list[ImapSearchToken] = []
-        if before:
-            search_criteria.extend(["BEFORE", f"{before.day:02d}-{_IMAP_MONTHS[before.month - 1]}-{before.year:04d}"])
-        if since:
-            search_criteria.extend(["SINCE", f"{since.day:02d}-{_IMAP_MONTHS[since.month - 1]}-{since.year:04d}"])
+        before_utc = normalize_datetime_boundary(before, field_name="before")
+        since_utc = normalize_datetime_boundary(since, field_name="since")
+
+        # IMAP BEFORE/SINCE compare only the calendar part of INTERNALDATE and
+        # disregard its time and timezone. Accepted INTERNALDATE offsets are
+        # strictly less than 24 hours, so include the adjacent local date on
+        # each side and apply the exact UTC interval after FETCH INTERNALDATE.
+        if before_utc is not None:
+            try:
+                candidate_before = before_utc.date() + timedelta(days=2)
+            except OverflowError:
+                candidate_before = None
+            if candidate_before is not None:
+                search_criteria.extend([
+                    "BEFORE",
+                    f"{candidate_before.day:02d}-{_IMAP_MONTHS[candidate_before.month - 1]}-"
+                    f"{candidate_before.year:04d}",
+                ])
+        if since_utc is not None:
+            try:
+                candidate_since = since_utc.date() - timedelta(days=1)
+            except OverflowError:
+                candidate_since = None
+            if candidate_since is not None:
+                search_criteria.extend([
+                    "SINCE",
+                    f"{candidate_since.day:02d}-{_IMAP_MONTHS[candidate_since.month - 1]}-{candidate_since.year:04d}",
+                ])
 
         # Substring-match fields (IMAP keyword, value)
         text_criteria = [
@@ -1946,6 +1971,8 @@ class EmailClient:
             raise ValueError("page must be at least 1")
         if not 1 <= page_size <= 100:
             raise ValueError("page_size must be between 1 and 100")
+        before_utc = normalize_datetime_boundary(before, field_name="before")
+        since_utc = normalize_datetime_boundary(since, field_name="since")
         imap = await self._connect_imap()
         try:
             # Login and select mailbox
@@ -1955,8 +1982,8 @@ class EmailClient:
             _raise_for_imap_error(select_response, f"SELECT mailbox {mailbox}")
 
             search_criteria = self._build_search_criteria(
-                before,
-                since,
+                before_utc,
+                since_utc,
                 subject,
                 body=body,
                 text=text,
@@ -2000,7 +2027,7 @@ class EmailClient:
                 if not email_ids:
                     return 0, []
 
-            # Phase 1: Batch fetch INTERNALDATE for sorting (sequential chunks)
+            # Phase 1: Batch fetch INTERNALDATE for exact datetime filtering and sorting.
             fetch_dates_start = time.perf_counter()
             uid_dates = await self._batch_fetch_dates(imap, email_ids)
             fetch_dates_elapsed = time.perf_counter() - fetch_dates_start
@@ -2012,6 +2039,18 @@ class EmailClient:
                 raise MetadataProviderObservationError(
                     f"Provider returned incomplete INTERNALDATE metadata for {missing_date_count} UIDs"
                 )
+
+            if before_utc is not None or since_utc is not None:
+                candidate_count = len(email_ids)
+                email_ids = [
+                    uid
+                    for uid in email_ids
+                    if (since_utc is None or uid_dates[uid] >= since_utc)
+                    and (before_utc is None or uid_dates[uid] < before_utc)
+                ]
+                logger.info(f"Exact INTERNALDATE filter: {len(email_ids)} of {candidate_count} match")
+                if not email_ids:
+                    return 0, []
 
             # Keep UID SEARCH results as the source of truth and require
             # INTERNALDATE for exact provider-compatible ordering.

--- a/spec/06-mail-read-model-and-metadata-index.md
+++ b/spec/06-mail-read-model-and-metadata-index.md
@@ -84,6 +84,23 @@ fail before provider access. The projection never answers a tag-filtered query
 because external clients may mutate keywords without changing UIDNEXT or message
 count.
 
+Metadata datetime boundaries are timezone-aware absolute instants. Any valid UTC
+offset is normalized to UTC; an offset-free value fails before account authority
+or provider access. `since` is inclusive and `before` is exclusive, forming the
+interval `[since, before)`. Filtering and ordering use IMAP `INTERNALDATE` as the
+authoritative provider timestamp. The public metadata `date` remains the RFC 5322
+message-header value and can differ from `INTERNALDATE`.
+
+Base IMAP `BEFORE` and `SINCE` disregard the time and timezone components of
+`INTERNALDATE`, so they are conservative pushdowns rather than exact datetime
+predicates. The provider widens their calendar dates enough to include every
+accepted `INTERNALDATE` offset, fetches complete `INTERNALDATE` evidence for the
+bounded candidates, and reapplies the exact interval before total calculation,
+ordering, and pagination. At a representable datetime edge where a widened date
+cannot be formed, the provider omits that coarse criterion and relies on the
+exact residual predicate. Candidate or evidence limits fail explicitly rather
+than returning an approximate total or partial page.
+
 ## Metadata Query Flow
 
 ```mermaid
@@ -249,7 +266,9 @@ catalog authority or secret binding state.
    name, delimiter, and attributes.
 2. UIDVALIDITY changes prevent prior-epoch rows from answering current queries.
 3. Exact totals require fresh qualified complete coverage; partial absence never
-   deletes or proves absence.
+   deletes or proves absence. Datetime-filtered totals and pages apply the exact
+   timezone-aware `[since, before)` interval to complete `INTERNALDATE` evidence
+   after conservative IMAP date search and before ordering or pagination.
 4. Candidate UID count, fetch batches, headers, bodies, parser work, errors, and
    serialized results have enforced ceilings, including direct service calls.
 5. Body reads use PEEK, preserve input order, and return per-item outcomes for up

--- a/spec/12-delivery-validation-and-evolution.md
+++ b/spec/12-delivery-validation-and-evolution.md
@@ -23,7 +23,7 @@ before release.
 | layers, late secrets, resource/transaction scopes  | 03                     | import/architecture, isolation, lifecycle, and transaction tests                                |
 | mode, catalog/account/policy/import lifecycle      | 04                     | application + CLI + UI contract and crash/conflict tests                                        |
 | secret rotation/removal/cleanup/redaction          | 05                     | atomic activation, unchanged-authority failure, leakage, and parity tests                       |
-| mailbox/index/body/attachment reads                | 06                     | provider fakes, SQLite, filesystem race, bounds, and GreenMail tests                            |
+| mailbox/index/body/attachment reads                | 06                     | provider fakes, exact datetime boundaries, SQLite, filesystem race, bounds, and GreenMail tests |
 | mutations and independent effects                  | 07                     | capability, ambiguity, cancellation, no-bare-expunge, SMTP/sent-copy tests                      |
 | schema, WAL/SHM security, retention/rebuild        | 08                     | exact schema/migration, POSIX + native Windows pre-open race, concurrency, corruption tests     |
 | loopback UI security and packaging                 | 09                     | backend, frontend, real-browser, artifact, and no-Node tests                                    |
@@ -116,9 +116,10 @@ satisfied by mocks.
 ### End to end
 
 GreenMail tests exercise real IMAP/SMTP through MCP stdio, including restart,
-managed selection, read/mutation evidence, RFC 5321/RFC 5322 sender separation
-when a display name contains address-special characters, and ordinary ASCII
-APPEND/search behavior. Deterministic protocol tests additionally exercise
+managed selection, read/mutation evidence, exact same-day timezone-aware
+`INTERNALDATE` filtering before total and pagination, RFC 5321/RFC 5322 sender
+separation when a display name contains address-special characters, and ordinary
+ASCII APPEND/search behavior. Deterministic protocol tests additionally exercise
 quoted/grouped RFC 5322 addresses, MIME attachment subtrees and charset failure,
 exact IMAP LIST and multi-literal SEARCH framing, SMTPUTF8 decisions, SMTP DATA
 7-bit/8-bit/binary transport classification, and RFC 6855 APPEND because the

--- a/tests/e2e/test_stdio_greenmail.py
+++ b/tests/e2e/test_stdio_greenmail.py
@@ -14,7 +14,7 @@ import time
 import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from email import policy
 from email.message import EmailMessage, Message
 from email.parser import BytesParser
@@ -225,6 +225,28 @@ def _seed_message_with_attachment_as(
 
 def _seed_message(subject: str, body: str) -> None:
     _seed_message_as(ALICE, BOB[0], subject, body)
+
+
+def _append_message_at(
+    credentials: tuple[str, str],
+    mailbox: str,
+    *,
+    sender: str,
+    recipient: str,
+    subject: str,
+    body: str,
+    internal_date: datetime,
+) -> None:
+    message = EmailMessage()
+    message["From"] = sender
+    message["To"] = recipient
+    message["Subject"] = subject
+    message["Date"] = "Fri, 01 Jan 1999 00:00:00 +0000"
+    message["Message-ID"] = make_msgid(domain="example.test")
+    message.set_content(body)
+    with _imap_session(credentials) as client:
+        status, _ = client.append(mailbox, None, internal_date, message.as_bytes())
+        assert status == "OK"
 
 
 def _mark_deleted_without_expunge(credentials: tuple[str, str], mailbox: str, uid: str) -> None:
@@ -731,9 +753,23 @@ async def test_metadata_index_paging_fallback_and_restart_reuse_against_greenmai
     _ensure_empty_mailboxes(BOB, ["INBOX"])
     run_id = uuid.uuid4().hex
     subjects = [f"metadata-index-{run_id}-{number}" for number in range(5)]
-    for number, subject in enumerate(subjects):
-        _seed_message(subject, f"indexed body {number}; unique needle {run_id}-{number}")
-        _wait_for_message(BOB, "INBOX", subject)
+    internal_dates = [
+        datetime(2026, 9, 2, 16, 47, 59, tzinfo=UTC),
+        datetime(2026, 9, 2, 16, 48, tzinfo=UTC),
+        datetime(2026, 9, 2, 17, 0, tzinfo=UTC),
+        datetime(2026, 9, 2, 19, 12, 59, tzinfo=UTC),
+        datetime(2026, 9, 2, 19, 13, tzinfo=UTC),
+    ]
+    for number, (subject, internal_date) in enumerate(zip(subjects, internal_dates, strict=True)):
+        _append_message_at(
+            BOB,
+            "INBOX",
+            sender=ALICE[0],
+            recipient=BOB[0],
+            subject=subject,
+            body=f"indexed body {number}; unique needle {run_id}-{number}",
+            internal_date=internal_date,
+        )
     flagged = _wait_for_message(BOB, "INBOX", subjects[2])
     _add_flags(BOB, "INBOX", flagged.uid, r"\Seen \Flagged")
 
@@ -812,6 +848,31 @@ async def test_metadata_index_paging_fallback_and_restart_reuse_against_greenmai
                             {"account_name": "bob", "page_size": 10, **filters},
                         )
                         assert result["total"] == expected_total, (filters, result)
+
+                    datetime_arguments = {
+                        "account_name": "bob",
+                        "page_size": 2,
+                        "since": "2026-09-02T16:48:00Z",
+                        "before": "2026-09-02T19:13:00Z",
+                    }
+                    datetime_first = await _call_tool(
+                        session,
+                        "list_emails_metadata",
+                        datetime_arguments,
+                    )
+                    datetime_second = await _call_tool(
+                        session,
+                        "list_emails_metadata",
+                        {**datetime_arguments, "page": 2},
+                    )
+                    assert datetime_first["total"] == datetime_second["total"] == 3
+                    assert [email["subject"] for email in datetime_first["emails"]] == [subjects[3], subjects[2]]
+                    assert [email["subject"] for email in datetime_second["emails"]] == [subjects[1]]
+                    assert all(
+                        email["date"].startswith("1999-01-01")
+                        for email in datetime_first["emails"] + datetime_second["emails"]
+                    )
+
                     invalid = await session.call_tool(
                         "list_emails_metadata",
                         arguments={"account_name": "bob", "page_size": 101},

--- a/tests/fixtures/mcp_catalog.json
+++ b/tests/fixtures/mcp_catalog.json
@@ -150,7 +150,7 @@
         },
         {
             "name": "list_emails_metadata",
-            "description": "List email metadata (email_id, subject, sender, recipients, date) without body content. Returns email_id for use with get_emails_content.",
+            "description": "List email metadata (email_id, subject, sender, recipients, date) without body content. Time filtering and ordering use provider INTERNALDATE; the returned date is the message's RFC 5322 Date header. Returns email_id for use with get_emails_content.",
             "inputSchema": {
                 "properties": {
                     "account_name": {
@@ -185,7 +185,7 @@
                             }
                         ],
                         "default": null,
-                        "description": "Retrieve emails before this datetime (UTC).",
+                        "description": "Filter to messages whose provider INTERNALDATE is earlier than this timezone-aware datetime (exclusive); any UTC offset is accepted and normalized to UTC.",
                         "title": "Before"
                     },
                     "since": {
@@ -199,7 +199,7 @@
                             }
                         ],
                         "default": null,
-                        "description": "Retrieve emails since this datetime (UTC).",
+                        "description": "Filter to messages whose provider INTERNALDATE is equal to or later than this timezone-aware datetime (inclusive); any UTC offset is accepted and normalized to UTC.",
                         "title": "Since"
                     },
                     "subject": {
@@ -246,7 +246,7 @@
                     },
                     "order": {
                         "default": "desc",
-                        "description": "Sort matching emails by date: oldest first (`asc`) or newest first (`desc`).",
+                        "description": "Sort matching emails by provider INTERNALDATE: oldest first (`asc`) or newest first (`desc`).",
                         "enum": ["asc", "desc"],
                         "title": "Order",
                         "type": "string"

--- a/tests/test_email_client.py
+++ b/tests/test_email_client.py
@@ -514,15 +514,14 @@ class TestEmailClient:
             "custom",
         ]
 
-        # Test with before date
+        # Date-only IMAP criteria are widened before exact INTERNALDATE filtering.
         before_date = datetime(2023, 1, 1, tzinfo=UTC)
         criteria = EmailClient._build_search_criteria(before=before_date)
-        assert criteria == ["BEFORE", "01-JAN-2023"]
+        assert criteria == ["BEFORE", "03-JAN-2023"]
 
-        # Test with since date
         since_date = datetime(2023, 1, 1, tzinfo=UTC)
         criteria = EmailClient._build_search_criteria(since=since_date)
-        assert criteria == ["SINCE", "01-JAN-2023"]
+        assert criteria == ["SINCE", "31-DEC-2022"]
 
         # Test with subject
         criteria = EmailClient._build_search_criteria(subject="Test")
@@ -548,7 +547,7 @@ class TestEmailClient:
         criteria = EmailClient._build_search_criteria(
             subject="Test", from_address="test@example.com", since=datetime(2023, 1, 1, tzinfo=UTC)
         )
-        assert criteria == ["SINCE", "01-JAN-2023", "SUBJECT", "Test", "FROM", "test@example.com"]
+        assert criteria == ["SINCE", "31-DEC-2022", "SUBJECT", "Test", "FROM", "test@example.com"]
 
         # Test with seen=True (read emails)
         criteria = EmailClient._build_search_criteria(seen=True)
@@ -1736,3 +1735,98 @@ class TestSenderFilterCoverage:
         with patch.object(email_client, "_parse_headers", return_value=None):
             result = await email_client._batch_fetch_senders(mock_imap, [b"300"])
         assert result == {}
+
+
+def _metadata_imap(search_uids: bytes) -> AsyncMock:
+    imap = AsyncMock()
+    imap._client_task = asyncio.Future()
+    imap._client_task.set_result(None)
+    imap.wait_hello_from_server = AsyncMock()
+    imap.login = AsyncMock(return_value=MagicMock(result="OK", lines=[]))
+    imap.select = AsyncMock(return_value=("OK", []))
+    imap.uid_search = AsyncMock(return_value=("OK", [search_uids]))
+    imap.logout = AsyncMock()
+    return imap
+
+
+def test_datetime_search_criteria_are_conservative_utc_supersets() -> None:
+    since = datetime.fromisoformat("2026-09-02T00:30:00+14:00")
+    before = datetime.fromisoformat("2026-09-02T23:30:00-12:00")
+
+    assert EmailClient._build_search_criteria(before=before, since=since) == [
+        "BEFORE",
+        "05-SEP-2026",
+        "SINCE",
+        "31-AUG-2026",
+    ]
+    assert EmailClient._build_search_criteria(since=datetime.min.replace(tzinfo=UTC)) == ["ALL"]
+    assert EmailClient._build_search_criteria(before=datetime.max.replace(tzinfo=UTC)) == ["ALL"]
+
+
+@pytest.mark.asyncio
+async def test_get_emails_metadata_filters_exact_internaldate_before_total_and_pagination(email_client) -> None:
+    imap = _metadata_imap(b"1 2 3 4 5")
+    since = datetime.fromisoformat("2026-09-02T02:30:00+02:00")
+    before = datetime.fromisoformat("2026-09-03T01:30:00+02:00")
+    internal_dates = {
+        "1": datetime.fromisoformat("2026-09-01T22:29:59-02:00"),
+        "2": datetime.fromisoformat("2026-09-01T22:30:00-02:00"),
+        "3": datetime.fromisoformat("2026-09-03T07:00:00+14:00"),
+        "4": datetime.fromisoformat("2026-09-03T13:29:59+14:00"),
+        "5": datetime.fromisoformat("2026-09-03T13:30:00+14:00"),
+    }
+
+    def page_headers(_imap, uids, **_kwargs):
+        return {
+            uid: {
+                "email_id": uid,
+                "subject": f"Subject {uid}",
+                "from": "allowed@example.test",
+                "to": ["user@example.test"],
+                # The RFC 5322 Date header is deliberately outside the query;
+                # filtering is authoritative against provider INTERNALDATE.
+                "date": datetime(1999, 1, int(uid), tzinfo=UTC),
+                "attachments": [],
+            }
+            for uid in uids
+        }
+
+    with (
+        patch.object(email_client, "imap_class", return_value=imap),
+        patch.object(email_client, "_batch_fetch_dates", return_value=internal_dates),
+        patch.object(email_client, "_batch_fetch_headers", side_effect=page_headers),
+    ):
+        first_total, first_page = await email_client.get_emails_metadata(
+            page=1,
+            page_size=2,
+            since=since,
+            before=before,
+        )
+        second_total, second_page = await email_client.get_emails_metadata(
+            page=2,
+            page_size=2,
+            since=since,
+            before=before,
+        )
+
+    assert first_total == second_total == 3
+    assert [email["email_id"] for email in first_page] == ["4", "3"]
+    assert [email["email_id"] for email in second_page] == ["2"]
+    assert all(email["date"].year == 1999 for email in first_page + second_page)
+    imap.uid_search.assert_awaited_with(
+        "BEFORE",
+        "04-SEP-2026",
+        "SINCE",
+        "01-SEP-2026",
+        charset=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_emails_metadata_rejects_naive_datetime_before_provider_access(email_client) -> None:
+    connect = AsyncMock()
+    with patch.object(email_client, "_connect_imap", connect):
+        with pytest.raises(ValueError, match="since must include a timezone offset"):
+            await email_client.get_emails_metadata(since=datetime(2026, 9, 2, 0, 30))
+
+    connect.assert_not_awaited()

--- a/tests/test_metadata_query.py
+++ b/tests/test_metadata_query.py
@@ -512,3 +512,20 @@ async def test_metadata_provider_fallback_has_application_deadline(monkeypatch) 
 
     with pytest.raises(MetadataProviderError, match="timed out"):
         await service.execute(ListEmailMetadataQuery(account_name="work", subject="needle"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field_name", ["before", "since"])
+async def test_metadata_query_rejects_naive_datetime_before_authority_resolution(field_name: str) -> None:
+    service, accounts, _providers, _projections, _provider, _projection = _service()
+    value = datetime(2026, 9, 2, 12, 0)
+    query = ListEmailMetadataQuery(
+        account_name="work",
+        before=value if field_name == "before" else None,
+        since=value if field_name == "since" else None,
+    )
+
+    with pytest.raises(ValueError, match=rf"{field_name} must include a timezone offset"):
+        await service.execute(query)
+
+    accounts.resolve.assert_not_called()

--- a/tests/test_rfc_interoperability.py
+++ b/tests/test_rfc_interoperability.py
@@ -178,8 +178,8 @@ def test_imap_dates_use_fixed_english_month_names():
     expected_months = ("JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC")
 
     for month, expected in enumerate(expected_months, start=1):
-        value = datetime(2026, month, 1, tzinfo=UTC)
-        assert EmailClient._build_search_criteria(since=value) == ["SINCE", f"01-{expected}-2026"]
+        value = datetime(2026, month, 15, tzinfo=UTC)
+        assert EmailClient._build_search_criteria(since=value) == ["SINCE", f"14-{expected}-2026"]
 
 
 def test_list_response_framing_ignores_completion_and_reassembles_literal():


### PR DESCRIPTION
## Summary

- Make `list_emails_metadata` honor timezone-aware `before` and `since` values as exact datetime boundaries instead of collapsing them to conflicting or imprecise IMAP calendar dates.
- Keep exact totals, ordering, pagination, MCP descriptions, specifications, and user documentation aligned with provider `INTERNALDATE` semantics.

## Changes

- Reject offset-free metadata datetime boundaries before account authority or provider access, and normalize valid offsets to UTC instants.
- Widen base IMAP `BEFORE` and `SINCE` criteria into conservative candidate searches, then apply the exact `[since, before)` predicate to complete `INTERNALDATE` evidence before ordering and pagination.
- Preserve the existing response contract in which `date` is the RFC 5322 message header while documenting that filtering and ordering use `INTERNALDATE`.
- Update the exact MCP catalog fixture, metadata specifications, user-facing tool documentation, deterministic boundary tests, and GreenMail stdio coverage.

## Validation

- `uv run ruff format --check mcp_email_server/app.py mcp_email_server/application/metadata.py mcp_email_server/emails/classic.py tests/test_email_client.py tests/test_metadata_query.py tests/test_rfc_interoperability.py tests/e2e/test_stdio_greenmail.py`
- `uv run ruff check mcp_email_server/app.py mcp_email_server/application/metadata.py mcp_email_server/emails/classic.py tests/test_email_client.py tests/test_metadata_query.py tests/test_rfc_interoperability.py tests/e2e/test_stdio_greenmail.py`
- `uv run pyright mcp_email_server/app.py mcp_email_server/application/metadata.py mcp_email_server/emails/classic.py`
- `uv run pytest -q tests/test_email_client.py::test_datetime_search_criteria_are_conservative_utc_supersets tests/test_email_client.py::test_get_emails_metadata_filters_exact_internaldate_before_total_and_pagination tests/test_email_client.py::test_get_emails_metadata_rejects_naive_datetime_before_provider_access tests/test_metadata_query.py::test_metadata_query_rejects_naive_datetime_before_authority_resolution tests/test_rfc_interoperability.py::test_imap_dates_use_fixed_english_month_names tests/test_mcp_tools.py::TestMcpTools::test_complete_mcp_catalog_matches_exact_fixture` (`7 passed`)
- `uv run mkdocs build --strict`
- `make check`
- `make test` (`1457 passed, 37 skipped, 5 deselected`; coverage `87.38%`)
- `make docs-test`
- `make test-e2e` (`5 passed`)

Closes #243
