### PR TITLE
fix(container): correct OCI license label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM python:${PYTHON_VERSION}-slim AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/Wh1isper/mcp-email-server" \
       org.opencontainers.image.description="MCP server for IMAP and SMTP email workflows" \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.licenses="BSD-3-Clause"
 
 # tini reaps the children the server spawns; without an init the container
 # accumulates zombies on long-running IMAP sessions.

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -205,6 +205,7 @@ def test_container_build_context_and_runtime_copy_are_restricted() -> None:
     assert "uv sync --frozen --no-dev --no-editable" in dockerfile
     assert "COPY --from=builder /app/.venv /app/.venv" in dockerfile
     assert "COPY --from=builder /app /app" not in dockerfile
+    assert 'org.opencontainers.image.licenses="BSD-3-Clause"' in dockerfile
 
 
 def test_distribution_is_node_free_and_embeds_reproducible_ui(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- correct the Dockerfile OCI license label from MIT to the repository's BSD-3-Clause license
- add a packaging contract assertion to prevent drift

The published 1.6.2 image already has the correct label because release metadata overrides the Dockerfile default. This fixes local source builds.

## Validation

- `uv run pytest -q tests/test_packaging.py --cov-fail-under=0`
- local Docker build and label inspection