### PR TITLE
feat: report the delivered Message-Id from send_email and forward_email

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -285,6 +285,16 @@ include reviewed fixed diagnostics when available, for example
 `smtp-data-unknown`, or `provider-timeout`. Unrecognized detail and raw provider
 response text are omitted.
 
+The response names the delivered message's RFC `Message-Id`: a clean send appends
+`Message-Id: <...>` to the success line, and a partial delivery reports the same
+identifier in its own `message-id` section. The server reports it only once the
+provider has accepted the message data, so a rejected, timed-out, or otherwise
+ambiguous delivery names no identifier at all rather than one it cannot vouch
+for. A caller keeping its own record of sent mail can therefore store the
+identifier exactly when the send is proven, and store nothing when it is not.
+The independent Sent copy is not the source of this value; a failed or unknown
+Sent copy does not remove the identifier of a delivered message.
+
 Internationalized addr-specs in the envelope or From, Sender, To, Cc, Bcc, or
 Reply-To fields, and non-ASCII Message-ID, In-Reply-To, or References syntax,
 require the provider's SMTPUTF8 extension. The server requests `SMTPUTF8` and
@@ -431,7 +441,9 @@ be read, the call fails before any SMTP session is opened, so a forward is never
 delivered without the content and attachments it was supposed to carry. Delivery
 and sent-copy outcomes are reported separately under the same rules as
 `send_email`, and an ambiguous SMTP outcome is reported `unknown` and is never
-replayed automatically.
+replayed automatically. The forwarded message's `Message-Id` is reported under
+the same rule: named once the provider accepted the message data, and omitted
+for an ambiguous delivery.
 
 Reading the source message is a mail read. When a sender allowlist is
 configured, a message from a blocked sender is indistinguishable from a missing
@@ -635,5 +647,9 @@ To preserve conversation threading:
 
 Simple Message-IDs may be bare or already enclosed in angle brackets; the compose
 path emits the required bracketed RFC form for both headers.
+
+`send_email` and `forward_email` name the delivered message's own `Message-Id` in
+their response, so a follow-up in the same thread can be built from it without
+first locating the message again over IMAP.
 
 For a complete example, see [Reply with proper threading](guides.md#reply-with-proper-threading).

--- a/mcp_email_server/app.py
+++ b/mcp_email_server/app.py
@@ -195,6 +195,15 @@ def _send_outcome_is_clean(outcome: SendMutationOutcome) -> bool:
     )
 
 
+def _reported_message_id(outcome: SendMutationOutcome) -> str:
+    """Name the delivered message only when the provider proved which one it took.
+
+    An ambiguous submission reports nothing here, so a caller journaling the send
+    records an empty identifier instead of one the server cannot vouch for.
+    """
+    return f". Message-Id: {outcome.message_id}" if outcome.message_id else ""
+
+
 def _tagged_send_result(outcome: SendMutationOutcome) -> str:
     sections = _ordered_target_sections(
         outcome.delivery,
@@ -210,6 +219,8 @@ def _tagged_send_result(outcome: SendMutationOutcome) -> str:
         sent_copy_context.append(outcome.sent_copy.detail)
     if sent_copy_context:
         sent_copy = f"{sent_copy} ({'; '.join(sent_copy_context)})"
+    if outcome.message_id:
+        sections.append(f"message-id: {outcome.message_id}")
     sections.append(f"sent-copy: {sent_copy}")
     if outcome.reconciliation_needed:
         sections.append("warning: reconciliation needed")
@@ -555,7 +566,9 @@ async def list_allowed_senders() -> PolicyDiscoveryResult:
     description=(
         "Send one email using the specified account. Supports reply threading. Partial or ambiguous SMTP "
         "delivery reports per-recipient succeeded/failed/unknown status and reports the independent Sent-copy "
-        "outcome separately; ambiguous effects are not retried automatically."
+        "outcome separately; ambiguous effects are not retried automatically. The response names the delivered "
+        "message's RFC Message-Id once the provider accepts the message data, and reports no identifier for an "
+        "ambiguous delivery."
     ),
     annotations=_NONDESTRUCTIVE_REMOTE_MUTATION,
 )
@@ -650,7 +663,7 @@ async def send_email(
     if _send_outcome_is_clean(outcome):
         recipient_str = ", ".join(recipients)
         attachment_info = f" with {len(attachments)} attachment(s)" if attachments else ""
-        return f"Email sent successfully to {recipient_str}{attachment_info}"
+        return f"Email sent successfully to {recipient_str}{attachment_info}{_reported_message_id(outcome)}"
     return f"Email delivery [{_tagged_send_result(outcome)}]"
 
 
@@ -663,7 +676,9 @@ async def send_email(
         "plain-text forwarded block re-composed from the source's parsed text body, and the source's attachments "
         "are re-attached with their original MIME types unless include_attachments is false. Partial or ambiguous "
         "SMTP delivery reports per-recipient succeeded/failed/unknown status and reports the independent "
-        "Sent-copy outcome separately; ambiguous effects are not retried automatically."
+        "Sent-copy outcome separately; ambiguous effects are not retried automatically. The response names the "
+        "delivered message's RFC Message-Id once the provider accepts the message data, and reports no "
+        "identifier for an ambiguous delivery."
     ),
     annotations=_NONDESTRUCTIVE_REMOTE_MUTATION,
 )
@@ -733,7 +748,7 @@ async def forward_email(
             "before sending or saving. An empty allowlist denies all recipients."
         ) from exc
     if _send_outcome_is_clean(outcome):
-        return f"Email forwarded successfully to {', '.join(recipients)}"
+        return f"Email forwarded successfully to {', '.join(recipients)}{_reported_message_id(outcome)}"
     return f"Email forward [{_tagged_send_result(outcome)}]"
 
 

--- a/mcp_email_server/application/mutations.py
+++ b/mcp_email_server/application/mutations.py
@@ -111,6 +111,10 @@ class AppendMutationOutcome:
 class DeliveryMutationOutcome:
     outcomes: tuple[TargetMutationOutcome, ...]
     sent_message: object | None
+    # RFC 5322 Message-Id of the message the provider accepted, and None whenever
+    # delivery failed or stayed ambiguous. A caller's send journal may therefore
+    # cite an identifier only for a message that was demonstrably handed over.
+    message_id: str | None = None
 
     @property
     def has_accepted_recipient(self) -> bool:
@@ -129,6 +133,9 @@ class SendMutationOutcome:
     delivery: tuple[TargetMutationOutcome, ...]
     sent_copy: SentCopyMutationOutcome
     reconciliation_needed: bool = False
+    # Carried from the delivery effect, never from composition: an ambiguous or
+    # failed submission reports no identifier rather than one it cannot vouch for.
+    message_id: str | None = None
 
     def __post_init__(self) -> None:
         ambiguous = any(item.status == "unknown" for item in self.delivery) or self.sent_copy.status == "unknown"
@@ -766,9 +773,23 @@ def _validate_append_result(outcome: AppendMutationOutcome) -> AppendMutationOut
     return outcome
 
 
+def _validate_optional_message_id(message_id: str | None) -> None:
+    if message_id is None:
+        return
+    _validate_result_string(
+        message_id,
+        field_name="message_id",
+        maximum_bytes=APPLICATION_LIMITS.header_bytes,
+    )
+
+
 def _validate_delivery_result(outcome: DeliveryMutationOutcome) -> DeliveryMutationOutcome:
     _validate_target_outcomes(outcome.outcomes)
-    _validate_result_payload({"outcomes": [_outcome_payload(item) for item in outcome.outcomes]})
+    _validate_optional_message_id(outcome.message_id)
+    _validate_result_payload({
+        "outcomes": [_outcome_payload(item) for item in outcome.outcomes],
+        "message_id": outcome.message_id,
+    })
     return outcome
 
 
@@ -788,6 +809,7 @@ def _validate_sent_copy_result(outcome: SentCopyMutationOutcome) -> SentCopyMuta
 def _validate_send_result(outcome: SendMutationOutcome) -> SendMutationOutcome:
     _validate_target_outcomes(outcome.delivery)
     _validate_sent_copy_result(outcome.sent_copy)
+    _validate_optional_message_id(outcome.message_id)
     _validate_result_payload({
         "delivery": [_outcome_payload(item) for item in outcome.delivery],
         "sent_copy": {
@@ -796,6 +818,7 @@ def _validate_send_result(outcome: SendMutationOutcome) -> SendMutationOutcome:
             "detail": outcome.sent_copy.detail,
         },
         "reconciliation_needed": outcome.reconciliation_needed,
+        "message_id": outcome.message_id,
     })
     return outcome
 
@@ -844,12 +867,28 @@ class _MutationWorkflow:
     ) -> SendMutationOutcome:
         """Attach the independent Sent copy to already-authoritative delivery.
 
-        Every submission workflow shares this tail so the ambiguity and
-        ``reconciliation_needed`` semantics have exactly one owner.
+        Every submission workflow shares this tail so the ambiguity,
+        ``reconciliation_needed``, and reported-identifier semantics have exactly
+        one owner.
         """
 
+        def completed(
+            sent_copy: SentCopyMutationOutcome,
+            *,
+            reconciliation_needed: bool = False,
+        ) -> SendMutationOutcome:
+            """Report the delivery evidence identically on every sent-copy path."""
+            return _validate_send_result(
+                SendMutationOutcome(
+                    delivery.outcomes,
+                    sent_copy,
+                    reconciliation_needed,
+                    message_id=delivery.message_id,
+                )
+            )
+
         if not delivery.has_accepted_recipient or delivery.sent_message is None:
-            return _validate_send_result(SendMutationOutcome(delivery.outcomes, SentCopyMutationOutcome("skipped")))
+            return completed(SentCopyMutationOutcome("skipped"))
 
         # Saving the copy is a separate provider effect and therefore gets a fresh
         # lifecycle/credential resolution. SMTP delivery is never rewritten.
@@ -858,55 +897,32 @@ class _MutationWorkflow:
         except Exception:
             # SMTP delivery is already authoritative. Lifecycle or credential
             # failure before opening the independent copy cannot erase it.
-            return _validate_send_result(
-                SendMutationOutcome(
-                    delivery.outcomes,
-                    SentCopyMutationOutcome("failed", detail="sent-copy-unavailable"),
-                )
-            )
+            return completed(SentCopyMutationOutcome("failed", detail="sent-copy-unavailable"))
         try:
             sent_copy = await _bounded_provider_effect(sent_access.provider.save_sent_copy(delivery.sent_message, bcc))
         except MutationProviderError:
             # Typed APPEND-boundary cancellation is returned by the provider;
             # escaped setup/cancellation happened before APPEND started.
-            return _validate_send_result(
-                SendMutationOutcome(
-                    delivery.outcomes,
-                    SentCopyMutationOutcome("failed", detail="sent-copy-unavailable"),
-                )
-            )
+            return completed(SentCopyMutationOutcome("failed", detail="sent-copy-unavailable"))
         except TimeoutError:
-            return _validate_send_result(
-                SendMutationOutcome(
-                    delivery.outcomes,
-                    SentCopyMutationOutcome("unknown", detail="provider-timeout"),
-                    reconciliation_needed=True,
-                )
+            return completed(
+                SentCopyMutationOutcome("unknown", detail="provider-timeout"),
+                reconciliation_needed=True,
             )
         except asyncio.CancelledError:
             # Provider adapters use typed unknown outcomes once APPEND may have
             # started; an escaped cancellation is therefore pre-effect setup.
-            return _validate_send_result(
-                SendMutationOutcome(
-                    delivery.outcomes,
-                    SentCopyMutationOutcome("failed", detail="sent-copy-unavailable"),
-                )
-            )
+            return completed(SentCopyMutationOutcome("failed", detail="sent-copy-unavailable"))
         except Exception:
             # Treat an untyped provider escape conservatively rather than claim
             # that an APPEND definitely did not happen.
-            return _validate_send_result(
-                SendMutationOutcome(
-                    delivery.outcomes,
-                    SentCopyMutationOutcome("unknown", detail="sent-copy"),
-                )
-            )
+            return completed(SentCopyMutationOutcome("unknown", detail="sent-copy"))
         sent_copy = _validate_sent_copy_result(sent_copy)
         reconciliation_needed = False
         if sent_copy.status in ("succeeded", "unknown") and sent_copy.mailbox is not None:
             invalidated = await self._invalidate(sent_access.account, (sent_copy.mailbox,))
             reconciliation_needed = not invalidated
-        return _validate_send_result(SendMutationOutcome(delivery.outcomes, sent_copy, reconciliation_needed))
+        return completed(sent_copy, reconciliation_needed=reconciliation_needed)
 
     @staticmethod
     def _require_send_capability(account: MutationAccountSnapshot) -> None:

--- a/mcp_email_server/emails/classic.py
+++ b/mcp_email_server/emails/classic.py
@@ -2814,9 +2814,14 @@ class EmailClient:
                     all_recipients[accepted_index], accepted_status, accepted_detail
                 )
             delivery_outcomes = tuple(item for item in outcomes if item is not None)
+            accepted_message = msg if accepted_status == "succeeded" else None
+            # Only an accepted DATA phase proves which message the provider took,
+            # so a rejected or ambiguous submission reports no Message-Id at all.
+            accepted_message_id = accepted_message["Message-Id"] if accepted_message is not None else None
             return DeliveryMutationOutcome(
                 delivery_outcomes,
-                msg if accepted_status == "succeeded" else None,
+                accepted_message,
+                message_id=str(accepted_message_id) if accepted_message_id else None,
             )
 
         known_outcome: DeliveryMutationOutcome | None = None

--- a/spec/07-mail-mutations-and-provider-effects.md
+++ b/spec/07-mail-mutations-and-provider-effects.md
@@ -208,7 +208,13 @@ reports delivery and sent-copy outcomes. If SMTP is unknown, automated replay is
 forbidden; operator reconciliation is required.
 
 Message-ID or other local identifiers can aid reconciliation but do not create
-exactly-once guarantees.
+exactly-once guarantees. The delivery result carries the composed `Message-ID`
+only once the provider has accepted the message data; a rejected or ambiguous
+submission MUST report no identifier. A caller keeping its own record of what was
+sent can therefore cite an identifier exactly when the server can vouch for it,
+rather than choosing between an empty record and an invented one. The sent-copy
+APPEND reports its own identifier independently and never substitutes for
+delivery evidence.
 
 ### Forward
 
@@ -320,7 +326,11 @@ enter public errors.
    failure/unknown never causes SMTP replay. Tests prove display names are safely
    formatted while the SMTP reverse-path uses only the configured account
    address, including when the display name itself contains `@` and when the
-   account address requires SMTPUTF8/RFC 6532 serialization.
+   account address requires SMTPUTF8/RFC 6532 serialization. Submission results
+   report the delivered `Message-ID` when, and only when, the provider accepted
+   the message data. Tests prove a send and a forward name the identifier the
+   recipient actually received, that it survives an independent sent-copy
+   failure, and that a rejected, timed-out, or ambiguous delivery reports none.
 7. Cancellation and timeout tests cover before-effect, known-after-effect, and
    ambiguous boundaries for IMAP and SMTP.
 8. Public numeric IDs are documented and tested as current-mailbox compatibility

--- a/tests/e2e/test_stdio_greenmail.py
+++ b/tests/e2e/test_stdio_greenmail.py
@@ -1072,9 +1072,14 @@ async def test_current_stdio_server_against_greenmail(tmp_path: Path) -> None:
                     "references": references,
                 },
             )
-            assert send_result["result"] == f"Email sent successfully to {BOB[0]} with 1 attachment(s)"
+            send_prefix = f"Email sent successfully to {BOB[0]} with 1 attachment(s). Message-Id: "
+            assert send_result["result"].startswith(send_prefix)
+            reported_message_id = send_result["result"].removeprefix(send_prefix)
 
             delivered = _wait_for_message(BOB, "INBOX", sent_subject)
+            # The reported identifier must be the one the recipient actually received,
+            # so a caller's send journal can cite it without a second lookup.
+            assert str(delivered.message["Message-ID"]) == reported_message_id
             assert sent_body in (delivered.message.get_body(preferencelist=("plain",)).get_content())
             delivered_from = delivered.message["From"]
             assert delivered_from is not None
@@ -1206,12 +1211,15 @@ async def test_current_stdio_server_against_greenmail(tmp_path: Path) -> None:
                     "body": forward_note,
                 },
             )
-            assert forward_result["result"] == f"Email forwarded successfully to {BOB[0]}"
+            forward_prefix = f"Email forwarded successfully to {BOB[0]}. Message-Id: "
+            assert forward_result["result"].startswith(forward_prefix)
+            reported_forward_message_id = forward_result["result"].removeprefix(forward_prefix)
 
             # Read the delivered forward back over plain imaplib rather than trusting
             # the server's own report of what it claims to have sent.
             forwarded_subject = f"Fwd: {forward_source_subject}"
             forwarded = _wait_for_message(BOB, "INBOX", forwarded_subject)
+            assert str(forwarded.message["Message-ID"]) == reported_forward_message_id
             forwarded_text = forwarded.message.get_body(preferencelist=("plain",)).get_content()
             assert forward_note in forwarded_text
             assert "---------- Forwarded message ----------" in forwarded_text

--- a/tests/fixtures/mcp_catalog.json
+++ b/tests/fixtures/mcp_catalog.json
@@ -863,7 +863,7 @@
         },
         {
             "name": "send_email",
-            "description": "Send one email using the specified account. Supports reply threading. Partial or ambiguous SMTP delivery reports per-recipient succeeded/failed/unknown status and reports the independent Sent-copy outcome separately; ambiguous effects are not retried automatically.",
+            "description": "Send one email using the specified account. Supports reply threading. Partial or ambiguous SMTP delivery reports per-recipient succeeded/failed/unknown status and reports the independent Sent-copy outcome separately; ambiguous effects are not retried automatically. The response names the delivered message's RFC Message-Id once the provider accepts the message data, and reports no identifier for an ambiguous delivery.",
             "inputSchema": {
                 "properties": {
                     "account_name": {
@@ -1022,7 +1022,7 @@
         },
         {
             "name": "forward_email",
-            "description": "Forward an existing message to new recipients using the specified account. The source message is read over IMAP first: if it cannot be read, the call fails before any SMTP session is opened, so a forward is never delivered without the content it was supposed to carry. The subject is derived from the source as 'Fwd: <original subject>' without stacking a second prefix, the caller's note is placed above a plain-text forwarded block re-composed from the source's parsed text body, and the source's attachments are re-attached with their original MIME types unless include_attachments is false. Partial or ambiguous SMTP delivery reports per-recipient succeeded/failed/unknown status and reports the independent Sent-copy outcome separately; ambiguous effects are not retried automatically.",
+            "description": "Forward an existing message to new recipients using the specified account. The source message is read over IMAP first: if it cannot be read, the call fails before any SMTP session is opened, so a forward is never delivered without the content it was supposed to carry. The subject is derived from the source as 'Fwd: <original subject>' without stacking a second prefix, the caller's note is placed above a plain-text forwarded block re-composed from the source's parsed text body, and the source's attachments are re-attached with their original MIME types unless include_attachments is false. Partial or ambiguous SMTP delivery reports per-recipient succeeded/failed/unknown status and reports the independent Sent-copy outcome separately; ambiguous effects are not retried automatically. The response names the delivered message's RFC Message-Id once the provider accepts the message data, and reports no identifier for an ambiguous delivery.",
             "inputSchema": {
                 "properties": {
                     "account_name": {

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,4 +1,5 @@
 import json
+import re
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -53,6 +54,9 @@ from mcp_email_server.emails.models import (
     MailboxInfo,
 )
 from mcp_email_server.imap_keywords import ImapKeywordTag
+
+# RFC 5322 msg-id shape, as an external journal would look for it in the response.
+_MESSAGE_ID_PATTERN = re.compile(r"<[^<>@\s]+@[^<>@\s]+>")
 
 
 def _batch_outcome(
@@ -1181,6 +1185,102 @@ async def test_send_tool_reports_safe_internationalized_sent_copy_failure() -> N
         result = await send_email("test", ["recipient@example.test"], "Subject", "body")
 
     assert result == ("Email delivery [succeeded: recipient@example.test; sent-copy: failed (utf8-append-unsupported)]")
+
+
+@pytest.mark.asyncio
+async def test_send_tool_names_the_delivered_message_id() -> None:
+    """A caller that journals the send can only cite an identifier the tool actually reports."""
+    command_handler = AsyncMock(
+        return_value=SendMutationOutcome(
+            (TargetMutationOutcome("recipient@example.test", "succeeded"),),
+            SentCopyMutationOutcome("succeeded", "Sent"),
+            message_id="<delivered.1@example.test>",
+        )
+    )
+    with patch("mcp_email_server.app.send_email_command", command_handler):
+        result = await send_email("test", ["recipient@example.test"], "Subject", "body")
+
+    assert result == "Email sent successfully to recipient@example.test. Message-Id: <delivered.1@example.test>"
+    assert _MESSAGE_ID_PATTERN.search(result) is not None
+
+
+@pytest.mark.asyncio
+async def test_send_tool_names_the_message_id_of_a_partially_delivered_message() -> None:
+    command_handler = AsyncMock(
+        return_value=SendMutationOutcome(
+            (
+                TargetMutationOutcome("accepted@example.test", "succeeded"),
+                TargetMutationOutcome("rejected@example.test", "failed", "smtp-recipient-rejected"),
+            ),
+            SentCopyMutationOutcome("succeeded", "Sent"),
+            message_id="<delivered.2@example.test>",
+        )
+    )
+    with patch("mcp_email_server.app.send_email_command", command_handler):
+        result = await send_email(
+            "test",
+            ["accepted@example.test", "rejected@example.test"],
+            "Subject",
+            "body",
+        )
+
+    assert result == (
+        "Email delivery [succeeded: accepted@example.test; "
+        "failed: rejected@example.test (smtp-recipient-rejected); "
+        "message-id: <delivered.2@example.test>; sent-copy: succeeded (Sent)]"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_tool_does_not_invent_a_message_id_for_an_ambiguous_delivery() -> None:
+    """An unknown SMTP outcome must leave the journal empty rather than fabricate an identifier."""
+    command_handler = AsyncMock(
+        return_value=SendMutationOutcome(
+            (TargetMutationOutcome("recipient@example.test", "unknown", "smtp-data-unknown"),),
+            SentCopyMutationOutcome("skipped"),
+        )
+    )
+    with patch("mcp_email_server.app.send_email_command", command_handler):
+        result = await send_email("test", ["recipient@example.test"], "Subject", "body")
+
+    assert result == (
+        "Email delivery [unknown: recipient@example.test (smtp-data-unknown); sent-copy: skipped; "
+        "warning: reconciliation needed]"
+    )
+    assert _MESSAGE_ID_PATTERN.search(result) is None
+
+
+@pytest.mark.asyncio
+async def test_forward_tool_names_the_delivered_message_id() -> None:
+    command_handler = AsyncMock(
+        return_value=SendMutationOutcome(
+            (TargetMutationOutcome("recipient@example.test", "succeeded"),),
+            SentCopyMutationOutcome("succeeded", "Sent"),
+            message_id="<forwarded.1@example.test>",
+        )
+    )
+    with patch("mcp_email_server.app.forward_email_command", command_handler):
+        result = await forward_email("test_account", "12345", ["recipient@example.test"])
+
+    assert result == "Email forwarded successfully to recipient@example.test. Message-Id: <forwarded.1@example.test>"
+
+
+@pytest.mark.asyncio
+async def test_forward_tool_does_not_invent_a_message_id_for_an_ambiguous_delivery() -> None:
+    command_handler = AsyncMock(
+        return_value=SendMutationOutcome(
+            (TargetMutationOutcome("recipient@example.test", "unknown", "provider-timeout"),),
+            SentCopyMutationOutcome("skipped"),
+        )
+    )
+    with patch("mcp_email_server.app.forward_email_command", command_handler):
+        result = await forward_email("test_account", "12345", ["recipient@example.test"])
+
+    assert result == (
+        "Email forward [unknown: recipient@example.test (provider-timeout); sent-copy: skipped; "
+        "warning: reconciliation needed]"
+    )
+    assert _MESSAGE_ID_PATTERN.search(result) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_mutation_application.py
+++ b/tests/test_mutation_application.py
@@ -791,6 +791,83 @@ async def test_mutation_timeout_is_unknown_and_never_replayed(monkeypatch, workf
 
 
 @pytest.mark.asyncio
+async def test_send_carries_the_delivered_message_id_through_a_failed_sent_copy() -> None:
+    """The identifier belongs to authoritative SMTP delivery, not to the independent Sent copy."""
+    provider = MagicMock()
+    provider.send = AsyncMock(
+        return_value=DeliveryMutationOutcome(
+            (TargetMutationOutcome("recipient@example.test", "succeeded"),),
+            object(),
+            message_id="<delivered@example.test>",
+        )
+    )
+    provider.save_sent_copy = AsyncMock(return_value=SentCopyMutationOutcome("failed", "Sent", "append"))
+    services, _, _, _ = _services(provider=provider)
+
+    result = await services.send.execute(
+        SendCommand(
+            account_name="primary",
+            recipients=("recipient@example.test",),
+            subject="Message",
+            body="body",
+        )
+    )
+
+    assert result.message_id == "<delivered@example.test>"
+    assert result.sent_copy.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_send_timeout_reports_no_message_id(monkeypatch) -> None:
+    """A submission that timed out before any provider evidence has no identifier to report."""
+    monkeypatch.setattr(
+        mutations_module,
+        "APPLICATION_LIMITS",
+        replace(APPLICATION_LIMITS, provider_timeout_seconds=0.001),
+    )
+    provider = MagicMock()
+    provider.send = AsyncMock(side_effect=_hang_provider)
+    services, _, _, _ = _services(provider=provider)
+
+    result = await services.send.execute(
+        SendCommand(
+            account_name="primary",
+            recipients=("recipient@example.test",),
+            subject="Message",
+            body="body",
+        )
+    )
+
+    assert result.recipients("unknown") == ["recipient@example.test"]
+    assert result.message_id is None
+
+
+@pytest.mark.asyncio
+async def test_send_does_not_report_a_message_id_the_provider_withheld() -> None:
+    """An ambiguous DATA phase yields no accepted message, so the workflow must not invent one."""
+    provider = MagicMock()
+    provider.send = AsyncMock(
+        return_value=DeliveryMutationOutcome(
+            (TargetMutationOutcome("recipient@example.test", "unknown", "smtp-data-unknown"),),
+            None,
+        )
+    )
+    services, _, _, _ = _services(provider=provider)
+
+    result = await services.send.execute(
+        SendCommand(
+            account_name="primary",
+            recipients=("recipient@example.test",),
+            subject="Message",
+            body="body",
+        )
+    )
+
+    assert result.reconciliation_needed is True
+    assert result.message_id is None
+
+
+@pytest.mark.asyncio
 async def test_sent_copy_timeout_preserves_delivery_and_is_unknown(monkeypatch) -> None:
     monkeypatch.setattr(
         mutations_module,
@@ -1311,6 +1388,22 @@ async def test_forward_preserves_partial_delivery_and_skips_sent_copy_without_ev
     assert result.reconciliation_needed is False
     provider.save_sent_copy.assert_not_awaited()
     assert factory.open.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_forward_carries_the_delivered_message_id() -> None:
+    provider = _forward_provider(
+        delivery=DeliveryMutationOutcome(
+            (TargetMutationOutcome("recipient@example.test", "succeeded"),),
+            object(),
+            message_id="<forwarded@example.test>",
+        )
+    )
+    services, _, _, _ = _services(provider=provider)
+
+    result = await services.forward.execute(_forward_command())
+
+    assert result.message_id == "<forwarded@example.test>"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mutation_provider_outcomes.py
+++ b/tests/test_mutation_provider_outcomes.py
@@ -679,6 +679,36 @@ async def test_smtp_partial_recipient_rejection_is_preserved(email_server) -> No
 
 
 @pytest.mark.asyncio
+async def test_smtp_accepted_data_reports_the_delivered_message_id(email_server) -> None:
+    """The composed Message-Id is the only handle a caller has on what was actually delivered."""
+    client = EmailClient(email_server, sender="Sender <sender@example.test>")
+    smtp = _smtp()
+
+    with patch("mcp_email_server.emails.classic.aiosmtplib.SMTP", return_value=smtp):
+        result = await client.send_email_with_outcome(["one@example.test"], "Subject", "body")
+
+    assert [item.status for item in result.outcomes] == ["succeeded"]
+    assert result.message_id is not None
+    assert re.fullmatch(r"<[^<>@\s]+@[^<>@\s]+>", result.message_id)
+    assert f"Message-Id: {result.message_id}".encode() in smtp.data.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_smtp_data_transport_loss_reports_no_message_id(email_server) -> None:
+    """A lost DATA result leaves delivery unknown, so no identifier may be claimed for it."""
+    client = EmailClient(email_server, sender="Sender <sender@example.test>")
+    smtp = _smtp()
+    smtp.data.side_effect = ConnectionError("result lost")
+
+    with patch("mcp_email_server.emails.classic.aiosmtplib.SMTP", return_value=smtp):
+        result = await client.send_email_with_outcome(["one@example.test"], "Subject", "body")
+
+    assert [item.status for item in result.outcomes] == ["unknown"]
+    assert result.sent_message is None
+    assert result.message_id is None
+
+
+@pytest.mark.asyncio
 async def test_smtp_data_transport_loss_marks_accepted_recipients_unknown(email_server) -> None:
     client = EmailClient(email_server, sender="Sender <sender@example.test>")
     smtp = _smtp()


### PR DESCRIPTION
## Problem

Composition assigns an RFC 5322 `Message-Id` to every outgoing message
(`emails/classic.py`), but no submission result carries it. `send_email` and
`forward_email` return only `Email sent successfully to <recipients>`, so a
caller that keeps its own record of sent mail has to choose between storing an
empty identifier and inventing one. `save_to_mailbox` already reports the
identifier it appended; sends did not.

## Change

Carry the identifier from the SMTP delivery effect through to both tool
responses:

- `DeliveryMutationOutcome` and `SendMutationOutcome` gain an optional
  `message_id`, alongside the existing `AppendMutationOutcome.message_id`.
- `EmailClient.send_email_with_outcome` attaches it exactly where it already
  attaches the accepted message — after an accepted `DATA` phase.
- `_complete_send` reports it identically on every sent-copy path, so an
  independent Sent-copy failure cannot erase the identifier of a message that
  was demonstrably delivered.
- A clean send appends `. Message-Id: <...>` to the success line, matching the
  wording `save_to_mailbox` already uses. A partial delivery reports the same
  value in its own `message-id` section of the tagged result.

The identifier is never derived from composition. A rejected, timed-out, or
otherwise ambiguous submission reports none, so the response stays honest about
what the server can actually vouch for.

## Tests

- Provider: an accepted `DATA` phase reports the `Message-Id` that appears in the
  serialized message; a lost `DATA` result reports none.
- Application: the identifier survives a failed Sent copy for both send and
  forward; a provider timeout and a withheld message report none.
- MCP tools: send and forward name the identifier on success; a partial delivery
  names it in the tagged result; an ambiguous delivery contains no `<...@...>`
  at all.
- E2E (GreenMail): the identifier reported by `send_email` and `forward_email`
  equals the `Message-ID` the recipient actually received.

## Docs and spec

`docs/tools.md` documents the reported identifier for both tools and its use for
threading a follow-up. `spec/07` states the rule normatively and extends
acceptance criterion 6 rather than renumbering the list.

## Verification

`ruff format --check`, `ruff check`, `pyright`, `pre-commit run -a`,
`uv lock --locked`, `dev/build_frontend.py --check`, and `mkdocs build --strict`
are clean. The full suite passes at 83.71% coverage. Four pre-existing failures
on this Windows checkout are unrelated to this change and fail identically on
`main` (two `test_config.py` cases assume a `C:` drive; two require symlink and
owner-assignment privileges). `make test-e2e` was not run locally — Docker is
unavailable in this environment — so the updated GreenMail assertions rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
