### PR TITLE
fix: deny recipient-bound operations for empty allowlists

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -272,6 +272,12 @@ UI represents each recipient or sender pattern as an individual add/edit/remove
 item rather than a comma-separated field. Every update requires the revision
 shown by `config policy`.
 
+An empty recipient policy also denies `save_to_mailbox`; it is not just an SMTP
+switch. This applies in managed and legacy mode, including an omitted legacy
+setting or an explicit empty environment override. Older implementations
+incorrectly treated an empty list as unrestricted; see the
+[recipient policy upgrade note](security.md#recipient-policy-upgrade-note).
+
 Endpoint ports must be between 1 and 65535, and implicit TLS cannot be combined
 with STARTTLS. `account add` checks the selected catalog and these non-secret
 endpoint rules before prompting or reading a credential; application services

--- a/docs/security.md
+++ b/docs/security.md
@@ -518,7 +518,23 @@ understands display-name forms such as `Alice <alice@example.com>`.
 `list_allowed_recipients` is always visible in the static MCP tool catalog. An
 empty result means sending is disabled; it never means unrestricted sending.
 The Web UI edits recipients as individual add/edit/remove items and states this
-empty behavior explicitly.
+empty behavior explicitly. The restriction applies equally in managed and
+legacy mode and covers To, CC, and BCC. An initially empty policy is rejected
+before a provider is opened, including before a forward source is read.
+Clearing the last recipient does not enable unrestricted sending. This policy
+is not a read-only mode: other mailbox mutations remain available.
+
+### Recipient policy upgrade note
+
+Earlier implementations incorrectly permitted any recipient when this list was
+empty, despite the documented restriction and UI guidance. The fix for
+[#247](https://github.com/Wh1isper/mcp-email-server/issues/247) changes that
+behavior: an empty list now denies `send_email`, `forward_email`, and
+`save_to_mailbox`. This is a compatibility change in both managed and legacy
+mode. Before upgrading a workflow that relied on unrestricted recipients,
+configure its intended addresses explicitly. No automatic unrestricted fallback
+or wildcard recipient is provided. See
+[recipient-policy troubleshooting](troubleshooting.md#recipient-allowlist-errors).
 
 ## Sender allowlist
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -610,8 +610,11 @@ static for the lifetime of a server process. `send_email`,
 `list_allowed_recipients`, `list_allowed_senders`, and `download_attachment` are
 always advertised. Account existence, enabled state, SMTP capability, and
 current policies are enforced when each tool is called. The allowlist tools have
-distinct empty semantics: an empty recipient list disables sending, while an
-empty sender list does not restrict reading. Each list is limited to 1,000
+distinct empty semantics: an empty recipient list denies `send_email`,
+`forward_email`, and `save_to_mailbox`, while an empty sender list does not
+restrict reading. Recipient denial errors direct users to configure exact
+allowed addresses through the user-operated CLI/UI; this does not require
+sharing credentials with the agent. Each list is limited to 1,000
 entries, and the complete effective-configuration snapshot
 is canonically serialized against the shared 8 MiB ceiling before either policy
 result is returned; oversized authority data fails with `limit_exceeded`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,6 +15,29 @@ MCP_EMAIL_SERVER_LOG_LEVEL=DEBUG mcp-email-server stdio
 
 Restart the server after changing configuration paths or environment variables.
 
+## Recipient allowlist errors
+
+If sending or saving reports `Recipient(s) not in allowlist`, check that every
+To, CC, and BCC address appears in `allowed_recipients`. An empty list
+blocks `send_email`, `forward_email`, and `save_to_mailbox`, even when SMTP or
+IMAP credentials work. This applies in both managed and legacy mode. Earlier
+implementations incorrectly allowed any recipient for an empty list; see the
+[upgrade note](security.md#recipient-policy-upgrade-note).
+
+In managed mode, add the intended addresses in the Web UI policy panel, or run
+`mcp-email-server config policy` and then update using the displayed revision:
+
+```bash
+mcp-email-server config update-policy --expected-revision <revision> --allowed-recipients 'alice@example.com,bob@example.com'
+```
+
+This replaces the whole recipient list, so include any existing addresses that
+should remain allowed. Clearing the list disables these three operations; it
+never enables unrestricted sending. In legacy mode, configure `allowed_recipients`
+in TOML or `MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS` in the server environment and
+restart. An explicitly empty environment value overrides a non-empty TOML list.
+`list_allowed_recipients` shows the effective policy without exposing credentials.
+
 ## The server reports `Missing command`
 
 The CLI requires a subcommand. Use one of:

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -526,8 +526,8 @@ async def get_emails_content(
 @mcp.tool(
     description=(
         "List the configured recipient allowlist — the addresses that send_email and forward_email are "
-        "permitted to send to and save_to_mailbox is permitted to address. Returns an empty list when "
-        "unrestricted."
+        "permitted to send to and save_to_mailbox is permitted to address. An empty list denies all "
+        "recipients for these operations; configure allowed recipients through the user-operated CLI/UI."
     ),
     annotations=_READ_ONLY_LOCAL,
 )
@@ -643,7 +643,10 @@ async def send_email(
             )
         )
     except RecipientPolicyDeniedError as exc:
-        raise ValueError("Recipient(s) not in allowlist") from exc
+        raise ValueError(
+            "Recipient(s) not in allowlist; configure allowed recipients through the user-operated CLI/UI "
+            "before sending or saving. An empty allowlist denies all recipients."
+        ) from exc
     if _send_outcome_is_clean(outcome):
         recipient_str = ", ".join(recipients)
         attachment_info = f" with {len(attachments)} attachment(s)" if attachments else ""
@@ -725,7 +728,10 @@ async def forward_email(
             )
         )
     except RecipientPolicyDeniedError as exc:
-        raise ValueError("Recipient(s) not in allowlist") from exc
+        raise ValueError(
+            "Recipient(s) not in allowlist; configure allowed recipients through the user-operated CLI/UI "
+            "before sending or saving. An empty allowlist denies all recipients."
+        ) from exc
     if _send_outcome_is_clean(outcome):
         return f"Email forwarded successfully to {', '.join(recipients)}"
     return f"Email forward [{_tagged_send_result(outcome)}]"
@@ -829,7 +835,10 @@ async def save_to_mailbox(
             )
         )
     except RecipientPolicyDeniedError as exc:
-        raise ValueError("Recipient(s) not in allowlist") from exc
+        raise ValueError(
+            "Recipient(s) not in allowlist; configure allowed recipients through the user-operated CLI/UI "
+            "before sending or saving. An empty allowlist denies all recipients."
+        ) from exc
     if outcome.status == "succeeded" and not outcome.reconciliation_needed:
         email_id = outcome.uid or "unknown"
         return f"Email saved to '{mailbox}' successfully. Message-Id: {outcome.message_id}, email_id: {email_id}"

--- a/mcp_email_server/application/mutations.py
+++ b/mcp_email_server/application/mutations.py
@@ -642,14 +642,15 @@ def _validate_optional_header(name: str, value: str | None) -> None:
 
 
 def _recipient_policy_allows(recipient: str, allowed: tuple[str, ...]) -> bool:
-    # Re-parse the validated single-address value so direct application callers
-    # receive the same exact allowlist decision as the MCP compatibility gate.
+    """Require explicit recipient authority; an empty allowlist permits no address."""
+    # Re-parse the validated single-address value for exact normalized matching
+    # shared by MCP and direct application callers.
     from email.utils import getaddresses
 
     from mcp_email_server.config import normalize_address
 
     if not allowed:
-        return True
+        return False
     addresses = [normalize_address(address) for _, address in getaddresses([recipient]) if address]
     allowed_set = set(allowed)
     return bool(addresses) and all(address in allowed_set for address in addresses)

--- a/spec/04-configuration-and-managed-catalog.md
+++ b/spec/04-configuration-and-managed-catalog.md
@@ -175,10 +175,14 @@ trimmed, lowercased, empty-filtered, and stably deduplicated. Managed updates an
 legacy composition use the same canonicalizers. The UI presents each allowed
 recipient and sender as an individual add/edit/remove item rather than a
 comma-separated field. Empty collections have deliberately different semantics:
-empty allowed recipients disables sending, while empty allowed senders does not
-restrict reading. Permissive changes do not bypass capability or input
-validation. Restrictive changes take effect on the next independent effect
-because authority is revalidated at operation boundaries.
+an empty allowed-recipient collection denies `send_email`, `forward_email`, and
+`save_to_mailbox` in both managed and legacy mode, while an empty allowed-sender
+collection does not restrict reading. Every To, CC, and BCC address requires an
+exact normalized recipient match; no wildcard or implicit unrestricted mode exists.
+An initially empty recipient policy is rejected before opening a provider,
+including before a forward source is read. Permissive changes do not bypass
+capability or input validation. Restrictive changes take effect on the next
+independent effect because authority is revalidated at operation boundaries.
 
 ## Semantic IMAP Keyword Configuration
 
@@ -356,7 +360,9 @@ SQL, raw provider responses, or reusable locators.
 3. Every account, policy, catalog, import, binding, and bootstrap mutation
    rejects stale revisions with a bounded current summary; account and policy
    cardinality limits are enforced on both read and write boundaries, including
-   the full 1,000-entry recipient and sender policy limit.
+   the full 1,000-entry recipient and sender policy limit. Empty recipient policy
+   denies send, forward, and mailbox saves in both runtime modes, including
+   after policy is cleared between independent provider effects.
 4. Soft removal disables provider work and permanently reserves the normalized
    name in this delivery.
 5. Every finite management command has a tested single-document JSON success

--- a/spec/12-delivery-validation-and-evolution.md
+++ b/spec/12-delivery-validation-and-evolution.md
@@ -95,6 +95,12 @@ satisfied by mocks.
 
 - MCP: complete catalog snapshot, application-version identity, reviewed tool
   annotations, text/structured discovery equivalence, and raw protocol behavior.
+  Recipient policy evidence links `tests/test_mutation_application.py`,
+  `tests/test_mcp_tools.py`, and `tests/e2e/test_stdio_greenmail.py` to the
+  [configuration policy contract](04-configuration-and-managed-catalog.md):
+  empty-policy denial before provider effects, To/CC/BCC checks, current-policy
+  revalidation, discovery wording, and managed/legacy stdio behavior. Published
+  upgrade guidance lives in `docs/security.md` and `docs/troubleshooting.md`.
 - CLI: command help/options, confirmations, user-controlled stdin secrets, one
   parsed schema-version-1 JSON envelope for every finite command, typed errors
   with fixed safe messages, post-operation revisions/restart state,

--- a/tests/e2e/test_stdio_greenmail.py
+++ b/tests/e2e/test_stdio_greenmail.py
@@ -4,6 +4,7 @@ import base64
 import contextlib
 import imaplib
 import importlib.metadata
+import json
 import os
 import re
 import smtplib
@@ -277,6 +278,33 @@ async def _call_tool(session: ClientSession, name: str, arguments: dict[str, Any
     return result.structuredContent
 
 
+async def _assert_empty_recipient_policy_blocks_compose(
+    session: ClientSession, account_name: str, source_uid: str
+) -> None:
+    assert (await _call_tool(session, "list_allowed_recipients", {}))["result"] == []
+    counts_before = (
+        _message_count(BOB, "INBOX"),
+        _message_count(ALICE, "Drafts"),
+        _message_count(ALICE, "INBOX"),
+    )
+    for tool_name, arguments in (
+        ("send_email", {"subject": "Denied send", "body": "Synthetic body"}),
+        ("forward_email", {"email_id": source_uid}),
+        ("save_to_mailbox", {"subject": "Denied draft", "body": "Synthetic body"}),
+    ):
+        result = await session.call_tool(
+            tool_name, arguments={"account_name": account_name, "recipients": [BOB[0]], **arguments}
+        )
+        assert result.isError is True
+        assert "An empty allowlist denies all recipients" in _text_content(result)
+        assert "CLI/UI" in _text_content(result)
+    assert (
+        _message_count(BOB, "INBOX"),
+        _message_count(ALICE, "Drafts"),
+        _message_count(ALICE, "INBOX"),
+    ) == counts_before
+
+
 async def _metadata_for_subject_in_mailbox(
     session: ClientSession, account_name: str, mailbox: str, subject: str
 ) -> dict[str, Any]:
@@ -307,6 +335,22 @@ def _run_cli(console_script: Path, env: dict[str, str], arguments: list[str], *,
     )
     assert completed.returncode == 0, completed.stderr or completed.stdout
     return completed.stdout
+
+
+def _update_recipient_policy(console_script: Path, env: dict[str, str], recipients: str) -> None:
+    policy = json.loads(_run_cli(console_script, env, ["config", "policy", "--json"]))["data"]
+    _run_cli(
+        console_script,
+        env,
+        [
+            "config",
+            "update-policy",
+            "--expected-revision",
+            str(policy["revision"]),
+            "--allowed-recipients",
+            recipients,
+        ],
+    )
 
 
 @pytest.mark.asyncio
@@ -409,6 +453,26 @@ async def test_managed_cli_setup_restart_and_stdio_list_mailboxes_against_greenm
                 assert connection.execute("SELECT completeness FROM index_coverage").fetchone()[0] == "COMPLETE"
 
             managed_uid = metadata["emails"][0]["email_id"]
+            await _assert_empty_recipient_policy_blocks_compose(session, "alice-managed", managed_uid)
+            # Policy changes must be visible in this same stdio session: default
+            # denial -> explicit permission -> clearing the last recipient.
+            _update_recipient_policy(console_script, server_env, BOB[0])
+            assert (await _call_tool(session, "list_allowed_recipients", {}))["result"] == [BOB[0]]
+            allowed_subject = f"managed-allowed-{uuid.uuid4().hex}"
+            await _call_tool(
+                session,
+                "send_email",
+                {
+                    "account_name": "alice-managed",
+                    "recipients": [BOB[0]],
+                    "subject": allowed_subject,
+                    "body": "Explicitly allowed synthetic message",
+                },
+            )
+            _wait_for_message(BOB, "INBOX", allowed_subject)
+            _update_recipient_policy(console_script, server_env, "")
+            await _assert_empty_recipient_policy_blocks_compose(session, "alice-managed", managed_uid)
+            _update_recipient_policy(console_script, server_env, BOB[0])
             mark = await _call_tool(
                 session,
                 "mark_emails_as_read",
@@ -884,6 +948,45 @@ async def test_metadata_index_paging_fallback_and_restart_reuse_against_greenmai
     restart_observed_at, restart_page = await exercise_session(verify_filters=False)
     assert restart_observed_at == first_observed_at
     assert restart_page == first_page
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("policy_source", ["unset", "empty-toml", "empty-env"])
+async def test_legacy_empty_recipient_policy_against_greenmail(tmp_path: Path, policy_source: str) -> None:
+    _wait_until_ready()
+    _ensure_empty_mailboxes(ALICE, ["INBOX", "Drafts"])
+    _ensure_empty_mailboxes(BOB, ["INBOX"])
+    subject = f"denied-forward-source-{uuid.uuid4().hex}"
+    _seed_message_as(BOB, ALICE[0], subject, "Synthetic forward source")
+    source = _wait_for_message(ALICE, "INBOX", subject)
+    config = CONFIG_TEMPLATE
+    if policy_source == "unset":
+        config = config.replace('allowed_recipients = ["bob@example.test"]\n', "")
+    elif policy_source == "empty-toml":
+        config = config.replace('allowed_recipients = ["bob@example.test"]', "allowed_recipients = []")
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(config)
+    config_path.chmod(0o600)
+    server_env = {key: value for key, value in os.environ.items() if not key.startswith("MCP_EMAIL_SERVER_")}
+    server_env.update({
+        "MCP_EMAIL_SERVER_CONFIG_PATH": str(config_path),
+        "MCP_EMAIL_SERVER_LOG_LEVEL": "WARNING",
+    })
+    if policy_source == "empty-env":
+        server_env["MCP_EMAIL_SERVER_ALLOWED_RECIPIENTS"] = ""
+    server = StdioServerParameters(
+        command=str(Path(sys.executable).with_name("mcp-email-server")),
+        args=["stdio"],
+        env=server_env,
+        cwd=Path.cwd(),
+    )
+    async with stdio_client(server) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream, read_timeout_seconds=timedelta(seconds=15)) as session:
+            await session.initialize()
+            metadata = await _metadata_for_subject(session, "alice", subject)
+            assert metadata["email_id"] == source.uid
+            await _assert_empty_recipient_policy_blocks_compose(session, "alice", source.uid)
+            assert r"\Seen" not in _wait_for_message(ALICE, "INBOX", subject).flags
 
 
 @pytest.mark.asyncio

--- a/tests/fixtures/mcp_catalog.json
+++ b/tests/fixtures/mcp_catalog.json
@@ -803,7 +803,7 @@
         },
         {
             "name": "list_allowed_recipients",
-            "description": "List the configured recipient allowlist — the addresses that send_email and forward_email are permitted to send to and save_to_mailbox is permitted to address. Returns an empty list when unrestricted.",
+            "description": "List the configured recipient allowlist — the addresses that send_email and forward_email are permitted to send to and save_to_mailbox is permitted to address. An empty list denies all recipients for these operations; configure allowed recipients through the user-operated CLI/UI.",
             "inputSchema": {
                 "properties": {},
                 "title": "list_allowed_recipientsArguments",

--- a/tests/test_mutation_application.py
+++ b/tests/test_mutation_application.py
@@ -47,7 +47,13 @@ def _account(**changes: object) -> MutationAccountSnapshot:
         account_name="primary",
         mode="managed",
         allowed_senders=(),
-        allowed_recipients=(),
+        allowed_recipients=(
+            "recipient@example.test",
+            "accepted@example.test",
+            "rejected@example.test",
+            "secret@example.test",
+            "copied@example.test",
+        ),
         report_blocked_mutations=False,
         can_send=True,
     )
@@ -81,6 +87,85 @@ def _services(
         factory,
         selected_projection,
     )
+
+
+@pytest.mark.parametrize(
+    ("recipient", "allowed", "expected"),
+    [
+        ("recipient@example.test", (), False),
+        ("recipient@example.test", ("recipient@example.test",), True),
+        ("Recipient <RECIPIENT@Example.Test>", ("recipient@example.test",), True),
+        ("other@example.test", ("recipient@example.test",), False),
+        ("recipient@example.test", ("*",), False),
+    ],
+)
+def test_recipient_policy_requires_explicit_exact_match(
+    recipient: str, allowed: tuple[str, ...], expected: bool
+) -> None:
+    assert mutations_module._recipient_policy_allows(recipient, allowed) is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["managed", "legacy"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        SendCommand("primary", ("recipient@example.test",), "Subject", "body"),
+        SaveToMailboxCommand("primary", ("recipient@example.test",), "Subject", "body"),
+        ForwardCommand("primary", ("recipient@example.test",), "", "", source_email_id="42"),
+    ],
+    ids=["send", "save", "forward"],
+)
+@pytest.mark.parametrize("stage", ["resolve", "open"])
+async def test_empty_recipient_policy_denies_before_provider_effect(
+    mode: str, command: SendCommand | SaveToMailboxCommand | ForwardCommand, stage: str
+) -> None:
+    account = _account(mode=mode, allowed_recipients=() if stage == "resolve" else ("recipient@example.test",))
+    provider = MagicMock()
+    services, _, factory, projection = _services(account=account, provider=provider)
+    factory.open.return_value = MutationProviderAccess(replace(account, allowed_recipients=()), provider)
+    if isinstance(command, ForwardCommand):
+        operation = services.forward.execute(command)
+    elif isinstance(command, SaveToMailboxCommand):
+        operation = services.save_to_mailbox.execute(command)
+    else:
+        operation = services.send.execute(command)
+
+    with pytest.raises(RecipientPolicyDeniedError):
+        await operation
+
+    assert factory.open.call_count == (0 if stage == "resolve" else 1)
+    assert provider.mock_calls == []
+    projection.invalidate.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["recipients", "cc", "bcc"])
+@pytest.mark.parametrize(
+    "command",
+    [
+        SendCommand("primary", ("recipient@example.test",), "Subject", "body"),
+        SaveToMailboxCommand("primary", ("recipient@example.test",), "Subject", "body"),
+        ForwardCommand("primary", ("recipient@example.test",), "", "", source_email_id="42"),
+    ],
+    ids=["send", "save", "forward"],
+)
+async def test_recipient_policy_checks_every_address_before_provider_access(
+    field: str, command: SendCommand | SaveToMailboxCommand | ForwardCommand
+) -> None:
+    services, _, factory, _ = _services(account=_account(allowed_recipients=("recipient@example.test",)))
+    command = replace(command, **{field: ("recipient@example.test", "blocked@example.test")})
+    if isinstance(command, ForwardCommand):
+        operation = services.forward.execute(command)
+    elif isinstance(command, SaveToMailboxCommand):
+        operation = services.save_to_mailbox.execute(command)
+    else:
+        operation = services.send.execute(command)
+
+    with pytest.raises(RecipientPolicyDeniedError):
+        await operation
+
+    factory.open.assert_not_called()
 
 
 def _tag_registry() -> ImapKeywordRegistry:
@@ -1028,7 +1113,9 @@ async def test_forward_recipient_policy_denial_fails_before_provider_access() ->
 @pytest.mark.asyncio
 async def test_forward_recipient_policy_denial_after_open_fails_before_retrieval() -> None:
     provider = _forward_provider()
-    services, _, factory, _ = _services(provider=provider)
+    services, _, factory, _ = _services(
+        account=_account(allowed_recipients=("blocked@example.test",)), provider=provider
+    )
     factory.open.return_value = MutationProviderAccess(
         _account(allowed_recipients=("allowed@example.test",)),
         provider,
@@ -1158,12 +1245,17 @@ async def test_forward_send_capability_loss_after_open_fails_before_retrieval() 
 
 
 @pytest.mark.asyncio
-async def test_forward_recipient_policy_denial_before_delivery_fails_after_retrieval() -> None:
+@pytest.mark.parametrize("allowed", [(), ("allowed@example.test",)])
+async def test_forward_recipient_policy_denial_before_delivery_fails_after_retrieval(
+    allowed: tuple[str, ...],
+) -> None:
     provider = _forward_provider()
-    services, _, factory, _ = _services(provider=provider)
+    services, _, factory, _ = _services(
+        account=_account(allowed_recipients=("blocked@example.test",)), provider=provider
+    )
     factory.open.side_effect = [
         factory.open.return_value,
-        MutationProviderAccess(_account(allowed_recipients=("allowed@example.test",)), provider),
+        MutationProviderAccess(_account(allowed_recipients=allowed), provider),
     ]
 
     with pytest.raises(RecipientPolicyDeniedError):


### PR DESCRIPTION
## Summary

Closes #247.

Align recipient-policy enforcement with the existing specification, security documentation, and Web UI guidance: an empty `allowed_recipients` collection denies `send_email`, `forward_email`, and `save_to_mailbox` in both managed and legacy modes.

- Fix the shared application-layer predicate rather than introducing separate transport or UI gates.
- Preserve exact normalized matching for every To, CC, and BCC address and existing policy revalidation at provider-effect boundaries.
- Correct the `list_allowed_recipients` MCP description and catalog snapshot; make denial errors point users to user-operated CLI/UI setup.
- Add application regressions and live GreenMail stdio coverage for default denial, explicit permission, clearing the last recipient, legacy TOML defaults, and empty environment overrides.
- Document the compatibility change and remediation, and align the owning spec and validation references.

## Compatibility / upgrade note

Earlier implementations permitted any recipient when `allowed_recipients` was empty, despite the documented restriction and UI guidance. After this fix, those operations are denied until intended recipient addresses are explicitly configured. This applies equally to managed and legacy mode; no automatic unrestricted fallback or wildcard recipient is introduced.

An empty `allowed_senders` collection remains unrestricted. This is not a read-only mode: other mailbox mutations remain available. The separate read-only-mode suggestion is out of scope.

## Validation

- `make check` — passed (formatting, lint, types, dependencies, embedded assets)
- `make test` — 1485 passed, 37 skipped; 87.38% coverage
- `make docs-test` — strict build passed
- `make test-e2e` — 8 passed against isolated loopback GreenMail
- Focused independent review completed; the identified E2E catalog/account revision mix-up was corrected and E2E rerun successfully.

No real email accounts or messages were used for validation.